### PR TITLE
allow setting headers globally in swaggerApi

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -40,6 +40,7 @@
       }
       this.failure = options.failure != null ? options.failure : function() {};
       this.progress = options.progress != null ? options.progress : function() {};
+      this.headers = options.headers != null ? options.headers : {};
       this.discoveryUrl = this.suffixApiKey(this.discoveryUrl);
       if (options.success != null) {
         this.build();
@@ -394,7 +395,7 @@
     };
 
     SwaggerOperation.prototype.getMatchingParams = function(paramTypes, args, includeApiKey) {
-      var matchingParams, param, _i, _len, _ref;
+      var matchingParams, name, param, value, _i, _len, _ref, _ref1;
       matchingParams = {};
       _ref = this.parameters;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
@@ -405,6 +406,13 @@
       }
       if (includeApiKey && (this.resource.api.api_key != null) && this.resource.api.api_key.length > 0) {
         matchingParams[this.resource.api.apiKeyName] = this.resource.api.api_key;
+      }
+      if (jQuery.inArray('header', paramTypes) >= 0) {
+        _ref1 = this.resource.api.headers;
+        for (name in _ref1) {
+          value = _ref1[name];
+          matchingParams[name] = value;
+        }
       }
       return matchingParams;
     };

--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -18,6 +18,7 @@ class SwaggerApi
     @success = options.success if options.success?
     @failure = if options.failure? then options.failure else ->
     @progress = if options.progress? then options.progress else ->
+    @headers = if options.headers? then options.headers else {}
 
     # Suffix discovery url with api_key
     @discoveryUrl = @suffixApiKey(@discoveryUrl)
@@ -321,6 +322,10 @@ class SwaggerOperation
     #machingParams API key to the params
     if includeApiKey and @resource.api.api_key? and @resource.api.api_key.length > 0
       matchingParams[@resource.api.apiKeyName] = @resource.api.api_key
+
+    if (jQuery.inArray('header', paramTypes) >= 0)
+      for name, value of @resource.api.headers
+        matchingParams[name] = value
 
     matchingParams
 


### PR DESCRIPTION
this patch enables setting headers like this:

```
window.swaggerUi = new SwaggerUi({
    discoveryUrl:"http://petstore.swagger.wordnik.com/api/resources.json",
    dom_id:"swagger-ui-container",
    headers: { "Authorization": "XXXX", "someOtherHeader": "YYYY" },
    supportHeaderParams: true,
    supportedSubmitMethods: ['get', 'post', 'put']
});
```

These headers will then be sent with every request. This is what i use for Basic Auth. so it could also address https://github.com/wordnik/swagger-ui/issues/53  (although this patch is not tied to the api key)
