### PR TITLE
Tests added for supportedContentTypes spec addition

### DIFF
--- a/lib/swagger-spec.js
+++ b/lib/swagger-spec.js
@@ -210,7 +210,7 @@
         });
       });
     });
-    return describe("do", function() {
+    describe("do", function() {
       beforeEach(function() {
         window.args = {
           tags: 'tag1',
@@ -263,6 +263,37 @@
           expect(request.body.name).toMatch(/haute/);
           return expect(request.body.pronunciation).toMatch(/cooter/);
         });
+      });
+    });
+    return describe('constructor', function() {
+      beforeEach(function() {
+        var resource;
+        resource = {
+          name: 'hello hello',
+          models: {}
+        };
+        window.construct = function(c0nstructor, args) {
+          var F;
+          F = function() {
+            return c0nstructor.apply(this, args);
+          };
+          F.prototype = c0nstructor.prototype;
+          return new F();
+        };
+        return window.defaultParams = ['nickname', '/path', 'GET', [], 'This is a summary', 'Some notes', '', [], resource, []];
+      });
+      it('must have a nickname set', function() {
+        var noNicknameParams;
+        expect(operation).toBeDefined();
+        noNicknameParams = defaultParams;
+        noNicknameParams[0] = void 0;
+        return expect(function() {
+          return construct(SwaggerOperation, noNicknameParams);
+        }).toThrow();
+      });
+      return it('must not fail if supportedContentTypes is not set', function() {
+        expect(operation).toBeDefined();
+        return expect(operation.supportedContentTypes).toBeUndefined();
       });
     });
   });

--- a/src/swagger-spec.coffee
+++ b/src/swagger-spec.coffee
@@ -205,6 +205,29 @@ describe 'SwaggerOperation', ->
         expect(request.body).toBeDefined()
         expect(request.body.name).toMatch(/haute/)
         expect(request.body.pronunciation).toMatch(/cooter/)
+
+  describe 'constructor', ->
+
+    beforeEach ->
+      resource =
+        name: 'hello hello'
+        models: {}
+      window.construct = (c0nstructor, args) ->
+        F = -> c0nstructor.apply(this, args)
+        F.prototype = c0nstructor.prototype
+        new F()
+
+      window.defaultParams = ['nickname', '/path', 'GET',[], 'This is a summary', 'Some notes', '', [], resource, []]
+    
+    it 'must have a nickname set', ->
+      expect(operation).toBeDefined()
+      noNicknameParams = defaultParams
+      noNicknameParams[0] = undefined
+      expect( -> construct SwaggerOperation, noNicknameParams).toThrow()
+
+    it 'must not fail if supportedContentTypes is not set', ->
+      expect(operation).toBeDefined()
+      expect(operation.supportedContentTypes).toBeUndefined()
                         
 describe 'SwaggerRequest', ->
   


### PR DESCRIPTION
Based on the comments in the following commit: https://github.com/wordnik/swagger.js/commit/f9918dda9b486f6093096a91813b216e4faca8f3 I am adding tests to make sure that the added changes to the spec (adding `supportedContentTypes`) do not break the currently working APIs. So, meanwhile the proposed changes are reviewed the swagger.js code is not broken and still works even though the `supportedContentTypes` field is not set.

Thanks in advance,
