### PR TITLE
Error handling when dataType is undefined

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -372,7 +372,7 @@
     function SwaggerModelProperty(name, obj) {
       this.name = name;
       this.dataType = obj.type;
-      this.isArray = this.dataType.toLowerCase() === 'array';
+      this.isArray = this.dataType && this.dataType.toLowerCase() === 'array';
       this.descr = obj.description;
       this.required = obj.required;
       if (obj.items != null) {

--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -292,7 +292,7 @@ class SwaggerModel
 class SwaggerModelProperty
   constructor: (@name, obj) ->
     @dataType = obj.type
-    @isArray = @dataType.toLowerCase() is 'array'
+    @isArray = @dataType && @dataType.toLowerCase() is 'array'
     @descr = obj.description
     @required = obj.required
 


### PR DESCRIPTION
When the API definition fails to define a dataType, it results in
toLowerCase() being called on undefined, which raises a no such method
exception. This would cause swagger-ui to hang in trying to load the
resource.
