### PR TITLE
expose SwaggerModelProperty

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -765,4 +765,6 @@
 
   window.SwaggerRequest = SwaggerRequest;
 
+  window.SwaggerModelProperty = SwaggerModelProperty;
+
 }).call(this);

--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -560,3 +560,4 @@ window.SwaggerApi = SwaggerApi
 window.SwaggerResource = SwaggerResource
 window.SwaggerOperation = SwaggerOperation
 window.SwaggerRequest = SwaggerRequest
+window.SwaggerModelProperty = SwaggerModelProperty


### PR DESCRIPTION
I would like to monkey patch getSampleValue, but SwaggerModelProperty was not exposed.
