### PR TITLE
Removed discoverUrl restriction

### DIFF
--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -37,7 +37,7 @@ class SwaggerApi
         # If there is a basePath in response, use that or else derive from discoveryUrl
         if response.basePath? and jQuery.trim(response.basePath).length > 0
           @basePath = response.basePath
-          @fail "discoveryUrl basePath must be a URL." unless @basePath.match(/^HTTP/i)?
+
           # TODO: Take this out. It's an API regression.
           @basePath = @basePath.replace(/\/$/, '')
         else


### PR DESCRIPTION
Removed discoverUrl restriction. (swagger-node-express appears to have no equivalent restriction.)

This change enables the use of '/' as the discoveryUrl in index.html when creating SwaggerUi (which creates an instance of SwaggerApi with that option). 

This in turn makes it possible to run Swagger UI on different servers with different hostnames. e.g. http://localhost:3000 vs. http://test.company.com vs. http://realsite.com.
