### PR TITLE
Setting basePath to '/' will point api calls to root.

### DIFF
--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -260,8 +260,11 @@ class SwaggerResource
     # If there is a basePath in response, use that or else use
     # the one from the api object
     if response.basePath? and response.basePath.replace(/\s/g,'').length > 0
-      if response.basePath == '/'
-        @basePath = window.location.protocol + '//' + window.location.host
+      if response.basePath[0] == '/'
+        if repsonse.basePath.length == 1
+          @basePath = window.location.protocol + '//' + window.location.host
+        else
+          @basePath = window.location.protocol + '//' + window.location.host + response.basePath
       else
         @basePath = response.basePath
 


### PR DESCRIPTION
Currently when you set the basePath of an api declaration to root ('/') a malformed url will be used (something like '//some/url'), which results in an error when you attempt to use the api.

In older versions of swagger this worked as expected, seems this functionality broke when the shred library started being used as it does some magic with parsing urls etc and results in different behaviors.  We found this ability useful as it allows us to post swagger specs many different places with different hostnames & ports (i.e. local vs development vs production versions of the api) without having to change the basePath in the code.

This commit will detect if a url begins with a forward slash in the basePath and update it to point all api calls there.
