### PR TITLE
Construct the absolute resource basePath from relative one, using the Api basePath

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -321,6 +321,25 @@
       }
     }
 
+    SwaggerResource.prototype.getAbsoluteBasePath = function(relativeBasePath) {
+      var parts, pos, url;
+      url = this.api.basePath;
+      pos = url.lastIndexOf(relativeBasePath);
+      if (pos === -1) {
+        parts = url.split("/");
+        url = parts[0] + "//" + parts[2];
+        if (relativeBasePath.indexOf("/") === 0) {
+          return url + relativeBasePath;
+        } else {
+          return url + "/" + relativeBasePath;
+        }
+      } else if (relativeBasePath === "/") {
+        return url.substring(0, pos);
+      } else {
+        return url.substring(0, pos) + relativeBasePath;
+      }
+    };
+
     SwaggerResource.prototype.addApiDeclaration = function(response) {
       var endpoint, _i, _len, _ref;
       if (response.produces != null) {
@@ -330,7 +349,7 @@
         this.consumes = response.consumes;
       }
       if ((response.basePath != null) && response.basePath.replace(/\s/g, '').length > 0) {
-        this.basePath = response.basePath;
+        this.basePath = response.basePath.indexOf("http") === -1 ? this.getAbsoluteBasePath(response.basePath) : response.basePath;
       }
       this.addModels(response.models);
       if (response.apis) {


### PR DESCRIPTION
This change allows using relative paths (like "api/v0", "v0" or simply "/") for the Resource's basePath value. In such cases the absolute resource's basePath is being constructed from relative one, using the runtime value of the parent api basePath.
Examples: 
runtime api.basePath = http://myhost.com:8090/mywebapp/v0/api-docs
relative resource basePath = v0
=> absolute resource basePath =  http://myhost.com:8090/mywebapp/v0

This also addresses and resolves the issue #52.
