### PR TITLE
Added model loader extension point

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -341,7 +341,8 @@
     };
 
     SwaggerResource.prototype.addApiDeclaration = function(response) {
-      var endpoint, _i, _len, _ref;
+      var load,
+        _this = this;
       if (response.produces != null) {
         this.produces = response.produces;
       }
@@ -351,21 +352,23 @@
       if ((response.basePath != null) && response.basePath.replace(/\s/g, '').length > 0) {
         this.basePath = response.basePath.indexOf("http") === -1 ? this.getAbsoluteBasePath(response.basePath) : response.basePath;
       }
-      if (SwaggerApi.modelLoader != null) {
-        this.addModels(SwaggerApi.modelLoader(response));
-      } else {
-        this.addModels(response.models);
-      }
-      if (response.apis) {
-        _ref = response.apis;
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          endpoint = _ref[_i];
-          this.addOperations(endpoint.path, endpoint.operations, response.consumes, response.produces);
+      load = SwaggerApi.modelLoader || function(response, next) {
+        return next();
+      };
+      return load(response, function() {
+        var endpoint, _i, _len, _ref;
+        _this.addModels(response.models);
+        if (response.apis) {
+          _ref = response.apis;
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            endpoint = _ref[_i];
+            _this.addOperations(endpoint.path, endpoint.operations, response.consumes, response.produces);
+          }
         }
-      }
-      this.api[this.name] = this;
-      this.ready = true;
-      return this.api.selfReflect();
+        _this.api[_this.name] = _this;
+        _this.ready = true;
+        return _this.api.selfReflect();
+      });
     };
 
     SwaggerResource.prototype.addModels = function(models) {

--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -282,24 +282,23 @@ class SwaggerResource
     if response.basePath? and response.basePath.replace(/\s/g,'').length > 0
       @basePath = if response.basePath.indexOf("http") is -1 then @getAbsoluteBasePath(response.basePath) else response.basePath
 
-    if SwaggerApi.modelLoader?
-        @addModels(SwaggerApi.modelLoader(response))
-    else
-        @addModels(response.models)
+    load = SwaggerApi.modelLoader || (response, next) -> next()
+    load response, () =>
+      @addModels(response.models)
 
-    # Instantiate SwaggerOperations and store them in the @operations map and @operationsArray
-    if response.apis
-      for endpoint in response.apis
-        @addOperations(endpoint.path, endpoint.operations, response.consumes, response.produces)
+      # Instantiate SwaggerOperations and store them in the @operations map and @operationsArray
+      if response.apis
+        for endpoint in response.apis
+          @addOperations(endpoint.path, endpoint.operations, response.consumes, response.produces)
 
-    # Store a named reference to this resource on the parent object
-    @api[this.name] = this
+      # Store a named reference to this resource on the parent object
+      @api[this.name] = this
 
-    # Mark as ready
-    @ready = true
+      # Mark as ready
+      @ready = true
 
-    # Now that this resource is loaded, tell the API to check in on itself
-    @api.selfReflect()
+      # Now that this resource is loaded, tell the API to check in on itself
+      @api.selfReflect()
 
   addModels: (models) ->
     if models?


### PR DESCRIPTION
This adds a small hook to the models creation. It allows to define a modelLoader function in the SwaggerApi class which processes the "models" section of the API description.

The goal is to enable alternative sources for models. For example, I aim at providing models in a separate files. The strategy for fetching and assembling the models can be plugged in using this new hook without touching swagger-js itself.
