### PR TITLE
Exposing raw models at resource level

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -283,6 +283,7 @@
       this.operationsArray = [];
       this.modelsArray = [];
       this.models = {};
+      this.rawModels = {};
       if ((resourceObj.apis != null) && (this.api.resourcePath != null)) {
         this.addApiDeclaration(resourceObj);
       } else {
@@ -372,6 +373,7 @@
             swaggerModel = new SwaggerModel(modelName, models[modelName]);
             this.modelsArray.push(swaggerModel);
             this.models[modelName] = swaggerModel;
+            this.rawModels[modelName] = models[modelName];
           }
         }
         _ref = this.modelsArray;

--- a/src/swagger.coffee
+++ b/src/swagger.coffee
@@ -211,6 +211,7 @@ class SwaggerResource
     # We're going to store models in a map (models) and a list (modelsArray)
     @modelsArray = []
     @models = {}
+    @rawModels = {}
 
     if resourceObj.apis? and @api.resourcePath?
       # read resource directly from operations object
@@ -305,6 +306,7 @@ class SwaggerResource
           swaggerModel = new SwaggerModel(modelName, models[modelName])
           @modelsArray.push swaggerModel
           @models[modelName] = swaggerModel
+          @rawModels[modelName] = models[modelName];
       for model in @modelsArray
         model.setReferencedModels(@models)
 


### PR DESCRIPTION
To enable alternative rendering of the models (see http://lbovet.github.io/swagger-ui/dist/index.html), this change makes the raw json-schema model exposed on the resources.
