### PR TITLE
Multiple values of a query parameter in case of type='array'

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -903,7 +903,7 @@ SwaggerOperation.prototype.pathXml = function() {
 };
 
 SwaggerOperation.prototype.urlifyQueryParam = function(param, args) {
-  if (param.type.toLowerCase() === 'array') {
+  if (param.type.toLowerCase().indexOf('array') === 0) {
     var values = args[param.name].split(',');
     var queryParams = '';
     for(var i = 0; i < values.length; i ++) {


### PR DESCRIPTION
Comma separated value of the query parameter of type='array' are urlified as multiple occurence of the parameter eg. param1=value1&param1=value2...
One can discuss if the comma as the separator is a best choice, I've just followed the petstore example.

Adresses the issue https://github.com/wordnik/swagger-ui/issues/118
