### PR TITLE
btoa was not working before it was dereferenced

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -1380,7 +1380,8 @@ var PasswordAuthorization = function(name, username, password) {
 };
 
 PasswordAuthorization.prototype.apply = function(obj, authorizations) {
-  obj.headers["Authorization"] = "Basic " + this._btoa(this.username + ":" + this.password);
+  var base64encoder = this._btoa;
+  obj.headers["Authorization"] = "Basic " + base64encoder(this.username + ":" + this.password);
   return true;
 };
 


### PR DESCRIPTION
In Chrome, initial setup showed an Uncaught TypeError: Illegal Invocation Error at this point.

Not sure why it wasn't working, but after dereferencing, it now encodes just fine.

Related to:
wordnik/swagger-js#63
wordnik/swagger-js#64

Tony said:
I'm not sure why this change would make any difference. It would need to go into swagger-js, though, since that is just a dependency in swagger-ui. You can send a PR there...
