### PR TITLE
should stringify the path param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ capybara-*.html
 /db/*.sqlite3
 /spec/tmp/*
 **.orig
+*.idea

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -884,6 +884,7 @@ SwaggerOperation.prototype.pathXml = function() {
 
 SwaggerOperation.prototype.encodePathParam = function(pathParam) {
   var encParts, part, parts, _i, _len;
+  pathParam = pathParam.toString();
   if (pathParam.indexOf("/") === -1) {
     return encodeURIComponent(pathParam);
   } else {


### PR DESCRIPTION
The README contains the following example for using swagger in the browser:

wagger.apis.pet.getPetById({petId:1}, function(data) {..}

encodePathParam() raises an error because it tries to get an indexOf() a number.  This change allows the example to work.
