### PR TITLE
Add "subTypes" support in swagger models, model signature now contains all inherited properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ capybara-*.html
 /spec/tmp/*
 **.orig
 *.idea
+node_modules

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -34,6 +34,53 @@ if (!('filter' in Array.prototype)) {
   };
 }
 
+if (!('some' in Array.prototype)) {
+  Array.prototype.some = function(fun /*, thisArg */) {
+    'use strict';
+
+    if (this === void 0 || this === null)
+      throw new TypeError();
+
+    var t = Object(this);
+    var len = t.length >>> 0;
+    if (typeof fun !== 'function')
+      throw new TypeError();
+
+    var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+    for (var i = 0; i < len; i++) {
+      if (i in t && fun.call(thisArg, t[i], i, t))
+        return true;
+    }
+
+    return false;
+  };
+}
+
+if (!('find' in Array.prototype)) {
+  Array.prototype.find = function(predicate) {
+    if (this == null) {
+      throw new TypeError('Array.prototype.find called on null or undefined');
+    }
+    if (typeof predicate !== 'function') {
+      throw new TypeError('predicate must be a function');
+    }
+    var list = Object(this);
+    var length = list.length >>> 0;
+    var thisArg = arguments[1];
+    var value;
+
+    for (var i = 0; i < length; i++) {
+      if (i in list) {
+        value = list[i];
+        if (predicate.call(thisArg, value, i, list)) {
+          return value;
+        }
+      }
+    }
+    return undefined;
+  }
+}
+
 if (!('map' in Array.prototype)) {
   Array.prototype.map= function(mapper, that /*opt*/) {
     var other= new Array(this.length);
@@ -78,6 +125,26 @@ Object.keys = Object.keys || (function () {
     return result;
   };
 })();
+
+if (typeof Object.create != 'function') {
+  (function() {
+    var F = function() {
+    };
+    Object.create = function(o) {
+      if (arguments.length > 1) {
+        throw Error('Second argument not supported');
+      }
+      if (o === null) {
+        throw Error('Cannot set a null [[Prototype]]');
+      }
+      if (typeof o != 'object') {
+        throw TypeError('Argument must be an object');
+      }
+      F.prototype = o;
+      return new F();
+    };
+  })();
+}
 
 var SwaggerApi = function(url, options) {
   this.url = null;
@@ -418,16 +485,24 @@ SwaggerResource.prototype.addApiDeclaration = function(response) {
 };
 
 SwaggerResource.prototype.addModels = function(models) {
+  var self = this;
   if (models != null) {
-    var modelName;
-    for (modelName in models) {
-      if (this.models[modelName] == null) {
-        var swaggerModel = new SwaggerModel(modelName, models[modelName]);
-        this.modelsArray.push(swaggerModel);
-        this.models[modelName] = swaggerModel;
-        this.rawModels[modelName] = models[modelName];
-      }
-    }
+
+    var model;
+
+    // to array
+    models = Object.keys(models).map(function(modelName) {
+      return models[modelName];
+    });
+
+    models.forEach(function(model) {
+      var modelName = model.id;
+      if (modelName in self.models)
+        return;
+
+      addAncestorModels(model);
+    });
+
     var output = [];
     for (var i = 0; i < this.modelsArray.length; i++) {
       model = this.modelsArray[i];
@@ -435,6 +510,45 @@ SwaggerResource.prototype.addModels = function(models) {
     }
     return output;
   }
+
+  // get the parent model
+  function getParentModel(me) {
+    return models.find(function(model) {
+      if(model.subTypes && model.subTypes.length) {
+        return model.subTypes.some(function(type) {
+          return me.id === type;
+        });
+      }
+      else
+        return false;
+    });
+  }
+
+  // process all all ancestors models
+  function addAncestorModels(me) {
+    var ancestors = [me];
+    var parent = me;
+    while (parent = getParentModel(parent)) {
+      // sorted by the ancestors
+      ancestors.unshift(parent);
+    }
+
+    // ancestor has to go first to get the prototype chain right
+    ancestors.forEach(function(model, index) {
+      self.addModel(model, ancestors[index-1]);
+    });
+  }
+};
+
+SwaggerResource.prototype.addModel = function(model, parentModel) {
+  var modelName = model.id;
+  if (modelName in this.models)
+    return;
+
+  var swaggerModel = new SwaggerModel(modelName, model, parentModel);
+  this.modelsArray.push(swaggerModel);
+  this.models[modelName] = swaggerModel;
+  this.rawModels[modelName] = modelName;
 };
 
 SwaggerResource.prototype.addOperations = function(resource_path, ops, consumes, produces) {
@@ -511,20 +625,38 @@ SwaggerResource.prototype.help = function() {
   return output;
 };
 
-var SwaggerModel = function(modelName, obj) {
+var SwaggerModel = function(modelName, obj, parentModel) {
   this.name = obj.id != null ? obj.id : modelName;
   this.properties = [];
+  var allProps = obj.properties;
+
+  // inherit from parent model, re-create the "properties" object
+  if (parentModel) {
+    allProps = obj.properties = Object.create(parentModel.properties, (function(props) {
+      Object.keys(props).forEach(function(key) {
+        var val = props[key];
+        props[key] = {
+          value: val,
+          writable: true,
+          enumerable: true
+        };
+      });
+      return props;
+    })(obj.properties));
+  }
+
+  var prop;
   var propertyName;
-  for (propertyName in obj.properties) {
+  for (propertyName in allProps) {
     if (obj.required != null) {
       var value;
       for (value in obj.required) {
         if (propertyName === obj.required[value]) {
-          obj.properties[propertyName].required = true;
+          allProps[propertyName].required = true;
         }
       }
     }
-    prop = new SwaggerModelProperty(propertyName, obj.properties[propertyName]);
+    prop = new SwaggerModelProperty(propertyName, allProps[propertyName]);
     this.properties.push(prop);
   }
 }


### PR DESCRIPTION
The patch implements simple singular inheritance with prototype, where model will simply pull in all inherited properties from ancestor model, which seems to be enough to support the spec:
https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#modelSubTypes