### PR TITLE
Fixed mismatched var names (consumes vs contentType)

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -1191,7 +1191,7 @@ var SwaggerRequest = function(type, url, params, opts, successCallback, errorCal
 SwaggerRequest.prototype.setHeaders = function(params, operation) {
   // default type
   var accepts = "application/json";
-  var contentType = null;
+  var consumes = null;
 
   var allDefinedParams = this.operation.parameters;
   var definedFormParams = [];


### PR DESCRIPTION
'consumes' was not defined in the scope but used, whereas 'contentType' was defined but not used.
