### PR TITLE
Fix: treat child models as referenced

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -432,6 +432,11 @@ SwaggerResource.prototype.addModels = function(models) {
     for (var i = 0; i < this.modelsArray.length; i++) {
       model = this.modelsArray[i];
       output.push(model.setReferencedModels(this.models));
+      if (model.subTypes !== undefined) {
+        for (var j = 0; j < model.subTypes.length; j++) {
+          model.subTypes[j] = this.models[model.subTypes[j]];
+        }
+      }
     }
     return output;
   }
@@ -527,10 +532,16 @@ var SwaggerModel = function(modelName, obj) {
     prop = new SwaggerModelProperty(propertyName, obj.properties[propertyName]);
     this.properties.push(prop);
   }
+  this.subTypes = obj.subTypes;
 }
 
 SwaggerModel.prototype.setReferencedModels = function(allModels) {
   var results = [];
+  if (this.subTypes !== undefined) {
+    for (var i = 0; i < this.subTypes.length; i++) {
+      results.push(allModels[this.subTypes[i]]);
+    }
+  }
   for (var i = 0; i < this.properties.length; i++) {
     var property = this.properties[i];
     var type = property.type || property.dataType;
@@ -560,6 +571,11 @@ SwaggerModel.prototype.getMockSignature = function(modelsToIgnore) {
   if (!modelsToIgnore)
     modelsToIgnore = [];
   modelsToIgnore.push(this.name);
+  if (this.subTypes !== undefined) {
+    for (var i = 0; i < this.subTypes.length; i++) {
+      returnVal += '<br>' + this.subTypes[i].getMockSignature(modelsToIgnore);
+    }
+  }
 
   for (var i = 0; i < this.properties.length; i++) {
     prop = this.properties[i];


### PR DESCRIPTION
This commit shows model subtypes as referenced models in the swagger ui. Things missing: discriminator fields should be added here also, discriminator values should be shown for each child model. This is not possible yet as swagger spec does not have values information.

Does not break existing behavior if there are no subtypes in the model list.