### PR TITLE
Added application/json;charset="utf-8" as accepted content.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -944,7 +944,31 @@ SwaggerOperation.prototype.urlify = function(args) {
       if(args[param.name]) {
         // apply path params and remove from args
         var reg = new RegExp('\{' + param.name + '[^\}]*\}', 'gi');
-        url = url.replace(reg, this.encodePathParam(args[param.name]));
+          var paramStart = url.search(reg);
+          function findParamEnd(start,url){
+              var end = -1;
+              if(start>=0){
+                  var counter = 1;
+                  end = start+1;
+                  while(end<url.length){
+                      switch(url.charAt(end)){
+                          case '{':
+                              counter++;
+                              break;
+                          case '}':
+                              counter--;
+                              break;
+                      }
+                      end++;
+                      if(counter==0) break;
+                  }
+              }
+              return end;
+          }
+          var paramEnd = findParamEnd(paramStart,url);
+          if(paramStart>=0){
+              url = url.substring(0,paramStart)+this.encodePathParam(args[param.name]) + url.substring(paramEnd);
+          }
         delete args[param.name];
       }
       else


### PR DESCRIPTION
I got an issue when I deployed swagger core on JBoss7+Resteasy 2.5.7.

During initialization (downloading api-docs form endpoint on JBoss7) the request was rejected by JBoss server because Restasy framework said that it can't produce accepted content type.
The servlet from swagger-core told that it produces application/json;charset="utf-8" and client said that it can accept application/json. So I'm adding application/json;charset="utf-8" as accepted to those requests.
