### PR TITLE
fix authorizations

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -161,8 +161,6 @@ SwaggerApi.prototype.build = function() {
       }
     }
   };
-  var e = (typeof window !== 'undefined' ? window : exports);
-  e.authorizations.apply(obj);
   new SwaggerHttp().execute(obj);
   return this;
 };
@@ -340,6 +338,7 @@ var SwaggerResource = function(resourceObj, api) {
   produces = (this.produces | []);
   this.path = this.api.resourcePath != null ? this.api.resourcePath : resourceObj.path;
   this.description = resourceObj.description;
+  this.authorizations = (resourceObj.authorizations || {});
 
   var parts = this.path.split("/");
   this.name = parts[parts.length - 1].replace('.{format}', '');
@@ -381,8 +380,6 @@ var SwaggerResource = function(resourceObj, api) {
         }
       }
     };
-    var e = typeof window !== 'undefined' ? window : exports;
-    e.authorizations.apply(obj);
     new SwaggerHttp().execute(obj);
   }
 }
@@ -701,7 +698,7 @@ var SwaggerOperation = function(nickname, path, method, parameters, summary, not
   this.resource = (resource||errors.push("Resource is required"));
   this.consumes = consumes;
   this.produces = produces;
-  this.authorizations = authorizations;
+  this.authorizations = typeof authorizations !== "undefined" ? authorizations : resource.authorizations;
   this["do"] = __bind(this["do"], this);
 
   if (errors.length > 0)
@@ -1194,7 +1191,7 @@ var SwaggerRequest = function(type, url, params, opts, successCallback, errorCal
     } else {
       e = exports;
     }
-    status = e.authorizations.apply(obj, this.operation.authorizations);
+    var status = e.authorizations.apply(obj, this.operation.authorizations);
     if (opts.mock == null) {
       if (status !== false) {
         new SwaggerHttp().execute(obj);
@@ -1546,29 +1543,18 @@ SwaggerAuthorizations.prototype.remove = function(name) {
 };
 
 SwaggerAuthorizations.prototype.apply = function(obj, authorizations) {
-  var status = null;
-  var key;
+  var status, key, value, result;
+  status = true;
 
-  // if the "authorizations" key is undefined, or has an empty array, add all keys
-  if(typeof authorizations === 'undefined' || Object.keys(authorizations).length == 0) {
-    for (key in this.authz) {
-      value = this.authz[key];
-      result = value.apply(obj, authorizations);
-      if (result === true)
-        status = true;
-    }
-  }
-  else {
-    for(name in authorizations) {
-      for (key in this.authz) {
-        if(key == name) {
-          value = this.authz[key];
-          result = value.apply(obj, authorizations);
-          if (result === true)
-            status = true;
-        }
-      }      
-    }
+  for(name in authorizations) {
+    for(key in this.authz) {
+      if(key == name) {
+        value = this.authz[key];
+        result = value.apply(obj, authorizations);
+        if (result === false)
+          status = false;
+      }
+    }      
   }
 
   return status;


### PR DESCRIPTION
Pull request for the issue https://github.com/wordnik/swagger-js/issues/127

* Calls to the authorizations are only made when requesting an operation, and not when requesting the resources list, or any resource (according to the RFC)
* Operations without any `authorizations` field inherits from the `authorizations` field of its resource
* Empty object `{}` as `authorizations` field means no authorization required, and is the default value for a resource
* All the authorizations of the `authorizations` field are required