### PR TITLE
Deprecated is in spec, add it to model.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -498,7 +498,7 @@
           }
         }
         o.nickname = this.sanitize(o.nickname);
-        var op = new SwaggerOperation(o.nickname, resource_path, method, o.parameters, o.summary, o.notes, type, responseMessages, this, consumes, produces, o.authorizations);
+        var op = new SwaggerOperation(o.nickname, resource_path, method, o.parameters, o.summary, o.notes, type, responseMessages, this, consumes, produces, o.authorizations, o.deprecated);
         this.operations[op.nickname] = op;
         output.push(this.operationsArray.push(op));
       }
@@ -691,7 +691,7 @@
     return str;
   };
 
-  var SwaggerOperation = function (nickname, path, method, parameters, summary, notes, type, responseMessages, resource, consumes, produces, authorizations) {
+  var SwaggerOperation = function (nickname, path, method, parameters, summary, notes, type, responseMessages, resource, consumes, produces, authorizations, deprecated) {
     var _this = this;
 
     var errors = [];
@@ -707,6 +707,7 @@
     this.consumes = consumes;
     this.produces = produces;
     this.authorizations = authorizations;
+    this.deprecated = deprecated;
     this["do"] = __bind(this["do"], this);
 
     if (errors.length > 0) {


### PR DESCRIPTION
Deprecated is in the Swagger 2.0 spec.  Let's add it to the model so we can use it.
