### PR TITLE
Prevent ugly error on missing type

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -739,7 +739,7 @@
       }
       param.type = type;
 
-      if (type.toLowerCase() === 'boolean') {
+      if (type && type.toLowerCase() === 'boolean') {
         param.allowableValues = {};
         param.allowableValues.values = ["true", "false"];
       }


### PR DESCRIPTION
See https://github.com/wordnik/swagger-ui/pull/650

What we should probably do is log an error somehow and ignore the parameter, but I don't really see a way to do that gracefully the way the code is structured.
