### PR TITLE
Don't fail when JSON Schema type is an array

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -610,7 +610,7 @@
   var SwaggerModelProperty = function (name, obj) {
     this.name = name;
     this.dataType = obj.type || obj.dataType || obj["$ref"];
-    this.isCollection = this.dataType && (this.dataType.toLowerCase() === 'array' || this.dataType.toLowerCase() === 'list' || this.dataType.toLowerCase() === 'set');
+    this.isCollection = this.dataType && typeof this.dataType.toLowerCase === 'function' && (this.dataType.toLowerCase() === 'array' || this.dataType.toLowerCase() === 'list' || this.dataType.toLowerCase() === 'set');
     this.descr = obj.description;
     this.required = obj.required;
     this.defaultValue = modelPropertyMacro(obj.defaultValue);


### PR DESCRIPTION
This fixes the case of a type array in JSON Schema:
{
type: [ "string", "object" ]
}
