### PR TITLE
making swagger-ui location relative when schemes and host are not provid...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ capybara-*.html
 /spec/tmp/*
 **.orig
 *.idea
+*.iml
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@
 .npmignore
 lib/swagger-*spec.js
 src/swagger-*-spec.js
+*.iml
+npm-debug.log

--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -1,5 +1,5 @@
 // swagger-client.js
-// version 2.1.0-alpha.1
+// version 2.1.0-alpha.2
 /**
  * Array Model
  **/
@@ -375,7 +375,8 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
   this.info = response.info || {};
   this.title = response.title || '';
   this.host = response.host || '';
-  this.schemes = response.schemes || [ 'http' ];
+  this.schemes = response.schemes || [];
+  this.scheme;
   this.basePath = response.basePath || '';
   this.apis = {};
   this.apisArray = [];
@@ -383,9 +384,19 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
   this.produces = response.produces;
   this.authSchemes = response.authorizations;
 
+  var location = this.parseUri(this.url);
+  if(typeof this.schemes === 'undefined' || this.schemes.length === 0) {
+    this.scheme = location.scheme;
+  }
+  else {
+    this.scheme = this.schemes[0];
+  }
+
   if(typeof this.host === 'undefined' || this.host === '') {
-    var location = this.parseUri(this.url);
     this.host = location.host;
+    if (location.port) {
+      this.host = this.host + ':' + location.port;
+    }
   }
 
   this.definitions = response.definitions;
@@ -466,6 +477,7 @@ SwaggerClient.prototype.parseUri = function(uri) {
   return {
     scheme: parts[4].replace(':',''),
     host: parts[11],
+    port: parts[12],
     path: parts[15]
   };
 }
@@ -516,6 +528,7 @@ var Operation = function(parent, operationId, httpMethod, path, args, definition
   this.parent = parent;
   this.host = parent.host;
   this.schemes = parent.schemes;
+  this.scheme = parent.scheme || 'http';
   this.basePath = parent.basePath;
   this.nickname = (operationId||errors.push('Operations must have a nickname.'));
   this.method = (httpMethod||errors.push('Operation ' + operationId + ' is missing method.'));
@@ -551,6 +564,11 @@ var Operation = function(parent, operationId, httpMethod, path, args, definition
         param.allowableValues.values.push(value);
         param.allowableValues.descriptiveValues.push({value : value, isDefault: isDefault});
       }
+    }
+    if(param.type === 'array' && typeof param.allowableValues === 'undefined') {
+      // can't show as a list if no values to select from
+      delete param.isList;
+      delete param.allowMultiple;
     }
     param.signature = this.getSignature(innerType, models);
     param.sampleJSON = this.getSampleJSON(innerType, models);
@@ -840,8 +858,7 @@ Operation.prototype.execute = function(arg1, arg2, arg3, arg4, parent) {
     // todo append?
     args.body = encoded;
   }
-  var scheme = this.schemes[0];
-  var url = scheme + '://' + this.host + this.basePath + requestUrl + querystring;
+  var url = this.scheme + '://' + this.host + this.basePath + requestUrl + querystring;
 
   var obj = {
     url: url,

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1,5 +1,5 @@
 // swagger-client.js
-// version 2.1.0-alpha.1
+// version 2.1.0-alpha.2
 /**
  * Array Model
  **/
@@ -375,7 +375,8 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
   this.info = response.info || {};
   this.title = response.title || '';
   this.host = response.host || '';
-  this.schemes = response.schemes || [ 'http' ];
+  this.schemes = response.schemes || [];
+  this.scheme;
   this.basePath = response.basePath || '';
   this.apis = {};
   this.apisArray = [];
@@ -383,9 +384,19 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
   this.produces = response.produces;
   this.authSchemes = response.authorizations;
 
+  var location = this.parseUri(this.url);
+  if(typeof this.schemes === 'undefined' || this.schemes.length === 0) {
+    this.scheme = location.scheme;
+  }
+  else {
+    this.scheme = this.schemes[0];
+  }
+
   if(typeof this.host === 'undefined' || this.host === '') {
-    var location = this.parseUri(this.url);
     this.host = location.host;
+    if (location.port) {
+      this.host = this.host + ':' + location.port;
+    }
   }
 
   this.definitions = response.definitions;
@@ -466,6 +477,7 @@ SwaggerClient.prototype.parseUri = function(uri) {
   return {
     scheme: parts[4].replace(':',''),
     host: parts[11],
+    port: parts[12],
     path: parts[15]
   };
 }
@@ -516,6 +528,7 @@ var Operation = function(parent, operationId, httpMethod, path, args, definition
   this.parent = parent;
   this.host = parent.host;
   this.schemes = parent.schemes;
+  this.scheme = parent.scheme || 'http';
   this.basePath = parent.basePath;
   this.nickname = (operationId||errors.push('Operations must have a nickname.'));
   this.method = (httpMethod||errors.push('Operation ' + operationId + ' is missing method.'));
@@ -845,8 +858,7 @@ Operation.prototype.execute = function(arg1, arg2, arg3, arg4, parent) {
     // todo append?
     args.body = encoded;
   }
-  var scheme = this.schemes[0];
-  var url = scheme + '://' + this.host + this.basePath + requestUrl + querystring;
+  var url = this.scheme + '://' + this.host + this.basePath + requestUrl + querystring;
 
   var obj = {
     url: url,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     }
   ],
   "description": "swagger.js is a javascript client for use with swaggering APIs.",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "homepage": "http://swagger.io",
   "repository": {
     "type": "git",

--- a/src/main/javascript/swagger.js
+++ b/src/main/javascript/swagger.js
@@ -89,7 +89,8 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
   this.info = response.info || {};
   this.title = response.title || '';
   this.host = response.host || '';
-  this.schemes = response.schemes || [ 'http' ];
+  this.schemes = response.schemes || [];
+  this.scheme;
   this.basePath = response.basePath || '';
   this.apis = {};
   this.apisArray = [];
@@ -97,9 +98,19 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
   this.produces = response.produces;
   this.authSchemes = response.authorizations;
 
+  var location = this.parseUri(this.url);
+  if(typeof this.schemes === 'undefined' || this.schemes.length === 0) {
+    this.scheme = location.scheme;
+  }
+  else {
+    this.scheme = this.schemes[0];
+  }
+
   if(typeof this.host === 'undefined' || this.host === '') {
-    var location = this.parseUri(this.url);
     this.host = location.host;
+    if (location.port) {
+      this.host = this.host + ':' + location.port;
+    }
   }
 
   this.definitions = response.definitions;
@@ -180,6 +191,7 @@ SwaggerClient.prototype.parseUri = function(uri) {
   return {
     scheme: parts[4].replace(':',''),
     host: parts[11],
+    port: parts[12],
     path: parts[15]
   };
 }
@@ -230,6 +242,7 @@ var Operation = function(parent, operationId, httpMethod, path, args, definition
   this.parent = parent;
   this.host = parent.host;
   this.schemes = parent.schemes;
+  this.scheme = parent.scheme || 'http';
   this.basePath = parent.basePath;
   this.nickname = (operationId||errors.push('Operations must have a nickname.'));
   this.method = (httpMethod||errors.push('Operation ' + operationId + ' is missing method.'));
@@ -559,8 +572,7 @@ Operation.prototype.execute = function(arg1, arg2, arg3, arg4, parent) {
     // todo append?
     args.body = encoded;
   }
-  var scheme = this.schemes[0];
-  var url = scheme + '://' + this.host + this.basePath + requestUrl + querystring;
+  var url = this.scheme + '://' + this.host + this.basePath + requestUrl + querystring;
 
   var obj = {
     url: url,


### PR DESCRIPTION
...ed

This makes it possible to omit the host and scheme and have it adopt the host and scheme of the docs url. Handy when your API docs follow the API through lots of envs.  (e.g. local, dev, test, stage, prod) 

Will require someone to verify I didn't break something unexpectedly.

![noidea](https://cloud.githubusercontent.com/assets/754053/4687590/49386264-5658-11e4-8267-2f3c3114101b.jpg)
