### PR TITLE
refTyp substring fix

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1105,7 +1105,7 @@ var Property = function(name, obj, required) {
   this.required = required;
   if(obj['$ref']) {
     var refType = obj['$ref'];
-    refType = refType.indexOf('#/definitions') === -1 ? refType : refType.substring('#/definitions').length;
+    refType = refType.indexOf('#/definitions') === -1 ? refType : refType.substring('#/definitions'.length);
     this['$ref'] = refType;
   }
   else if (obj.type === 'array') {


### PR DESCRIPTION
The substrin was not called on the proper string. Using the #/definitions as ref was not working in all the cases
