### PR TITLE
Edit SwaggerOperation.prototype.urlify to check if query is undefined an...

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -988,7 +988,7 @@
           queryParams += encodeURIComponent(param.name) + '=' + output;    
         }
         else {
-          if (args[param.name]) {
+          if (typeof args[param.name] !== 'undefined') {
             queryParams += encodeURIComponent(param.name) + '=' + encodeURIComponent(args[param.name]);
           } else {
             if (param.required)


### PR DESCRIPTION
Check that query parameter is defined before appending to url. If param is undefined and required throw error.

Issue #158 
