### PR TITLE
Allow a body alias of body

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -906,10 +906,12 @@
       else if (param.paramType === 'form' || param.paramType.toLowerCase() === 'file')
         possibleParams.push(param);
       else if (param.paramType === 'body' && param.name !== 'body') {
-        if (args.body) {
-          throw new Error("Saw two body params in an API listing; expecting a max of one.");
+        if (args[param.name]) {
+          if (args.body) {
+            throw new Error("Saw two body params in an API listing; expecting a max of one.");
+          }
+          args.body = args[param.name];
         }
-        args.body = args[param.name];
       }
     }
 


### PR DESCRIPTION
Allow the body of a swagger call to be aliased to body if it is not using the correct swagger defined name.  This allows a default of body as well as the swagger name for the body. Resolves swagger-api/swagger-js#168