### PR TITLE
Do not send undefined query params

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -981,9 +981,9 @@
     for (var i = 0; i < params.length; i++) {
       var param = params[i];
       if(param.paramType === 'query') {
-        if (queryParams !== '')
-          queryParams += '&';    
         if (Array.isArray(param)) {
+          if (queryParams !== '')
+            queryParams += '&';
           var j;   
           var output = '';   
           for(j = 0; j < param.length; j++) {    
@@ -993,7 +993,9 @@
           }    
           queryParams += encodeURIComponent(param.name) + '=' + output;    
         }    
-        else {   
+        else if (args[param.name] !== undefined) {
+          if (queryParams !== '')
+            queryParams += '&';
           queryParams += encodeURIComponent(param.name) + '=' + encodeURIComponent(args[param.name]);                
         }
       }


### PR DESCRIPTION
Sending ?someparam=undefined is taken literally and breaks my API.  This change won't send queryParams with "undefined". 
