### PR TITLE
Fix for undefined and null values being sent as URL parameters (#158)

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -980,21 +980,24 @@
     var queryParams = "";
     for (var i = 0; i < params.length; i++) {
       var param = params[i];
-      if(param.paramType === 'query') {
+      var paramValue = args[param.name];
+      var isValidScalarValue =  paramValue !== null && paramValue !== void 0;
+      var isValidValue = (Array.isArray(param) || isValidScalarValue);
+      if(param.paramType === 'query' && isValidValue) {
         if (queryParams !== '')
           queryParams += '&';    
         if (Array.isArray(param)) {
           var j;   
           var output = '';   
-          for(j = 0; j < param.length; j++) {    
+          for(j = 0; j < param.length; j++) {
             if(j > 0)    
               output += ',';   
-            output += encodeURIComponent(param[j]);    
+            output += encodeURIComponent(param[j]);
           }    
           queryParams += encodeURIComponent(param.name) + '=' + output;    
         }    
-        else {   
-          queryParams += encodeURIComponent(param.name) + '=' + encodeURIComponent(args[param.name]);                
+        else {
+          queryParams += encodeURIComponent(param.name) + '=' + encodeURIComponent(paramValue);
         }
       }
     }


### PR DESCRIPTION
This change only affects scalar parameters, array behaviour is left the same.
