### PR TITLE
Allow multiple APIs to be accessed at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,31 @@ client.authorizations.add("apiKey", new client.ApiKeyAuthorization("api_key","sp
 ```js
 client.authorizations.add("apiKey", new client.ApiKeyAuthorization("api_key","special-key","header"));
 ```
+####What if you need to call two APIs with the Swagger Client?
+Add a Swagger Authorization when you create the api client.
+
+```js
+var client = require("swagger-client")
+// Add the default authorization to the global client.
+client.authorizations.add("apiKey", new client.ApiKeyAuthorization("api_key","special-key","header"));
+
+var swagger = new client.SwaggerApi({
+  url: 'http://petstore.swagger.wordnik.com/api/api-docs',
+  success: function() {
+    if(swagger.ready === true) {
+      swagger.apis.pet.getPetById({petId:1});
+    }
+  },
+  // Add an authorization for this specific swagger client
+  authorization: new client.SwaggerAuthorization(
+                        "apiKey",
+                        new client.APiKeyAuthorization("api_key", "another-special-key", "header")
+  )
+});
+
+```
+This adds a global default authorization to the client and then adds a different authorization to the specific swagger
+api client when it is created.
 
 ### Calling an API with Swagger + the browser!
 

--- a/README.md
+++ b/README.md
@@ -96,15 +96,16 @@ var swagger = new client.SwaggerApi({
     }
   },
   // Add an authorization for this specific swagger client
-  authorization: new client.SwaggerAuthorization(
+  authorizations: new client.SwaggerAuthorization(
                         "apiKey",
-                        new client.APiKeyAuthorization("api_key", "another-special-key", "header")
+                        new client.ApiKeyAuthorization("api_key", "another-special-key", "header")
   )
 });
 
 ```
 This adds a global default authorization to the client and then adds a different authorization to the specific swagger
-api client when it is created.
+api client when it is created.  You are able to pass in any number of new authorization headers by creating your
+SwaggerAuthorization and then using its add method to add new ApiKeyAuthorizations.
 
 ### Calling an API with Swagger + the browser!
 

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -58,17 +58,17 @@
 
   Object.keys = Object.keys || (function () {
     var hasOwnProperty = Object.prototype.hasOwnProperty,
-      hasDontEnumBug = !{ toString: null }.propertyIsEnumerable("toString"),
-      DontEnums = [
-      'toString',
-      'toLocaleString',
-      'valueOf',
-      'hasOwnProperty',
-      'isPrototypeOf',
-      'propertyIsEnumerable',
-      'constructor'
-      ],
-    DontEnumsLength = DontEnums.length;
+        hasDontEnumBug = !{ toString: null }.propertyIsEnumerable("toString"),
+        DontEnums = [
+          'toString',
+          'toLocaleString',
+          'valueOf',
+          'hasOwnProperty',
+          'isPrototypeOf',
+          'propertyIsEnumerable',
+          'constructor'
+        ],
+        DontEnumsLength = DontEnums.length;
 
     return function (o) {
       if (typeof o != "object" && typeof o != "function" || o === null)
@@ -122,7 +122,7 @@
       this.useJQuery = options.useJQuery;
 
     if (options.authorizations) {
-      this.clientAuthorizations = authorizations;
+      this.clientAuthorizations = options.authorizations;
     } else {
       var e = (typeof window !== 'undefined' ? window : exports);
       this.clientAuthorizations = e.authorizations;
@@ -212,7 +212,6 @@
       var newName = response.resourcePath.replace(/\//g, '');
       this.resourcePath = response.resourcePath;
       var res = new SwaggerResource(response, this);
-      res.clientAuthorizations = this.clientAuthorizations;
       this.apis[newName] = res;
       this.apisArray.push(res);
     } else {
@@ -390,7 +389,7 @@
           },
           error: function (response) {
             return _this.api.fail("Unable to read api '" +
-              _this.name + "' from path " + _this.url + " (server returned " + response.statusText + ")");
+            _this.name + "' from path " + _this.url + " (server returned " + response.statusText + ")");
           }
         }
       };
@@ -1207,9 +1206,9 @@
       };
 
       var status = false;
-      if (operation.response && operation.response.clientAuthorizations) {
+      if (this.operation.resource && this.operation.resource.api && this.operation.resource.api.clientAuthorizations) {
         // Get the client authorizations from the resource declaration
-        status = operation.response.clientAuthorizations.apply(obj, operation.authorizations);
+        status = this.operation.resource.api.clientAuthorizations.apply(obj, this.operation.authorizations);
       } else {
         // Get the client authorization from the default authorization declaration
         var e;
@@ -1387,7 +1386,7 @@
     obj.data = obj.body;
     obj.complete = function (response, textStatus, opts) {
       var headers = {},
-        headerArray = response.getAllResponseHeaders().split("\n");
+          headerArray = response.getAllResponseHeaders().split("\n");
 
       for (var i = 0; i < headerArray.length; i++) {
         var toSplit = headerArray[i].trim();
@@ -1400,7 +1399,7 @@
           continue;
         }
         var name = toSplit.substring(0, separator).trim(),
-          value = toSplit.substring(separator + 1).trim();
+            value = toSplit.substring(separator + 1).trim();
         headers[name] = value;
       }
 
@@ -1561,7 +1560,7 @@
    */
   var SwaggerAuthorizations = function (name, auth) {
     this.authz = {};
-    if(!name && !auth) {
+    if(name && auth) {
       this.authz[name] = auth;
     }
   };
@@ -1672,6 +1671,7 @@
   e.SampleModels = sampleModels;
   e.SwaggerHttp = SwaggerHttp;
   e.SwaggerRequest = SwaggerRequest;
+  e.SwaggerAuthorizations = SwaggerAuthorizations;
   e.authorizations = new SwaggerAuthorizations();
   e.ApiKeyAuthorization = ApiKeyAuthorization;
   e.PasswordAuthorization = PasswordAuthorization;

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -121,13 +121,20 @@
     if (typeof options.useJQuery === 'boolean')
       this.useJQuery = options.useJQuery;
 
+    if (options.authorizations) {
+      this.clientAuthorizations = authorizations;
+    } else {
+      var e = (typeof window !== 'undefined' ? window : exports);
+      this.clientAuthorizations = e.authorizations;
+    }
+
     this.failure = options.failure != null ? options.failure : function () { };
     this.progress = options.progress != null ? options.progress : function () { };
     if (options.success != null) {
       this.build();
       this.isBuilt = true;
     }
-  }
+  };
 
   SwaggerApi.prototype.build = function () {
     if (this.isBuilt)
@@ -205,6 +212,7 @@
       var newName = response.resourcePath.replace(/\//g, '');
       this.resourcePath = response.resourcePath;
       var res = new SwaggerResource(response, this);
+      res.clientAuthorizations = this.clientAuthorizations;
       this.apis[newName] = res;
       this.apisArray.push(res);
     } else {
@@ -1197,13 +1205,22 @@
           }
         }
       };
-      var e;
-      if (typeof window !== 'undefined') {
-        e = window;
+
+      var status = false;
+      if (operation.response && operation.response.clientAuthorizations) {
+        // Get the client authorizations from the resource declaration
+        status = operation.response.clientAuthorizations.apply(obj, operation.authorizations);
       } else {
-        e = exports;
+        // Get the client authorization from the default authorization declaration
+        var e;
+        if (typeof window !== 'undefined') {
+          e = window;
+        } else {
+          e = exports;
+        }
+        status = e.authorizations.apply(obj, this.operation.authorizations);
       }
-      var status = e.authorizations.apply(obj, this.operation.authorizations);
+
       if (opts.mock == null) {
         if (status !== false) {
           new SwaggerHttp().execute(obj);
@@ -1542,8 +1559,11 @@
   /**
    * SwaggerAuthorizations applys the correct authorization to an operation being executed
    */
-  var SwaggerAuthorizations = function () {
+  var SwaggerAuthorizations = function (name, auth) {
     this.authz = {};
+    if(!name && !auth) {
+      this.authz[name] = auth;
+    }
   };
 
   SwaggerAuthorizations.prototype.add = function (name, auth) {


### PR DESCRIPTION
Turn the existing authorization to be a default and allow an override to be passed in for each api client that is created.

This resolves #109.