### PR TITLE
[develop 2.0] Use Gulp as build tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ capybara-*.html
 *.idea
 *.iml
 npm-debug.log
+/node_modules/
+/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ capybara-*.html
 npm-debug.log
 /node_modules/
 /dist/
+/coverage/
+.coverrun

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's written in CoffeeScript and tested with Jasmine, and is the fastest way to 
 The goal of Swagger™ is to define a standard, language-agnostic interface to REST APIs which allows both humans and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined via Swagger, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interfaces have done for lower-level programming, Swager removes the guesswork in calling the service.
 
 
-Check out [Swagger-Spec](https://github.com/wordnik/swagger-spec) for additional information about the Swagger project, including additional libraries with support for other languages and more. 
+Check out [Swagger-Spec](https://github.com/wordnik/swagger-spec) for additional information about the Swagger project, including additional libraries with support for other languages and more.
 
 
 ### Calling an API with swagger + node.js!
@@ -125,19 +125,19 @@ You can easily write your own request signing code for Swagger.  For example:
 
 ```js
 var CustomRequestSigner = function(name) {
-  this.name = name; 
-}; 
+  this.name = name;
+};
 
-CustomRequestSigner.prototype.apply = function(obj, authorizations) { 
-  var hashFunction = this._btoa; 
-  var hash = hashFunction(obj.url); 
+CustomRequestSigner.prototype.apply = function(obj, authorizations) {
+  var hashFunction = this._btoa;
+  var hash = hashFunction(obj.url);
 
-  obj.headers["signature"] = hash; 
-  return true; 
-}; 
+  obj.headers["signature"] = hash;
+  return true;
+};
 ```
 
-In the above simple example, we're creating a new request signer that simply 
+In the above simple example, we're creating a new request signer that simply
 base 64 encodes the URL.  Of course you'd do something more sophisticated, but
 after encoding it, a header called `signature` is set before sending the request.
 
@@ -155,29 +155,37 @@ The HTTP requests themselves are handled by the excellent [shred](https://github
 Development
 -----------
 
-Please [fork the code](https://github.com/wordnik/swagger-js) and help us improve
+Please [fork the code](https://github.com/swagger-api/swagger-js) and help us improve
 swagger.js. Send us a pull request and **we'll mail you a wordnik T-shirt!**
 
-Swagger.js is written in CoffeeScript, so you'll need Node.js and the
-CoffeeScript compiler. For more detailed installation instructions, see
-[coffeescript.org/#installation](http://coffeescript.org/#installation).
+Swagger.js use gulp for Node.js.
 
 ```bash
-# generate the javascript libraries and put them in the `lib` folder
+# Install the gulp client on the path
+npm install -g gulp
 
-npm run-script build
+# Install all project dependencies
+npm install
 ```
 
 ```bash
-# The 'dev' task will:
-# 1. Open source files in your $EDITOR
-# 2. Open and run the Jasmine specs in your browser.
-# 3. Watch for changes to CoffeeScript files and auto-compile them to Javascript.
+# List all tasks.
+gulp -T
 
-npm run-script dev
+# Run the test suite
+gulp test
 
-# List all cake tasks:
-cake
+# Build the library (minified and unminified) in the dist folder
+gulp build
+
+# continuously run the test suite:
+gulp watch
+
+# run jshint report
+gulp lint
+
+# run a coverage report
+gulp cover
 ```
 
 License

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var jshint = require('gulp-jshint');
 var mocha  = require('gulp-mocha');
 var concat = require('gulp-concat');
 var rename = require('gulp-rename');
+var istanbul = require('gulp-istanbul');
 var del = require('del');
 
 var basename = 'swagger-client';
@@ -36,6 +37,17 @@ gulp.task('test', function() {
     .pipe(mocha());
 });
 
+gulp.task('cover', function (cb) {
+  gulp.src(paths.sources)
+    .pipe(istanbul({includeUntested: true}))
+    .pipe(istanbul.hookRequire())
+    .on('finish', function () {
+      gulp.src(paths.tests)
+        .pipe(mocha())
+        .pipe(istanbul.writeReports())
+        .on('end', cb);
+    });
+});
 
 gulp.task('build', function() {
   return gulp.src(paths.sources)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,54 @@
+var gulp   = require('gulp');
+var gutil  = require('gulp-util');
+var uglify = require('gulp-uglify');
+var jshint = require('gulp-jshint');
+var mocha  = require('gulp-mocha');
+var concat = require('gulp-concat');
+var rename = require('gulp-rename');
+var del = require('del');
+
+var basename = 'swagger-client';
+var paths = {
+  sources: ['src/main/javascript/*.js'],
+  tests: ['test/*.js'],
+  dist: 'dist'
+};
+
+paths.all = paths.sources.concat(paths.tests).concat(['gulpfile.js']);
+
+
+gulp.task('clean', function (cb) {
+  del([
+    paths.dist + '/**',
+  ], cb);
+});
+
+gulp.task('lint', function() {
+  return gulp
+    .src(paths.all)
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
+});
+
+gulp.task('test', function() {
+  return gulp
+    .src(paths.tests)
+    .pipe(mocha());
+});
+
+
+gulp.task('build', function() {
+  return gulp.src(paths.sources)
+    .pipe(concat(basename + '.js'))
+    .pipe(gulp.dest(paths.dist))
+    .pipe(uglify())
+    .pipe(rename(basename + '.min.js'))
+    .pipe(gulp.dest(paths.dist))
+    .on('error', gutil.log);
+});
+
+gulp.task('watch', ['test'], function() {
+  gulp.watch(paths.all, ['test']);
+});
+
+gulp.task('default', ['clean', 'lint', 'test', 'build']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ var del = require('del');
 
 var basename = 'swagger-client';
 var paths = {
-  sources: ['src/main/javascript/*.js'],
+  sources: ['src/js/*.js'],
   tests: ['test/*.js'],
   dist: 'dist'
 };

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "type": "git",
     "url": "git://github.com/swagger-api/swagger-js.git"
   },
-  "main": "lib/swagger.js",
+  "main": "dist/swagger.js",
   "scripts": {
-    "build": "PATH=$PATH:./node_modules/.bin cake bake",
-    "dev": "PATH=$PATH:./node_modules/.bin cake dev",
+    "build": "gulp build",
+    "dev": "gulp watch",
     "test": "gulp test"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "PATH=$PATH:./node_modules/.bin cake bake",
     "dev": "PATH=$PATH:./node_modules/.bin cake dev",
-    "test": "mocha test"
+    "test": "gulp test"
   },
   "engines": {
     "node": ">= 0.6.6"
@@ -22,9 +22,17 @@
     "btoa": "1.1.1"
   },
   "devDependencies": {
+    "del": "^1.1.1",
+    "gulp": "^3.8.10",
+    "gulp-concat": "^2.4.3",
+    "gulp-jshint": "^1.9.0",
+    "gulp-mocha": "^2.0.0",
+    "gulp-rename": "^1.2.0",
+    "gulp-uglify": "^1.0.2",
+    "gulp-util": "^3.0.1",
     "mocha": "^1.21.3",
-    "unit.js": "1.1.2",
-    "should": "4.4.2"
+    "should": "4.4.2",
+    "unit.js": "1.1.2"
   },
   "license": "apache 2.0"
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "del": "^1.1.1",
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.3",
+    "gulp-istanbul": "^0.5.0",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
This pull-request add gulp as a build tool (should address #181).

It's a start, but to be ideal, I think the following is needed:
- [ ] split each class in its own file
- [ ] make use of require for dependencies
- [ ] no more globals (see #178 )
- [ ] use npm to manage external dependencies (shred, jquery..)
- [ ] use browerify or webpack for portable browser build
- [ ] produce a bower version in the build (https://www.npmjs.com/package/gulp-bower)