### PR TITLE
Set arg4 to callback when no opt passed in

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -815,7 +815,7 @@
       if(typeof opts === 'function') {
         arg2 = {};
         arg3 = opts;
-        arg4 = error;
+        arg4 = callback;
       }
       return _this['do'](arg1, arg2, arg3, arg4);
     };


### PR DESCRIPTION
When a user does not pass in the opts argument the code will shift the arguments so that the callbacks still get set correctly.  There is a bug that cuases the error callback to be set to null if opts is not passed in.  This fixes swagger-api/swagger-js#203.