### PR TITLE
path regex matcher allows quantifiers in pattern

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -842,7 +842,7 @@ Operation.prototype.urlify = function (args) {
     var param = this.parameters[i];
     if(typeof args[param.name] !== 'undefined') {
       if(param.in === 'path') {
-        var reg = new RegExp('\{' + param.name + '\}', 'gi');
+        var reg = new RegExp('\{' + param.name + '[^\\{\\}\\/]*(?:[^\\{\\}\\/]*\\{.*?\\})*.*?\\}(?=(\\/?|$))', 'gi');
         var value = args[param.name];
         if(Array.isArray(value))
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
@@ -2341,7 +2341,7 @@ SwaggerOperation.prototype.urlify = function (args) {
     if (param.paramType === 'path') {
       if (typeof args[param.name] !== 'undefined') {
         // apply path params and remove from args
-        var reg = new RegExp('\\{\\s*?' + param.name + '.*?\\}(?=\\s*?(\\/?|$))', 'gi');
+        var reg = new RegExp('\\{\\s*?' + param.name + '[^\\{\\}\\/]*(?:[^\\{\\}\\/]*\\{.*?\\})*.*?\\}(?=(\\/?|$))', 'gi');
         url = url.replace(reg, this.encodePathParam(args[param.name]));
         delete args[param.name];
       }


### PR DESCRIPTION
Expanding on issue #121.

Flexible support for multiple quantifiers in various positions.
e.g. `@Path( "/{first : (?i)[\\w\\d]{2}[\\w\\d]{2}}5/{second : (?i)[\\w\\d]{4}}" )`