### PR TITLE
regex pattern matching fix

### DIFF
--- a/src/js/swagger-compat.js
+++ b/src/js/swagger-compat.js
@@ -792,7 +792,7 @@ SwaggerOperation.prototype.urlify = function (args) {
     if (param.paramType === 'path') {
       if (typeof args[param.name] !== 'undefined') {
         // apply path params and remove from args
-        var reg = new RegExp('\\{\\s*?' + param.name + '.*?\\}(?=\\s*?(\\/?|$))', 'gi');
+        var reg = new RegExp('\\{\\s*?' + param.name + '[^\\{\\}\\/]*(?:\\{.*?\\}[^\\{\\}\\/]*)*\\}(?=(\\/?|$))', 'gi');
         url = url.replace(reg, this.encodePathParam(args[param.name]));
         delete args[param.name];
       }


### PR DESCRIPTION
Expanding on issue #121.

This supports regular expressions in path parameters.

For example: `@Path( "/{first : (?i)[\\w]{2}[\\d]{2}}5/{second : (?i)[\\d]{4}}" )`

will allow calls to `basepath/ab125/1234`

but will reject calls to `basepath/abcd5/1234`, `basepath/ab12/1234`, `basepath/ab125/12345`, or others that don't fit the regex pattern.