### PR TITLE
Expose response.statusText in the response out object

### DIFF
--- a/src/js/swaggerHttp.js
+++ b/src/js/swaggerHttp.js
@@ -93,6 +93,7 @@ JQueryHttpClient.prototype.execute = function(obj) {
       url: request.url,
       method: request.method,
       status: response.status,
+      statusText: response.statusText,
       data: response.responseText,
       headers: headers
     };


### PR DESCRIPTION
Hi there,

Currently, there is no way to obtain the statusText from the response in the response handlers. In our case, we have a need for this as we have meaningful statusText that we need to act upon. This pull request adds response.statusText to the response out object to expose meaningful statusText.

I refrained from generating the lib/swagger-client.js and lib/swagger-client.min.js files. If you could forward-port it to the master branch, this would be great.

Let me know if there is anything additional I can do!

Thanks for your hard work and great library! 