### PR TITLE
Fixed check for absolute URL

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1863,7 +1863,7 @@ SwaggerResource.prototype.addApiDeclaration = function (response) {
   if (typeof response.consumes === 'string')
     this.consumes = response.consumes;
   if ((typeof response.basePath === 'string') && response.basePath.replace(/\s/g, '').length > 0)
-    this.basePath = response.basePath.indexOf('http') === -1 ? this.getAbsoluteBasePath(response.basePath) : response.basePath;
+    this.basePath = response.basePath.indexOf('http') !== 0 ? this.getAbsoluteBasePath(response.basePath) : response.basePath;
   this.resourcePath = response.resourcePath;
   this.addModels(response.models);
   if (response.apis) {


### PR DESCRIPTION
Comparing the `indexOf()` result against `-1` just tells you whether `http` is somewhere in the URL. So an basepath like `/foo/http/bar` is currently treated as absolute.