### PR TITLE
Fix missing defaultValues for model properties

### DIFF
--- a/src/js/swagger-compat.js
+++ b/src/js/swagger-compat.js
@@ -450,7 +450,7 @@ var SwaggerModelProperty = function (name, obj, model) {
   this.isCollection = this.dataType && (this.dataType.toLowerCase() === 'array' || this.dataType.toLowerCase() === 'list' || this.dataType.toLowerCase() === 'set');
   this.descr = obj.description;
   this.required = obj.required;
-  this.defaultValue = applyModelPropertyMacro(obj, model);
+  this.defaultValue = applyModelPropertyMacro(model, obj);
   if (obj.items) {
     if (obj.items.type) {
       this.refDataType = obj.items.type;


### PR DESCRIPTION
Currently, the defaultValue attribute of a property is not respected, as the defaultValue property check takes place against the entire model rather than the property.

This pull request fixes the incorrect ordering of parameters for applyModelPropertyMacro, and should allow defaultValues to work as expected.