### PR TITLE
Properly encode slashes in path parameters

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -9,7 +9,7 @@ var ArrayModel = function(definition) {
   this.name = "arrayModel";
   this.definition = definition || {};
   this.properties = [];
-  
+
   var requiredFields = definition.enum || [];
   var innerType = definition.items;
   if(innerType) {
@@ -301,7 +301,7 @@ PrimitiveModel.prototype.getMockSignature = function(modelsToIgnore) {
   }
   return returnVal;
 };
-/** 
+/**
  * Resolves a spec's remote references
  */
 var Resolver = function (){};
@@ -1460,22 +1460,8 @@ Operation.prototype.encodeQueryParam = function(arg) {
   return encodeURIComponent(arg);
 };
 
-/**
- * TODO revisit, might not want to leave '/'
- **/
 Operation.prototype.encodePathParam = function(pathParam) {
-  var encParts, part, parts, i, len;
-  pathParam = pathParam.toString();
-  if (pathParam.indexOf('/') === -1) {
-    return encodeURIComponent(pathParam);
-  } else {
-    parts = pathParam.split('/');
-    encParts = [];
-    for (i = 0, len = parts.length; i < len; i++) {
-      encParts.push(encodeURIComponent(parts[i]));
-    }
-    return encParts.join('/');
-  }
+  return encodeURIComponent(pathParam);
 };
 
 var Model = function(name, definition) {
@@ -1721,7 +1707,7 @@ Property.prototype.toString = function() {
   }
 
 
-  var options = ''; 
+  var options = '';
   var isArray = this.schema.type === 'array';
   var type;
 
@@ -1783,11 +1769,11 @@ Property.prototype.toString = function() {
     }
 
     options += optionHtml('Enum', enumString);
-  }     
+  }
 
   if (options.length > 0)
     str = '<span class="propWrap">' + str + '<table class="optionsWrapper"><tr><th colspan="2">' + this.name + '</th></tr>' + options + '</table></span>';
-  
+
   return str;
 };
 
@@ -1882,7 +1868,7 @@ SwaggerClient.prototype.finish = function() {
     this.isBuilt = true;
     this.selfReflect();
     this.success();
-  }  
+  }
 };
 
 SwaggerClient.prototype.buildFrom1_1Spec = function (response) {
@@ -2173,11 +2159,11 @@ SwaggerResource.prototype.addOperations = function (resource_path, ops, consumes
           o.summary,
           o.notes,
           type,
-          responseMessages, 
-          this, 
-          consumes, 
-          produces, 
-          o.authorizations, 
+          responseMessages,
+          this,
+          consumes,
+          produces,
+          o.authorizations,
           o.deprecated);
 
       this.operations[op.nickname] = op;
@@ -2674,15 +2660,15 @@ SwaggerOperation.prototype.urlify = function (args) {
     param = params[i];
     if(param.paramType === 'query') {
       if (queryParams !== '')
-        queryParams += '&';    
+        queryParams += '&';
       if (Array.isArray(param)) {
-        var output = '';   
-        for(j = 0; j < param.length; j++) {    
-          if(j > 0)    
-            output += ',';   
-          output += encodeURIComponent(param[j]);    
-        }    
-        queryParams += encodeURIComponent(param.name) + '=' + output;    
+        var output = '';
+        for(j = 0; j < param.length; j++) {
+          if(j > 0)
+            output += ',';
+          output += encodeURIComponent(param[j]);
+        }
+        queryParams += encodeURIComponent(param.name) + '=' + output;
       }
       else {
         if (typeof args[param.name] !== 'undefined') {
@@ -2751,7 +2737,7 @@ SwaggerOperation.prototype.asCurl = function (args) {
   var results = [];
   var i;
 
-  var headers = SwaggerRequest.prototype.setHeaders(args, {}, this);    
+  var headers = SwaggerRequest.prototype.setHeaders(args, {}, this);
   for(i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
     if(param.paramType && param.paramType === 'header' && args[param.name]) {


### PR DESCRIPTION
Swagger spec version 2.0 only supports level 1 URI templating as described in
http://tools.ietf.org/html/rfc6570#section-3.2.2. This means that the entire
path component (including slashes) needs to be encoded with
encodeURIComponent.