### PR TITLE
Add support for bower.io

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "swagger-js",
+  "version": "2.1.11-M1",
+  "homepage": "http://swagger.io",
+  "authors": [
+    "Tony Tam <fehguy@gmail.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/swagger-api/swagger-js.git"
+  },
+  "description": "swagger.js is a javascript client for use with swaggering APIs.",
+  "main": "lib/swagger-client.js",
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "swagger",
+    "swagger-js",
+    "swaggerjs"
+  ],
+  "license": "apache 2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swagger-client",
   "author": "Tony Tam <fehguy@gmail.com>",
   "description": "swagger.js is a javascript client for use with swaggering APIs.",
-  "version": "2.1.10-M1",
+  "version": "2.1.11-M1",
   "homepage": "http://swagger.io",
   "repository": {
     "type": "git",

--- a/test/mock.js
+++ b/test/mock.js
@@ -16,7 +16,7 @@ exports.petstore = function(arg1, arg2, arg3, arg4) {
     var uri = url.parse(req.url).pathname;
     var filename = path.join('test/spec', uri);
     // for testing redirects
-    
+
     if(filename === 'test/spec/api/redirect') {
       res.writeHead(302, {
         'Location': 'http://localhost:8000/api/pet/1'
@@ -30,12 +30,12 @@ exports.petstore = function(arg1, arg2, arg3, arg4) {
             var body = '';
             req.on('data', function (data) {
               body += data.toString();
+              res.setHeader("Access-Control-Allow-Origin", "*");
+              res.setHeader("Content-Type", "application/json");
+              res.writeHead(200, "application/json");
+              res.write(body);
+              res.end();
             });
-            res.setHeader("Access-Control-Allow-Origin", "*");
-            res.setHeader("Content-Type", "application/json");
-            res.writeHead(200, "application/json");
-            res.write(body);
-            res.end();
             return;
           }
           var accept = req.headers.accept;
@@ -57,7 +57,7 @@ exports.petstore = function(arg1, arg2, arg3, arg4) {
         else if(filename === 'test/compat/spec/api/pet/0') {
           res.writeHead(500);
           res.end();
-          return;          
+          return;
         }
         else {
           res.writeHead(200, {'Content-Type': 'text/plain'});


### PR DESCRIPTION
Added a bower.json File such that it can be installed using bower.

Note: A few things are required to eventually be able to just "bower install swagger-js"

- Add a tag "v2.1.11"

When this is done, swagger-js can be installed with: **bower install swagger-js#v2.1.11-M1**

bower by default downloads the latest not-prerelease version by looking at all tags (currently 2.0.49) and install this version. As there is no bower.json in this version, it will not work properly.

Therefore when doing the next "real"  (not a prerelease according to semver):
- Set the release version in bower.json (e.g. 2.1.20)
- Add a tag with this release (v2.1.20)
- register swagger-js with **bower register swagger-js git@github.com:swagger-api/swagger-js.git**




