### PR TITLE
Update Gulp flow and README to reflect

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,20 +168,23 @@ npm install
 # List all tasks.
 gulp -T
 
-# Run the test suite
+# Run lint (will not fail if there are errors/warnings), tests (without coverage) and builds the browser binaries
+gulp
+
+# Run the test suite (without coverage)
 gulp test
 
-# Build the library (minified and unminified) in the dist folder
+# Build the browser binaries (One for development with source maps and one that is minified and without source maps) in the browser directory
 gulp build
 
-# continuously run the test suite:
+# Continuously run the test suite:
 gulp watch
 
-# run jshint report
+# Run jshint report
 gulp lint
 
-# run a coverage report
-gulp cover
+# Run a coverage report based on running the unit tests
+gulp coverage
 ```
 
 License

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,7 @@ gulp.task('lint', function () {
     .pipe(jshint.reporter('jshint-stylish'));
 });
 
-gulp.task('test', function () {
+gulp.task('coverage', function () {
   return gulp
     .src(paths.sources)
     .pipe(istanbul({includeUntested: true}))
@@ -90,8 +90,14 @@ gulp.task('build', function (cb) {
   });
 });
 
+gulp.task('test', function () {
+  return gulp
+    .src(paths.tests)
+    .pipe(mocha({reporter: 'spec'}));
+});
+
 gulp.task('watch', ['test'], function () {
   gulp.watch(paths.all, ['test']);
 });
 
-gulp.task('default', ['clean', 'lint', 'test']);
+gulp.task('default', ['clean', 'lint', 'test', 'build']);


### PR DESCRIPTION
* Resurrected the `coverage` task
* `test` task no longer runs against instrumented code so that failures
  in the core libraries are easier to diagnose
* The default Gulp task now builds the browser binaries to avoid commits
  without updated binaries