### PR TITLE
httpClient: Fix response headers. This looks like a typo, but the curren...

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -178,7 +178,7 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     var response = {
       url: obj.url,
       method: obj.method,
-      headers: headers
+      headers: res.headers
     };
     var cb;
 

--- a/test/request.js
+++ b/test/request.js
@@ -292,4 +292,18 @@ describe('swagger request functions', function () {
 
     expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d "{\\"id\\":10101}" "http://localhost:8000/v2/api/pet"');
   });
+
+  it('gets an server side 404, and verifies that the content-type in the response is correct, and different than one in the request', function (done) {
+    var petApi = sample.pet;
+    var req = petApi.findPetsByStatus({status: undefined}, {responseContentType: 'application/json'});
+
+    // This test will actually hit the 404 path of mock server, which we use to test the content-type is correct
+    petApi.findPetsByStatus({status: undefined}, function (resp) {
+	expect(resp.headers).toNotBe(undefined);
+	expect(resp.headers['content-type']).toNotBe(undefined);
+	expect(resp.headers['content-type']).toBe('text/plain');
+
+	done();
+    });
+  });
 });


### PR DESCRIPTION
This looks like a typo, but the current response headers are being inhereted from the *request*, not from the response.

This bug prevents swagger-ui from rendering responses appropriately, since the content-type from the server's response is ignored.