### PR TITLE
add index.js to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "LICENSE",
-    "lib"
+    "lib",
+	"index.js"
   ],
   "engines": {
     "node": ">= 0.6.6"


### PR DESCRIPTION
Currently, `require('swagger-client')` doesn't work, because the npm package won't include the index.js file. This PR fixes that.