### PR TITLE
Pass responseObj to converter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -181,7 +181,7 @@ SwaggerClient.prototype.build = function (mock) {
         } else {
           var converter = new SwaggerSpecConverter();
           converter.setDocumentationLocation(self.url);
-          converter.convert(resp.obj, function(spec) {
+          converter.convert(responseObj, function(spec) {
             new Resolver().resolve(spec, self.buildFromSpec, self);
             self.isValid = true;
           });


### PR DESCRIPTION
`responseObj` variable was meant to be used here