### PR TITLE
Add Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "swagger-js",
+  "version": "2.1.0-M2",
+  "main": "browser/swagger-client.min.js",
+  "ignore": [
+    "gulpfile.js",
+    "index.js", 
+    "lib/", 
+    "package.json", 
+    "README.md",
+    "test/",
+    ".*"
+  ],
+  "description": "swagger-client is a javascript client for use with swaggering APIs.",
+  "authors": [ "Tony Tam <fehguy@gmail.com>" ],
+  "license": "apache 2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/swagger-api/swagger-client.git"
+  },
+  "homepage": "http://swagger.io",
+  "moduleType": [ "globals" ],
+  "keywords": [
+    "swagger",
+    "client",
+    "JavaScript",
+    "REST"
+  ]
+}


### PR DESCRIPTION
I am following up on #286 as the modifications are not done yet, but I would need Bower support quite soon.

Also #286 included the wrong mail file. This bower.json downloads the minimum set of files required for browser.