### PR TITLE
Update spec-converter.js to take into account obj.basePath

### DIFF
--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -32,6 +32,11 @@ SwaggerSpecConverter.prototype.convert = function (obj, callback) {
 
   // add security definitions
   this.securityDefinitions(obj, swagger);
+  
+  // take basePath into account
+  if (obj.basePath) {
+    this.setDocumentationLocation(obj.basePath);
+  }
 
   // see if this is a single-file swagger definition
   var isSingleFileSwagger = false;


### PR DESCRIPTION
PR against the proper branch. Issue #346