### PR TITLE
Default value attribute as an array for array type parameters.

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -73,6 +73,10 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     if (param.type === 'array') {
       param.isList = true;
       param.allowMultiple = true;
+      // the enum can be defined at the items level
+      if (param.items && param.items.enum) {
+        param['enum'] = param.items.enum;
+      }
     }
 
     var innerType = this.getType(param);
@@ -92,7 +96,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
 
       for (id = 0; id < param['enum'].length; id++) {
         var value = param['enum'][id];
-        var isDefault = (value === param.default) ? true : false;
+        var isDefault = this.isDefaultArrayItemValue(value, param);
 
         param.allowableValues.values.push(value);
         param.allowableValues.descriptiveValues.push({value : value, isDefault: isDefault});
@@ -186,6 +190,13 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   }
 
   return this;
+};
+
+Operation.prototype.isDefaultArrayItemValue = function(value, param) {
+  if (param.default && Array.isArray(param.default)) {
+    return param.default.indexOf(value) !== -1;
+  }
+  return value === param.default;
 };
 
 Operation.prototype.getType = function (param) {


### PR DESCRIPTION
Hi,

this is related and required by the https://github.com/swagger-api/swagger-ui/pull/1121 PR in a context of default values for the array type parameters.

Additionally - enum definition at array items level as an option. This approach conforms either to Swagger Spec or to JSON Schema, so probably should be handled.

Best,
Waldek
