### PR TITLE
Default value attribute as an array for array type parameters.

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -73,6 +73,10 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     if (param.type === 'array') {
       param.isList = true;
       param.allowMultiple = true;
+      // the enum can be defined at the items level
+      if (param.items && param.items.enum) {
+        param['enum'] = param.items.enum;
+      }
     }
 
     var innerType = this.getType(param);
@@ -92,7 +96,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
 
       for (id = 0; id < param['enum'].length; id++) {
         var value = param['enum'][id];
-        var isDefault = (value === param.default) ? true : false;
+        var isDefault = this.isDefaultArrayItemValue(value, param);
 
         param.allowableValues.values.push(value);
         param.allowableValues.descriptiveValues.push({value : value, isDefault: isDefault});
@@ -186,6 +190,13 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   }
 
   return this;
+};
+
+Operation.prototype.isDefaultArrayItemValue = function(value, param) {
+  if (param.default && Array.isArray(param.default)) {
+    return param.default.indexOf(value) !== -1;
+  }
+  return value === param.default;
 };
 
 Operation.prototype.getType = function (param) {


### PR DESCRIPTION
Hi,

this is related and required by the swagger-api/swagger-ui#1121 PR in a context of default values for the array type parameters.

Additionally - enum definition at array items level as an option. This approach conforms either to Swagger Spec or to JSON Schema, so probably should be handled.

@webron: this is the #354 duplicate, now created against the develop_2.0 branch.
The #354 branch was created from develop_2.0 branch, I've only missed, that the master branch is proposed as default when creating any PR. Sorry for the inconvenience.

Best,
Waldek