### PR TITLE
fix the parse error from the json generated by springfox.

### DIFF
--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -367,7 +367,8 @@ SwaggerSpecConverter.prototype.toJsonSchema = function(source) {
     return 'object';
   }
   var detectedType = (source.type || source.dataType || source.responseClass || '');
-  var lcType = detectedType.toLowerCase();
+
+  var lcType = (detectedType.absoluteType && detectedType.absoluteType.toLowerCase()) || detectedType.toLowerCase();
   var format = (source.format || '').toLowerCase();
 
   if(lcType.indexOf('list[') === 0) {


### PR DESCRIPTION
Hi

When I'm using sprintfox, swagger-ui failed to display my json. So I traced the code and found the difference in the data structre using SwaggerSpecConverter.prototype.toJsonSchema().

I added the fixing code. please review the code and accept this.