### PR TITLE
parseBody handle whitespace in responses

### DIFF
--- a/browser/swagger-client.js
+++ b/browser/swagger-client.js
@@ -18484,7 +18484,7 @@ Response.prototype.setHeaderProperties = function(header){
 
 Response.prototype.parseBody = function(str){
   var parse = request.parse[this.type];
-  return parse && str && jQuery.trim(str).length
+  return parse && str && str.trim().length
     ? parse(str)
     : null;
 };

--- a/browser/swagger-client.js
+++ b/browser/swagger-client.js
@@ -18484,7 +18484,7 @@ Response.prototype.setHeaderProperties = function(header){
 
 Response.prototype.parseBody = function(str){
   var parse = request.parse[this.type];
-  return parse && str && str.trim().length
+  return parse && str && jQuery.trim(str).length
     ? parse(str)
     : null;
 };

--- a/browser/swagger-client.js
+++ b/browser/swagger-client.js
@@ -18484,7 +18484,7 @@ Response.prototype.setHeaderProperties = function(header){
 
 Response.prototype.parseBody = function(str){
   var parse = request.parse[this.type];
-  return parse && str && str.length
+  return parse && str && str.trim().length
     ? parse(str)
     : null;
 };


### PR DESCRIPTION
Hi there,

we're currently investigating using swagger as the primary means to document our APIs at XING. We really like swagger so far and see a lot of potential in it for us. You guys do an awesome job. 

During our tests with swagger we bumped into little things here and there. I just wanted to contribute a little bit back :-)

Our APIs are mostly Rails based and Rails seems to return responses  body containing whitespace on 201s, which results in a parser error. This little patch makes the client a little more robust against that.

I tried to write a test for that as well, but unfortunately I'm not a javascript crack and failed to succeed. I hope that's alright ^^ 