### PR TITLE
ui#1133: add more support for inline schema's

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -37,6 +37,8 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.type = null;
   this.useJQuery = parent.useJQuery;
 
+  this.inlineModels = [];
+
   if (typeof this.deprecated === 'string') {
     switch(this.deprecated.toLowerCase()) {
       case 'true': case 'yes': case '1': {
@@ -242,6 +244,10 @@ Operation.prototype.getType = function (param) {
         return ref;
       }
     } else {
+      // If inline schema, we add it our interal hash -> which gives us it's ID (int)
+      if(schema.type === 'object') {
+        return 'inline#'+ this.addInlineModel(schema);
+      }
       return this.getType(schema);
     }
   }
@@ -250,6 +256,36 @@ Operation.prototype.getType = function (param) {
   } else {
     return str;
   }
+};
+
+/**
+ * adds an inline schema (model) to a hash, where we can ref it later
+ * @param {object} schema a schema
+ * @return {number} the ID of the schema being added, or null
+ **/
+Operation.prototype.addInlineModel = function (schema) {
+  var len = this.inlineModels.length;
+  var model = this.resolveModel(schema, {});
+  if(model) {
+    this.inlineModels.push(model);
+    return len; // to be added to the ID...eg: 'inline#123', where 123 is the ID
+  }
+  return null; // report errors?
+};
+
+/**
+ * gets the internal ref to an inline model
+ * @param {string} inline_str a string reference to an inline model
+ * @return {Model} the model being referenced. Or null
+ **/
+Operation.prototype.getInlineModel = function(inline_str) {
+  if(/inline#/.test(inline_str)) {
+    var id = parseInt(inline_str.split('#')[1],10); //
+    var model = this.inlineModels[id];
+    return model;
+  }
+  // I'm returning null here, should I rather throw an error?
+  return null;
 };
 
 Operation.prototype.resolveModel = function (schema, definitions) {
@@ -263,7 +299,9 @@ Operation.prototype.resolveModel = function (schema, definitions) {
     if (definitions[ref]) {
       return new Model(ref, definitions[ref], this.models);
     }
-  } else if (schema.type === 'object' || _.isUndefined(schema.type)) {
+  // schema must at least be an object to get resolved to an inline Model
+  } else if (schema && typeof schema === 'object' &&
+            (schema.type === 'object' || _.isUndefined(schema.type))) {
     return new Model(undefined, schema, this.models);
   }
 
@@ -293,14 +331,21 @@ Operation.prototype.getModelSignature = function (type, definitions) {
   if (type instanceof Array) {
     listType = true;
     type = type[0];
-  } else if (typeof type === 'undefined') {
-    type = 'undefined';
   }
 
-  if (type === 'string') {
+  // Convert undefined to string of 'undefined'
+  if (typeof type === 'undefined') {
+    type = 'undefined';
     isPrimitive = true;
+
+  } else if (definitions[type]){
+    // a model def exists?
+    type = definitions[type]; /* Model */
+    isPrimitive = false;
+
   } else {
-    isPrimitive = (listType && definitions[listType]) || (definitions[type]) ? false : true;
+    // We default to primitive
+    isPrimitive = true;
   }
 
   if (isPrimitive) {
@@ -311,9 +356,9 @@ Operation.prototype.getModelSignature = function (type, definitions) {
     }
   } else {
     if (listType) {
-      return 'Array[' + definitions[type].getMockSignature() + ']';
+      return 'Array[' + type.getMockSignature() + ']';
     } else {
-      return definitions[type].getMockSignature();
+      return type.getMockSignature();
     }
   }
 };
@@ -481,10 +526,16 @@ Operation.prototype.getBody = function (headers, args, opts) {
  **/
 Operation.prototype.getModelSampleJSON = function (type, models) {
   var isPrimitive, listType, sampleJson;
+  models = models || {};
 
   listType = (type instanceof Array);
-  isPrimitive = models[type] ? false : true;
-  sampleJson = isPrimitive ? void 0 : models[type].createJSONSample();
+
+  if(models[type]) {
+    sampleJson = models[type].createJSONSample();
+  } else if (this.getInlineModel(type)){
+    sampleJson = this.getInlineModel(type).createJSONSample(); // may return null, if type isn't correct
+  }
+
 
   if (sampleJson) {
     sampleJson = listType ? [sampleJson] : sampleJson;

--- a/test/operation.js
+++ b/test/operation.js
@@ -298,6 +298,71 @@ describe('operations', function () {
     expect(op.parameters[0].signature).toEqual('Array[string]');
   });
 
+  it('should get the $ref schema signature, as model name', function () {
+    var parameters = [{
+      name: 'test',
+      in: 'body',
+      schema: {
+        '$ref': '#/definitions/testModel'
+      }
+    }];
+    var definitions = {
+      testModel: {
+        type: 'object',
+        properties: {
+          foo:  {
+            type: 'string'
+          }
+        }
+      }
+    };
+
+    var op = new Operation({}, 'http', 'test', 'get', '/fantastic',
+                           { parameters: parameters }, definitions,{}, new auth.SwaggerAuthorizations());
+
+    expect(op.parameters[0].signature).toEqual('testModel');
+  });
+
+  it('should get the inline schema signature, as "inline#0"', function () {
+    var parameters = [{
+      name: 'test',
+      in: 'body',
+      schema: {
+        type: 'object',
+        properties: { foo:  { type: 'string' }
+        }
+      }
+    }];
+
+    var op = new Operation({}, 'http', 'test', 'get', '/fantastic',
+                           { parameters: parameters }, {},{}, new auth.SwaggerAuthorizations());
+
+    expect(op.parameters[0].signature).toEqual('inline#0');
+  });
+
+  // only testing for swagger-ui#1133...pending more logic clarification
+  it('should return some object like string for inline objects.',function() {
+
+    var parameters = [{
+      name: 'test',
+      in: 'body',
+      schema: {
+        type: 'object',
+        properties: {
+          josh: {
+            type: 'string'
+          }
+        }
+      }
+    }];
+
+    var op = new Operation({}, 'http', 'test', 'get', '/fantastic',
+                           { parameters: parameters }, {},{}, new auth.SwaggerAuthorizations());
+    var param = op.parameters[0];
+
+    expect(param.sampleJSON).toEqual('{\n  \"josh\": \"string\"\n}');
+  });
+
   it('should get a date array signature', function () {
     var parameters = [
       { in: 'query', name: 'year', type: 'array', items: {type: 'string', format: 'date-time'} }

--- a/test/types.js
+++ b/test/types.js
@@ -12,4 +12,34 @@ describe('type conversions', function () {
 
     expect(type).toBe('integer');
   });
+
+  it('should return an interal ref, when inline schema',function() {
+
+    var op = new Operation();
+    var type = op.getType({
+      schema: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        }
+      }
+    });
+
+    var type1 = op.getType({
+      schema: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string'
+          }
+        }
+      }
+    });
+
+    expect(type).toBe('inline#0');
+    expect(type1).toBe('inline#1');
+
+  });
 });


### PR DESCRIPTION
Fixes swagger-api/swagger-ui#1133.

operation#getType returns a string, which was fine for everything but
inline models, which until now couldn't be referenced.

opertation#getType now returns 'inline#123' for inline models, where 123
is the index of the inline model.
I've put in an array, operation#inlineModels, that keeps track of
inline models added via operation#addInlineModel.
To de-reference inline models, use operation#getInlineModel, passing it
the 'inline#123' string

operation#getSampleModelJson, uses the above.