### PR TITLE
Correctly use useJQuery from Client in Operation

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -579,7 +579,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     url: url,
     method: this.method.toUpperCase(),
     body: body,
-    useJQuery: this.useJQuery,
+    useJQuery: opts.useJQuery,
     headers: headers,
     on: {
       response: function (response) {

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -539,7 +539,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   success = (success || helpers.log);
   error = (error || helpers.log);
 
-  if (this.useJQuery) {
+  if (typeof opts.useJQuery === 'undefined') {
     opts.useJQuery = this.useJQuery;
   }
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -141,7 +141,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     response = responses['default'];
     defaultResponseCode = 'default';
   }
-  
+
   if (response && response.schema) {
     var resolvedModel = this.resolveModel(response.schema, definitions);
     var successResponse;
@@ -150,7 +150,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
 
     if (resolvedModel) {
       this.successResponse = {};
-      successResponse = this.successResponse[defaultResponseCode] = resolvedModel; 
+      successResponse = this.successResponse[defaultResponseCode] = resolvedModel;
     } else if (!response.schema.type || response.schema.type === 'object' || response.schema.type === 'array') {
       // Inline model
       this.successResponse = {};
@@ -539,8 +539,8 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   success = (success || helpers.log);
   error = (error || helpers.log);
 
-  if (opts.useJQuery) {
-    this.useJQuery = opts.useJQuery;
+  if (this.useJQuery) {
+    opts.useJQuery = this.useJQuery;
   }
 
   var missingParams = this.getMissingParams(args);
@@ -762,7 +762,7 @@ Operation.prototype.encodeQueryCollection = function (type, name, value) {
       separator = '\\t';
     } else if (type === 'pipes') {
       separator = '|';
-    } else if (type === 'brackets') { 
+    } else if (type === 'brackets') {
       for (i = 0; i < value.length; i++) {
         if (i !== 0) {
           encoded += '&';


### PR DESCRIPTION
When creating a SwaggerClient with `useJQuery: true`, the Operations each inherit the `useJQuery` value. However, on execution, instead of using the value of `useJQuery` it looks for the value to be passed in via the Operation's options. Furthermore, it takes the value passed in at sets that on the Operation, having the side effect of overriding the correct value for the Operation's `useJQuery` setting.

This pull has the `Operation.prototype.execute` use the `useJQuery` setting inherited from the SwaggerClient by default, but if a value for `useJQuery` is passed in the Operation.prototype.execute parameters, it uses that value instead, but only for that single method execution.