### PR TITLE
Update git repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "http://swagger.io",
   "repository": {
     "type": "git",
-    "url": "git://github.com/swagger-api/swagger-client.git"
+    "url": "https://github.com/swagger-api/swagger-js.git"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This updates the project GitHub URL. Link on https://www.npmjs.com/package/swagger-client still points to https://github.com/swagger-api/swagger-client, how can I help to fix it?