### PR TITLE
Fix for #409: Top level example is included in model

### DIFF
--- a/lib/types/model.js
+++ b/lib/types/model.js
@@ -403,7 +403,7 @@ Model.prototype.createJSONSample = Model.prototype.getSampleValue = function (mo
     if (_.isString(this.definition.example)) {
       this.definition.example = JSON.parse(this.definition.example);
     }
-  } else {
+  } else if (!this.definition.example) {
     this.definition.example = this.examples;
   }
 

--- a/test/models.js
+++ b/test/models.js
@@ -26,6 +26,24 @@ describe('models', function () {
     expect(model.createJSONSample()).toEqual({ id: 0, name: 'string' });
   });
 
+  it('should use the JSON sample on the object level', function () {
+    var definition = {
+      example: '// Manual example',
+      properties: {
+        id: {
+          type: 'integer',
+          format: 'int64'
+        },
+        name: {
+          type: 'string'
+        }
+      }
+    };
+    var model = new Model('Tag', definition);
+
+    expect(model.createJSONSample()).toEqual('// Manual example');
+  });
+
   it('should verify the JSON sample for a primitive array', function () {
     var definition = {
       type: 'array',


### PR DESCRIPTION
Examples on top-level definitions are now included in the model.

See issue #409 