### PR TITLE
Test harness for running browser tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ language: node_js
 node_js:
   - '0.10'
 script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - npm install
   - mocha

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ var basename = 'swagger-client';
 var paths = {
   sources: ['index.js', 'lib/**/*.js'],
   tests: ['test/*.js', 'test/compat/*.js', '!test/browser/*.js'],
+  browserTests: ['test/browser/*.js'],
   dist: 'browser'
 };
 
@@ -98,6 +99,20 @@ gulp.task('test', function () {
   return gulp
     .src(paths.tests)
     .pipe(mocha({reporter: 'spec'}));
+});
+
+gulp.task('browsertest', function () {
+  process.env.NODE_ENV = 'test';
+
+  return gulp
+    .src(paths.browserTests)
+    .pipe(mocha({reporter: 'spec'}))
+    .once('error', function () {
+      process.exit(1);
+    })
+    .once('end', function () {
+      process.exit();
+    });;
 });
 
 gulp.task('watch', ['test'], function () {

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
   "scripts": {
     "build": "gulp build",
     "dev": "gulp watch",
-    "test": "gulp test"
+    "test": "gulp test",
+    "browsertest": "gulp browsertest"
   },
   "files": [
     "LICENSE",
     "lib",
     "browser",
-	  "index.js"
+    "index.js"
   ],
   "engines": {
     "node": ">= 0.6.6"
@@ -46,8 +47,10 @@
     "gulp-istanbul": "^0.5.0",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
+    "http-server": "git://github.com/nodeapps/http-server.git",
     "jshint-stylish": "^1.0.1",
     "mocha": "^1.21.3",
+    "selenium-webdriver": "^2.45.1",
     "uglifyify": "^3.0.1",
     "unit.js": "1.1.2",
     "vinyl-source-stream": "^1.1.0"

--- a/test/browser/driver.js
+++ b/test/browser/driver.js
@@ -1,0 +1,9 @@
+/*
+ * Web driver manager
+*/
+'use strict';
+
+var webdriver = require('selenium-webdriver');
+var driver = new webdriver.Builder().withCapabilities(webdriver.Capabilities.firefox()).build();
+
+module.exports = driver;

--- a/test/browser/servers.js
+++ b/test/browser/servers.js
@@ -1,0 +1,35 @@
+/*
+ * Swagger UI and Specs Servers
+*/
+'use strict';
+
+var path = require('path');
+var createServer = require('http-server').createServer;
+var dist = path.join(__dirname, '..', '..', 'browser');
+var specs = path.join(__dirname, '..', '..', 'test', 'spec');
+var DOCS_PORT = 8080;
+var SPEC_SERVER_PORT = 8081;
+var driver = require('./driver');
+var swaggerBrowserClient;
+var specServer;
+
+module.exports.start = function (specsLocation, done) {
+  swaggerBrowserClient = createServer({ root: dist, cors: true });
+  specServer = createServer({ root: specs, cors: true });
+
+  swaggerBrowserClient.listen(DOCS_PORT);
+  specServer.listen(SPEC_SERVER_PORT);
+
+  var swaggerSpecLocation = encodeURIComponent('http://localhost:' + SPEC_SERVER_PORT + specsLocation);
+  var url = 'http://localhost:' + DOCS_PORT + '/index.html?url=' + swaggerSpecLocation;
+
+  setTimeout(function(){
+    driver.get(url);
+    done();
+  }, process.env.TRAVIS ? 20000 : 3000);
+};
+
+module.exports.close = function() {
+  swaggerBrowserClient.close();
+  specServer.close();
+};

--- a/test/browser/test-v2.js
+++ b/test/browser/test-v2.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var expect = require('expect');
+var driver = require('./driver');
+var servers = require('./servers');
+
+describe('swagger-js browser tests', function () {
+  this.timeout(10 * 1000);
+
+  before(function (done) {
+    this.timeout(25 * 1000);
+    servers.start('/v2/petstore.json', done);
+  });
+
+  afterEach(function(){
+    it('should not have any console errors', function (done) {
+      driver.manage().logs().get('browser').then(function(browserLogs) {
+        var errors = [];
+        browserLogs.forEach(function(log){
+          // 900 and above is "error" level. Console should not have any errors
+          if (log.level.value > 900) {
+            console.log('browser error message:', log.message); errors.push(log);
+          }
+        });
+        expect(errors).to.be.empty;
+        done();
+      });
+    });
+  });
+
+  it('should create body when file parameter present', function (done) {
+    driver.manage().timeouts().setScriptTimeout(5000);
+    driver.executeAsyncScript(function() {
+      var callback = arguments[arguments.length - 1];
+      var client = new SwaggerClient({
+        url: 'http://localhost:8081/v2/petstore.json',
+        useJQuery: true,
+        success: function() {
+          var req = client.pet.uploadFile({petId: 1, file: new Blob(['Hello World'], {type: 'text/plain'})}, {mock: true});
+          callback(req)
+        },
+        failure: function() {
+          throw 'unable to create SwaggerClient';
+        }
+      });
+    }).then(function(req) {
+      expect(req.useJQuery).toBe(true);
+      expect(req.method).toBe('POST');
+      expect(req.headers['Content-Type']).toBe('multipart/form-data');
+      expect(req.body).toNotBe(null);
+      expect(req.body).toNotBe(undefined);
+      expect(req.body.type).toBe('formData');
+      done();
+    }, function(err) {
+      throw err;
+    });
+  });
+
+  after(function() {
+    servers.close();
+  });
+});

--- a/test/spec/v2/petstore.json
+++ b/test/spec/v2/petstore.json
@@ -399,6 +399,62 @@
         ]
       }
     },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "formData",
+            "description": "Additional data to pass to server",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file to upload",
+            "required": false,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/ApiResponse"
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
     "/store/inventory": {
       "get": {
         "tags": [


### PR DESCRIPTION
This pull should resolve #383. The test harness here borrows from the swagger-api/swagger-ui browser test harness. 

Currently, browser tests are wired separately from the non-browser tests, based on what I saw in the gulpfile (line 25, `paths.tests` explicitly ignores `test/browser/*.js`). To run browser tests, issue either `npm run browsertest` or `gulp browsertest`.