### PR TITLE
Don't warn when produces is "*/*".

### DIFF
--- a/browser/swagger-client.js
+++ b/browser/swagger-client.js
@@ -3129,7 +3129,7 @@ Operation.prototype.setContentTypes = function (args, opts) {
   }
 
   if (accepts && this.produces) {
-    if (this.produces.indexOf(accepts) === -1) {
+    if (this.produces.indexOf(accepts) === -1 && this.operation.produces != '*/*') {
       helpers.log('server can\'t produce ' + accepts);
     }
   }


### PR DESCRIPTION
I'm sure this is a very naive fix, but I just wanted to throw that out there unless someone has any better ideas