### PR TITLE
specify host in options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -258,9 +258,9 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
     } else {
       this.scheme = this.schemes[0];
     }
-
+    
     if (typeof this.host === 'undefined' || this.host === '') {
-      this.host = location.host;
+      this.host = this.options.host || location.host;
 
       if (location.port) {
         this.host = this.host + ':' + location.port;


### PR DESCRIPTION
allow swagger-ui to specify host url. This is useful when the rest api target host name is a) not known in advance and b) is not the machine hosting swagger