### PR TITLE
Set operation.schemes to the value of 'schemes' if set

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -37,7 +37,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.path = (path || errors.push('Operation ' + this.nickname + ' is missing path.'));
   this.responses = (args.responses || {});
   this.scheme = scheme || parent.scheme || 'http';
-  this.schemes = parent.schemes;
+  this.schemes = args.schemes || parent.schemes;
   this.security = args.security;
   this.summary = args.summary || '';
   this.type = null;


### PR DESCRIPTION
This is based on my reading of the 2.0 spec: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operationObject says that the `schemes` in the operation override any `schemes` in the parent. 