### PR TITLE
Apply global security requirements

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -228,6 +228,7 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
   this.produces = response.produces;
   this.schemes = response.schemes || [];
   this.securityDefinitions = response.securityDefinitions;
+  this.security = response.security;
   this.title = response.title || '';
 
   if (response.externalDocs) {

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -19,7 +19,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     this.client = parent.options.client || null;
     this.responseInterceptor = parent.options.responseInterceptor || null;
   }
-  this.authorizations = args.security;
+  this.authorizations = args.security || parent.security;
   this.basePath = parent.basePath || '/';
   this.clientAuthorizations = clientAuthorizations;
   this.consumes = args.consumes || parent.consumes || ['application/json'];
@@ -38,7 +38,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.responses = (args.responses || {});
   this.scheme = scheme || parent.scheme || 'http';
   this.schemes = parent.schemes;
-  this.security = args.security;
+  this.security = args.security || parent.security;
   this.summary = args.summary || '';
   this.type = null;
   this.useJQuery = parent.useJQuery;

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -694,7 +694,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     }
   };
 
-  this.clientAuthorizations.apply(obj, this.operation.security);
+  this.clientAuthorizations.apply(obj, this.security);
   if (opts.mock === true) {
     return obj;
   } else {


### PR DESCRIPTION
Based on https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#securityRequirementObject and the global `security` element I read this as that I should be able to specify global security requirements via the global `security` element, and that a single operation can (but doesn't have to) modify the requirements by having a `security` element.

There is a bit of confusion (for me ...) related to the "AND" (local) vs "OR" (global) interpretation of multiple security requirements, so I might be missing something here.

The idea in any case would be to define APIs that always require authentication/authorization, without having to repeat the same block of `security` requirements for each and every operation.

Please note that I think 02a799f and 1fddfcd should be applied in any case :)