### PR TITLE
Fixed #504: The `asCurl` method doesn't allow to set content type for response and request

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -807,8 +807,14 @@ Operation.prototype.matchesAccept = function(accepts) {
   return this.produces.indexOf(accepts) !== -1 || this.produces.indexOf('*/*') !== -1;
 };
 
-Operation.prototype.asCurl = function (args) {
-  var obj = this.execute(args, {mock: true});
+Operation.prototype.asCurl = function (args1, args2) {
+  var opts = {mock: true};
+  if (typeof args2 === 'object') {
+    for (var argKey in args2) {
+      opts[argKey] = args2[argKey];
+    }
+  }
+  var obj = this.execute(args1, opts);
 
   this.clientAuthorizations.apply(obj);
 

--- a/test/help.js
+++ b/test/help.js
@@ -60,4 +60,14 @@ describe('help options', function () {
 
     expect(curl).toBe('curl -X GET --header "Accept: application/json" --header "name: tony" --header "age: 42" "http://localhost/path"');
   });
+
+  it('prints a curl statement with custom content-type', function () {
+    var op = new Operation({}, 'http', 'test', 'get', '/path', {summary: 'test operation'}, {}, {},
+        new auth.SwaggerAuthorizations());
+    var curl = op.asCurl({}, {
+      responseContentType: 'application/xml'
+    });
+
+    expect(curl).toBe('curl -X GET --header "Accept: application/xml" "http://localhost/path"');
+  });
 });


### PR DESCRIPTION
Appends operations parameters to the `asCurl` method