### PR TITLE
fix allOf support

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -31,6 +31,7 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
     }
 
     if(definition.allOf) {
+      definition['x-resolved-from'] = [ '#/definitions/' + name ];
       var allOf = definition.allOf;
       // the refs go first
       allOf.sort(function(a, b) {
@@ -474,11 +475,18 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
   var name;
   for(var key in obj) {
     var item = obj[key];
+    if(typeof item === 'object') {
+      this.resolveAllOf(spec, item, depth + 1);
+    }
     if(item && typeof item.allOf !== 'undefined') {
       var allOf = item.allOf;
       if(Array.isArray(allOf)) {
         var output = {};
         output['x-composed'] = true;
+        if (typeof item['x-resolved-from'] !== 'undefined') {
+          output['x-resolved-from'] = item['x-resolved-from'];
+        }
+        output.properties = {};
         for(var i = 0; i < allOf.length; i++) {
           var component = allOf[i];
           var source = 'self';
@@ -488,7 +496,7 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
 
           for(var part in component) {
             if(!output.hasOwnProperty(part)) {
-              output[part] = component[part];
+              output[part] = JSON.parse(JSON.stringify(component[part]));
               if(part === 'properties') {
                 for(name in output[part]) {
                   output[part][name]['x-resolved-from'] = source;
@@ -499,8 +507,12 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
               if(part === 'properties') {
                 var properties = component[part];
                 for(name in properties) {
-                  output.properties[name] = properties[name];
-                  output.properties[name]['x-resolved-from'] = source;
+                  output.properties[name] = JSON.parse(JSON.stringify(properties[name]));
+                  var resolvedFrom = properties[name]['x-resolved-from'];
+                  if (typeof resolvedFrom === 'undefined' || resolvedFrom === 'self') {
+                    resolvedFrom = source;
+                  }
+                  output.properties[name]['x-resolved-from'] = resolvedFrom;
                 }
               }
               else if(part === 'required') {
@@ -525,9 +537,6 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
         }
         obj[key] = output;
       }
-    }
-    if(typeof item === 'object') {
-      this.resolveAllOf(spec, item, depth + 1);
     }
   }
 };

--- a/test/composition.js
+++ b/test/composition.js
@@ -70,9 +70,9 @@ describe('swagger resolver', function () {
         Monster: {
           allOf : [
             {
-              $ref: '#/definitions/Animal'
-            }, {
               $ref: '#/definitions/Ghoul'
+            }, {
+              $ref: '#/definitions/Pet'
             }, {
               properties: {
                 hasScales: {
@@ -102,12 +102,10 @@ describe('swagger resolver', function () {
       expect(properties.name['x-resolved-from']).toBe('#/definitions/Animal');
       test.object(properties.type);
       expect(properties.type['x-resolved-from']).toBe('#/definitions/Animal');
-      test.object(properties.firstName);
-      expect(properties.firstName['x-resolved-from']).toBe('#/definitions/Animal');
-      test.object(properties.lastName);
-      expect(properties.lastName['x-resolved-from']).toBe('#/definitions/Animal');
+      test.undefined(properties.firstName);
+      test.undefined(properties.lastName);
       test.object(properties.isDomestic);
-      expect(properties.isDomestic['x-resolved-from']).toBe('#/definitions/Animal');
+      expect(properties.isDomestic['x-resolved-from']).toBe('#/definitions/Pet');
       test.object(properties.fangs);
       expect(properties.fangs['x-resolved-from']).toBe('#/definitions/Ghoul');
       test.object(properties.hasScales);

--- a/test/composition.js
+++ b/test/composition.js
@@ -110,6 +110,7 @@ describe('swagger resolver', function () {
       expect(properties.fangs['x-resolved-from']).toBe('#/definitions/Ghoul');
       test.object(properties.hasScales);
       expect(properties.hasScales['x-resolved-from']).toBe('self');
+      test.undefined(spec.definitions.Animal.properties.firstName);
       done();
     });
   });


### PR DESCRIPTION
Fix `allOf` to work as intended.

The example JSON we have:

```js
"definitions": {
  "Parent": {
    "properties": {
      "hey": {
        "type": "string"
      }
    }
  },
  "Child": {
    "allOf": [
      {
        "$ref": "#/definitions/Parent"
      },
      {
        "properties": {
          "there": {
            "type": "string"
          }
        }
      }
    ]
  },
  "Grandchild": {
    "allOf": [
      {
        "$ref": "#/definitions/Child"
      },
      {
        "properties": {
          "bob": {
            "type": "string"
          }
        }
      }
    ]
  }
}
```

And in the Swagger UI now the model looks like (as should be):

```js
{
  "grandchild": {
    "hey": "string",
    "there": "string",
    "bob": "string"
  },
  "child": {
    "hey": "string",
    "there": "string"
  },
  "parent": {
    "hey": "string"
  }
}
```

instead of the previous (incorrect) result:

```js
{
  "grandchild": {
    "bob": "string"
  },
  "child": {
    "hey": "string",
    "there": "string"
  },
  "parent": {
    "hey": "string",
    "there": "string"
  }
}
```