### PR TITLE
browser/swagger-client.js: Throw errors for null types

### DIFF
--- a/browser/swagger-client.js
+++ b/browser/swagger-client.js
@@ -1493,6 +1493,9 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
   var name;
   for(var key in obj) {
     var item = obj[key];
+    if(item === null) {
+      throw new TypeError("Swagger 2.0 does not support null types (" + obj + ").  See https://github.com/swagger-api/swagger-spec/issues/229.")
+    }
     if(item && typeof item.allOf !== 'undefined') {
       var allOf = item.allOf;
       if(Array.isArray(allOf)) {


### PR DESCRIPTION
Avoid `too much recursion` errors with properties like:

    "species": {
      "type": "string",
      "enum": [
        null,
        "cat",
        "dog"
      ]
    }

The [JSON Schema spec says for enums][1]:

> Elements in the array MAY be of any type, including null.

But they [aren't supported by Swagger 2.0][2], because [null isn't one
of Swagger 2's types][3].  This commit gives a more obvious hint about
that.  It would be nice to have [clarification in the spec][2] so we
could link to tidier docs than the GitHub issue too.

It would be nice if I could point to line numbers (or the chain of
keys?) to find the broken entry in the parsed spec, but it doesn't
seem like that information is available in `resolveAllOf` and I'm not
clear enough on the larger picture here to know where that would plug
in.

Anyway, this PR should help avoid futher confusion on this issue in
the 2.0 series.

[1]: http://json-schema.org/latest/json-schema-validation.html#anchor77
[2]: https://github.com/swagger-api/swagger-spec/issues/229#issuecomment-115379297
[3]: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types