### PR TITLE
Fix inability to apply multiple apiKey authentications

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -38,7 +38,7 @@ SwaggerAuthorizations.prototype.remove = function (name) {
 };
 
 SwaggerAuthorizations.prototype.apply = function (obj, securities) {
-  var status = null;
+  var status = true;
   var applyAll = !securities;
   var flattenedSecurities = [];
 
@@ -58,7 +58,8 @@ SwaggerAuthorizations.prototype.apply = function (obj, securities) {
 
   _.each(this.authz, function (auth, authName) {
     if(applyAll || _.includes(flattenedSecurities, authName)) {
-      status = status || !!auth.apply(obj); // logical ORs regarding status
+      var newStatus = auth.apply(obj);
+      status = status && !!newStatus; // logical ORs regarding status
     }
   });
 


### PR DESCRIPTION
If you have several apiKey authentications defined (like key+secret),
they were not applied both to the Request, because of
`status = status || !!auth.apply(obj);`

Once status becomes `true` after applying the first security rule, the
seconds (and all next ones) are ignored, as logic expression was
errorneous.

Fixing it, by changing OR into AND, as we want to return `false` if ANY
of the auths were failing, second of all making `auth.apply(obj)` be
executed always, by extracting the statement into separate line.