### PR TITLE
Fix swagger-api/swagger-ui#1435

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -753,7 +753,8 @@ Operation.prototype.setContentTypes = function (args, opts) {
   }
 
   // if there's a body, need to set the consumes header via requestContentType
-  if (this.method === 'post' || this.method === 'put' || this.method === 'patch' || this.method === 'delete') {
+  if (this.method === 'post' || this.method === 'put' || this.method === 'patch' ||
+      (this.method === 'delete' && body) ) {
     if (opts.requestContentType) {
       consumes = opts.requestContentType;
     }

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -753,7 +753,7 @@ Operation.prototype.setContentTypes = function (args, opts) {
   }
 
   // if there's a body, need to set the consumes header via requestContentType
-  if (this.method === 'post' || this.method === 'put' || this.method === 'patch') {
+  if (this.method === 'post' || this.method === 'put' || this.method === 'patch' || this.method === 'delete') {
     if (opts.requestContentType) {
       consumes = opts.requestContentType;
     }

--- a/test/request.js
+++ b/test/request.js
@@ -158,15 +158,14 @@ describe('swagger request functions', function () {
 
     expect(req.method).toBe('DELETE');
     expect(req.headers.Accept).toBe('application/json');
-    expect(req.headers['Content-Type']).toBe('application/json');
+    expect(req.headers['Content-Type']).toBe(undefined);
     expect(req.url).toBe('http://localhost:8000/v2/api/pet/100');
     expect(req.body).toBe(undefined);
   });
 
-  it.skip('generate a DELETE request with body', function () {
+  it('generate a DELETE request with body', function () {
     var petApi = sample.pet;
-    // TODO: deletePet returns 'undefined' when body supplied; Help needed [@sublimeye]
-    var req = petApi.deletePet({body: {petId: 100}}, {mock: true});
+    var req = petApi.deletePet({petId: 100, body: {id: 100, name: 'gorilla'}}, {mock: true});
 
     test.object(req);
 
@@ -175,7 +174,6 @@ describe('swagger request functions', function () {
     expect(req.headers['Content-Type']).toBe('application/json');
     expect(req.url).toBe('http://localhost:8000/v2/api/pet/100');
     expect(req.body).toEqual({ id: 100, name: 'gorilla' });
-    expect(req.body).toEqual({petId: 100});
   });
 
   it('escape an operation id', function () {

--- a/test/request.js
+++ b/test/request.js
@@ -150,7 +150,7 @@ describe('swagger request functions', function () {
     expect(req.body).toEqual('name=monster&status=miserable%20dog');
   });
 
-  it('generate a DELETE request', function () {
+  it('generate a DELETE request with no body', function () {
     var petApi = sample.pet;
     var req = petApi.deletePet({petId: 100}, {mock: true});
 
@@ -158,9 +158,24 @@ describe('swagger request functions', function () {
 
     expect(req.method).toBe('DELETE');
     expect(req.headers.Accept).toBe('application/json');
-    expect(req.headers['Content-Type']).toBe(undefined);
+    expect(req.headers['Content-Type']).toBe('application/json');
     expect(req.url).toBe('http://localhost:8000/v2/api/pet/100');
     expect(req.body).toBe(undefined);
+  });
+
+  it.skip('generate a DELETE request with body', function () {
+    var petApi = sample.pet;
+    // TODO: deletePet returns 'undefined' when body supplied; Help needed [@sublimeye]
+    var req = petApi.deletePet({body: {petId: 100}}, {mock: true});
+
+    test.object(req);
+
+    expect(req.method).toBe('DELETE');
+    expect(req.headers.Accept).toBe('application/json');
+    expect(req.headers['Content-Type']).toBe('application/json');
+    expect(req.url).toBe('http://localhost:8000/v2/api/pet/100');
+    expect(req.body).toEqual({ id: 100, name: 'gorilla' });
+    expect(req.body).toEqual({petId: 100});
   });
 
   it('escape an operation id', function () {

--- a/test/spec/v2/petstore.json
+++ b/test/spec/v2/petstore.json
@@ -382,6 +382,15 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Pet extra params that needs to be deleted",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
Fix for an issue reported in swagger-ui project: (swagger DELETE requests changing to incorrect content type) https://github.com/swagger-api/swagger-ui/issues/1435

The code contains a skipped test for DELETE method with a body ( I'm not sure what is the best way to handle this... I'd need to research the structure of json/schemas and update mocks, I'm afraid it might take too long without a hint)

// This pull request is a part of a sample task by @webron.