### PR TITLE
Ability to choose scheme on client init..

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -138,6 +138,10 @@ SwaggerClient.prototype.initialize = function (url, options) {
   this.progress = options.progress || function () {};
   this.spec = _.cloneDeep(options.spec); // Clone so we do not alter the provided document
 
+  if (options.scheme) {
+    this.scheme = options.scheme;
+  }
+
   if (typeof options.success === 'function') {
     this.ready = true;
     this.build();
@@ -260,9 +264,9 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
 
   if (typeof this.url === 'string') {
     location = this.parseUri(this.url);
-    if (typeof this.schemes === 'undefined' || this.schemes.length === 0) {
+    if (typeof this.scheme === 'undefined' && typeof this.schemes === 'undefined' || this.schemes.length === 0) {
       this.scheme = location.scheme || 'http';
-    } else {
+    } else if (typeof this.scheme === 'undefined') {
       this.scheme = this.schemes[0];
     }
 
@@ -274,7 +278,7 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
       }
     }
   }
-  else {
+  else if (typeof this.scheme === 'undefined') {
     if (typeof this.schemes === 'undefined' || this.schemes.length === 0) {
       this.scheme = 'http';
     }


### PR DESCRIPTION
When an API supports multiple schemes like below, this client arbitrarily picks the first entry.  This PR adds the ability for the client to be initialized with a specific scheme.

```
"schemes": [
"http",
"https"
]
```

To initialize with a specific scheme, do this:

```
var client = require('swagger-client');

var swagger = new client({
  url: 'http://petstore.swagger.io/v2/swagger.json',
  scheme: 'https',
  success: function() {
    // do something
  }
});```