### PR TITLE
Don't throw when user defines a failure function.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -134,7 +134,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
   this.options = options || {};
 
   this.supportedSubmitMethods = options.supportedSubmitMethods || [];
-  this.failure = options.failure || function () {};
+  this.failure = options.failure || function (err) { throw err; };
   this.progress = options.progress || function () {};
   this.spec = _.cloneDeep(options.spec); // Clone so we do not alter the provided document
 
@@ -507,6 +507,4 @@ SwaggerClient.prototype.setBasePath = function (basePath) {
 
 SwaggerClient.prototype.fail = function (message) {
   this.failure(message);
-
-  throw message;
 };


### PR DESCRIPTION
Instead of calling failure and then throwing unconditionally, default to simply throwing, but allow the user to override this behavior in the provided callback.

This is currently broken AFAICT - the throw in SwaggerClient.prototype.fail() can't be caught. If I'm wrong, please let me know.

Not really sure how to test this because I can't catch the failure.