### PR TITLE
Added allOf support to schemaToJSON

### DIFF
--- a/lib/schema-markup.js
+++ b/lib/schema-markup.js
@@ -156,14 +156,27 @@ function schemaToJSON(schema, models, modelsToIgnore, modelPropertyMacro) {
     } else if (type === 'object') {
       output = {};
 
-      _.forEach(schema.properties, function (property, name) {
-        var cProperty = _.cloneDeep(property);
+      if (schema.properties) {
+        _.forEach(schema.properties, function (property, name) {
+          var cProperty = _.cloneDeep(property);
 
-        // Allow macro to set the default value
-        cProperty.default = modelPropertyMacro(property);
+          // Allow macro to set the default value
+          cProperty.default = modelPropertyMacro(property);
 
-        output[name] = schemaToJSON(cProperty, models, modelsToIgnore, modelPropertyMacro);
-      });
+          output[name] = schemaToJSON(cProperty, models, modelsToIgnore, modelPropertyMacro);
+        });
+      } else if (schema.allOf) {
+        _.forEach(schema.allOf, function (property) {
+          var cProperty = _.cloneDeep(property);
+
+          // Allow macro to set the default value
+          cProperty.default = modelPropertyMacro(property);
+          var compositeSchema = schemaToJSON(cProperty, models, modelsToIgnore, modelPropertyMacro);
+          _.forEach(compositeSchema, function (property, name) {
+              output[name] = property;
+          });
+        });
+      }
     } else if (type === 'array') {
       output = [];
 

--- a/test/responses.js
+++ b/test/responses.js
@@ -11,6 +11,7 @@ var SwaggerClient = require('..');
 var MonsterResponse = { schema: { $ref: '#/definitions/Monster' }};
 var StringResponse = { schema: { type: 'string'} };
 var BasicResponseModel = { schema: { $ref: '#/definitions/ResponseModel'}};
+var AllOfResponseModel = { schema: { allOf: [{ $ref: '#/definitions/Monster'}, { $ref: '#/definitions/ResponseModel'}]}};
 var MonsterModel = {
   properties: {
     id: { type: 'integer', format: 'int64' },
@@ -211,5 +212,27 @@ describe('response types', function () {
         done();
       }
     });
+  });
+
+  it('should return a composite JSON sample for a definition including allOf', function () {
+    var responses = {
+      200:       AllOfResponseModel
+    };
+    var definitions = {
+      Monster: MonsterModel,
+      ResponseModel: ResponseModel,
+      AllOfResponseModel: AllOfResponseModel
+    };
+    var op = new Operation(
+      {},
+      'http',
+      'operationId',
+      'get',
+      '/path',
+      {responses: responses}, // args
+      definitions); // definitions
+
+    expect(typeof op.successResponse).toBe('object');
+    expect(op.successResponse['200'].createJSONSample()).toEqual({ id: 0, name: 'string', code: 0, message: 'string' });
   });
 });


### PR DESCRIPTION
Currently Swagger UI outputs `{}` for a model defined with `allOf`. I dug into it and identified the underlying issue as it not being supported by the `schemaToJSON` method in Swagger JS.

This PR adds support for `allOf` so the sample JSON rendered by Swagger UI is a composite of the objects embedded under `allOf`. The Swagger Editor, however, appears to display the components still embedded in the `allOf` container. While my current implementation is best suited for my needs, I'm happy to adapt it if I've misinterpreted it.

I've seen there are a few different issues open against `allOf`support, but I wasn't sure which was the best one to relate this PR to.