### PR TITLE
responses containing references to definitions were not …

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,8 +39,8 @@ var simpleRef = module.exports.simpleRef = function (name) {
     return null;
   }
 
-  if (name.indexOf('#/definitions/') === 0) {
-    return name.substring('#/definitions/'.length);
+  if (name.indexOf('#/definitions/') !== -1) {
+    return name.replace(/^.*#\/definitions\//, '');
   } else {
     return name;
   }

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -318,8 +318,8 @@ Operation.prototype.resolveModel = function (schema, definitions) {
   if (typeof schema.$ref !== 'undefined') {
     var ref = schema.$ref;
 
-    if (ref.indexOf('#/definitions/') === 0) {
-      ref = ref.substring('#/definitions/'.length);
+    if (ref.indexOf('#/definitions/') !== -1) {
+      ref = ref.replace(/^.*#\/definitions\//, '');
     }
 
     if (definitions[ref]) {


### PR DESCRIPTION
…being fully resolved when the spec was pulled in over AJAX but was working locally. helpers.simpleRef()'s parsing of the responses was just checking if the ref _started_ with '#/definitions/', not whether it contained it, and when pulled in over AJAX the refs have the URL prepended to them.

This relates to [issue #1423](https://github.com/swagger-api/swagger-ui/issues/1423) in swagger-ui but also affects swagger-js.