### PR TITLE
download non json content

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -699,6 +699,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   if (opts.mock === true) {
     return obj;
   } else {
+    var request = obj;
     /*
      * swagger deals nicely with json response. However, in case of other
      * mime types we have to pass resource to browser. This is done via
@@ -729,9 +730,10 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
             }
         }
       };
-      new SwaggerHttp().execute(check, opts);
-    } else
-      new SwaggerHttp().execute(obj, opts);
+      request = check;
+    }
+
+    new SwaggerHttp().execute(obj, opts);
   }
 };
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -699,7 +699,39 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   if (opts.mock === true) {
     return obj;
   } else {
-    new SwaggerHttp().execute(obj, opts);
+    /*
+     * swagger deals nicely with json response. However, in case of other
+     * mime types we have to pass resource to browser. This is done via
+     * iframe. 'GET' method is assumed.
+     * Ajax call with 'HEAD' method set is used to check if obtaining resource
+     * causes error. If that is the case, issue 'GET' call to get response
+     * body with explanation.
+     */
+    if(this.produces != undefined && this.produces.indexOf('application/json') < 0) {
+      try {
+        var iframe = jQuery("<iframe>")
+          .hide()
+          .prop("src", obj.url)
+          .appendTo("body");
+      } catch(err) {
+        console.log(err);
+      }
+      var check = {
+        url: obj.url,
+        method: 'HEAD',
+        body: obj.body,
+        useJQuery: obj.useJQuery,
+        headers: obj.headers,
+        on: {
+            response: obj.on.response,
+            error: function (response) {
+              new SwaggerHttp().execute(obj, opts);
+            }
+        }
+      };
+      new SwaggerHttp().execute(check, opts);
+    } else
+      new SwaggerHttp().execute(obj, opts);
   }
 };
 


### PR DESCRIPTION
when you 'GET' resource you know is not of type "application/json" or any text format the resource is passed to browser to handle. For instance if u want to download resource with mime type "application/octet-stream" u want browser to ask user where to save. This commit make both that happen and handles error in case of failure.