### PR TITLE
Fix spec conversion with anonymous array/object types.

### DIFF
--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -410,26 +410,27 @@ SwaggerSpecConverter.prototype.toJsonSchema = function(source) {
     var innerType = detectedType.substring(5, detectedType.length - 1);
     var jsonType = this.toJsonSchema({type: innerType});
     return {type: 'array', items: jsonType};
-  }
-  else if(lcType === 'int' || (lcType === 'integer' && format === 'int32'))
+  } else if(lcType === 'int' || (lcType === 'integer' && format === 'int32')) {
     {return {type: 'integer', format: 'int32'};}
-  else if(lcType === 'long' || (lcType === 'integer' && format === 'int64'))
+  } else if(lcType === 'long' || (lcType === 'integer' && format === 'int64')) {
     {return {type: 'integer', format: 'int64'};}
-  else if(lcType === 'integer')
+  } else if(lcType === 'integer') {
     {return {type: 'integer', format: 'int64'};}
-  else if(lcType === 'float' || (lcType === 'number' && format === 'float'))
+  } else if(lcType === 'float' || (lcType === 'number' && format === 'float')) {
     {return {type: 'number', format: 'float'};}
-  else if(lcType === 'double' || (lcType === 'number' && format === 'double'))
+  } else if(lcType === 'double' || (lcType === 'number' && format === 'double')) {
     {return {type: 'number', format: 'double'};}
-  else if((lcType === 'string' && format === 'date-time') || (lcType === 'date'))
+  } else if((lcType === 'string' && format === 'date-time') || (lcType === 'date')) {
     {return {type: 'string', format: 'date-time'};}
-  else if(lcType === 'string')
+  } else if(lcType === 'string') {
     {return {type: 'string'};}
-  else if(lcType === 'file')
+  } else if(lcType === 'file') {
     {return {type: 'file'};}
-  else if(lcType === 'boolean')
+  } else if(lcType === 'boolean') {
     {return {type: 'boolean'};}
-  else if(lcType === 'array' || lcType === 'list') {
+  } else if(lcType === 'boolean') {
+    {return {type: 'boolean'};}
+  } else if(lcType === 'array' || lcType === 'list') {
     if(source.items) {
       var it = this.toJsonSchema(source.items);
       return {type: 'array', items: it};
@@ -437,14 +438,16 @@ SwaggerSpecConverter.prototype.toJsonSchema = function(source) {
     else {
       return {type: 'array', items: {type: 'object'}};
     }
-  }
-  else if(source.$ref) {
-    return {$ref: '#/definitions/' + this.modelMap[source.$ref] || source.$ref};
-  }
-  else if(lcType === 'void' || lcType === '')
+  } else if(source.$ref) {
+    return {$ref: this.modelMap[source.$ref] ? '#/definitions/' + this.modelMap[source.$ref] : source.$ref};
+  } else if(lcType === 'void' || lcType === '') {
     {return {};}
-  else {
-    return {$ref: '#/definitions/' + this.modelMap[source.type] || source.type};
+  } else if (this.modelMap[source.type]) {
+    // If this a model using `type` instead of `$ref`, that's fine.
+    return {$ref: '#/definitions/' + this.modelMap[source.type]};
+  } else {
+    // Unknown model type or 'object', pass it along.
+    return {type: source.type};
   }
 };
 

--- a/test/compat/converter.js
+++ b/test/compat/converter.js
@@ -181,6 +181,12 @@ describe('converts specs', function () {
         expect(photos.type).toBe('array');
         test.object(photos.items);
         expect(photos.items.type).toBe('string');
+
+        var category = definitions.Category;
+        expect(Object.keys(category.properties).length).toBe(3);
+        var metadata = category.properties.metadata;
+        expect(metadata.type).toBe('object');
+
         done();
       });
     };

--- a/test/spec/v1/single.json
+++ b/test/spec/v1/single.json
@@ -458,6 +458,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "metadata": {
+          "type": "object"
         }
       }
     }


### PR DESCRIPTION
The || logic here was faulty and always resolved to true. If a
spec came through with a type of 'object', the definition inside
spec-converter was returned as '#/definitions/undefined'.

This manifested in a *lot* of extra calls to the `swagger.json` endpoint when the client booted. For example, before this patch:

```
GET/explorer/resources/chat                2015.08.28 13:51:56.602
GET/explorer/resources/apiKey              2015.08.28 13:51:56.606
GET/explorer/resources/apiKeyConstraints   2015.08.28 13:51:56.608
GET/explorer/resources/execution           2015.08.28 13:51:56.609
GET/explorer/resources/instrument          2015.08.28 13:51:56.611
GET/explorer/resources/order               2015.08.28 13:51:56.612
GET/explorer/resources/orderBook           2015.08.28 13:51:56.617
GET/explorer/resources/position            2015.08.28 13:51:56.619
GET/explorer/resources/quote               2015.08.28 13:51:56.633
GET/explorer/resources/schema              2015.08.28 13:51:56.640
GET/explorer/resources/settlement          2015.08.28 13:51:56.646
GET/explorer/resources/stats               2015.08.28 13:51:56.651
GET/explorer/resources/user                2015.08.28 13:51:56.653
GET/explorer/resources/trade               2015.08.28 13:51:56.655
GET/explorer/resources                     2015.08.28 13:51:56.763
GET/explorer/resources                     2015.08.28 13:51:56.764
GET/explorer/resources                     2015.08.28 13:51:56.766
GET/explorer/resources                     2015.08.28 13:51:56.767
GET/explorer/resources                     2015.08.28 13:51:56.768
GET/explorer/resources                     2015.08.28 13:51:56.840
GET/explorer/resources                     2015.08.28 13:51:56.841
GET/explorer/resources                     2015.08.28 13:51:56.844
GET/explorer/resources                     2015.08.28 13:51:56.845
GET/explorer/resources                     2015.08.28 13:51:56.846
GET/explorer/resources                     2015.08.28 13:51:57.045
GET/explorer/resources                     2015.08.28 13:51:57.045
GET/explorer/resources                     2015.08.28 13:51:57.047
GET/explorer/resources                     2015.08.28 13:51:57.049
GET/explorer/resources                     2015.08.28 13:51:57.050
GET/explorer/resources                     2015.08.28 13:51:57.122
GET/explorer/resources                     2015.08.28 13:51:57.123
GET/explorer/resources                     2015.08.28 13:51:57.124
GET/explorer/resources                     2015.08.28 13:51:57.126
GET/explorer/resources                     2015.08.28 13:51:57.127
GET/explorer/resources                     2015.08.28 13:51:57.538
GET/explorer/resources                     2015.08.28 13:51:57.539
GET/explorer/resources                     2015.08.28 13:51:57.539
GET/explorer/resources                     2015.08.28 13:51:57.541
GET/explorer/resources                     2015.08.28 13:51:57.542
GET/explorer/resources                     2015.08.28 13:51:57.575
GET/explorer/resources                     2015.08.28 13:51:57.576
GET/explorer/resources                     2015.08.28 13:51:57.577
GET/explorer/resources                     2015.08.28 13:51:57.578
GET/explorer/resources                     2015.08.28 13:51:57.578
GET/explorer/resources                     2015.08.28 13:51:57.627
GET/explorer/resources                     2015.08.28 13:51:57.629
GET/explorer/resources                     2015.08.28 13:51:57.630
GET/explorer/resources                     2015.08.28 13:51:57.630
GET/explorer/resources                     2015.08.28 13:51:57.631
```

After:

```
GET/explorer/resources/apiKey              2015.08.28 13:54:51.246
GET/explorer/resources/apiKeyConstraints   2015.08.28 13:54:51.247
GET/explorer/resources/order               2015.08.28 13:54:51.248
GET/explorer/resources/execution           2015.08.28 13:54:51.249
GET/explorer/resources/quote               2015.08.28 13:54:51.250
GET/explorer/resources/schema              2015.08.28 13:54:51.252
GET/explorer/resources/chat                2015.08.28 13:54:51.253
GET/explorer/resources/instrument          2015.08.28 13:54:51.257
GET/explorer/resources/orderBook           2015.08.28 13:54:51.260
GET/explorer/resources/position            2015.08.28 13:54:51.261
GET/explorer/resources/settlement          2015.08.28 13:54:51.261
GET/explorer/resources/trade               2015.08.28 13:54:51.261
GET/explorer/resources/stats               2015.08.28 13:54:51.262
GET/explorer/resources/user                2015.08.28 13:54:51.264
```