### PR TITLE
add hasOwnProperty check in resolver

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -348,6 +348,7 @@ Resolver.prototype.getRefs = function(spec, obj) {
   obj = obj || spec;
   var output = {};
   for(var key in obj) {
+    if (!obj.hasOwnProperty(key)) continue;
     var item = obj[key];
     if(key === '$ref' && typeof item === 'string') {
       output[item] = null;
@@ -479,6 +480,7 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
   obj = obj || spec;
   var name;
   for(var key in obj) {
+    if (!obj.hasOwnProperty(key)) continue;
     var item = obj[key];
     if(item === null) {
       throw new TypeError("Swagger 2.0 does not support null types (" + obj + ").  See https://github.com/swagger-api/swagger-spec/issues/229.")


### PR DESCRIPTION
I have tried to use swagger-js in my Ember.js project. Swagger fails on reading json and raises "Maximum call stack size exceeded" error. The reason is [Ember's prototype extension](http://guides.emberjs.com/v2.0.0/configuring-ember/disabling-prototype-extensions/). I have added `.hasOwnProperty` check, it solves the problem.