### PR TITLE
Missed security parameter

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -818,7 +818,7 @@ Operation.prototype.asCurl = function (args1, args2) {
   }
   var obj = this.execute(args1, opts);
 
-  this.clientAuthorizations.apply(obj);
+  this.clientAuthorizations.apply(obj, this.operation.security);
 
   var results = [];
 


### PR DESCRIPTION
Security parameter used in `Operation.execute`, but not in `Operation.asCurl`. Without this parameter `SwaggerAuthorizations` will apply all available security rules ignoring actual settings from Swagger JSON for Curl string generation. See https://github.com/swagger-api/swagger-js/blob/master/lib/auth.js#L43