### PR TITLE
Allow schema example to be false

### DIFF
--- a/lib/schema-markup.js
+++ b/lib/schema-markup.js
@@ -114,7 +114,7 @@ function schemaToJSON(schema, models, modelsToIgnore, modelPropertyMacro) {
   var model;
   var output;
 
-  if (schema.example) {
+  if (!_.isUndefined(schema.example)) {
     output = schema.example;
   } else if (_.isUndefined(schema.items) && _.isArray(schema.enum)) {
     output = schema.enum[0];


### PR DESCRIPTION
If a property is type: boolean, allow its example to be false.

````javascript
{
  "description": "This is a boolean property",
  "type": "boolean",
  "example": false
}
````