### PR TITLE
Add a warning to the user, that this may take a while.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -155,7 +155,7 @@ SwaggerClient.prototype.build = function (mock) {
 
   var self = this;
 
-  this.progress('fetching resource list: ' + this.url);
+  this.progress('fetching resource list: ' + this.url + '; Please wait.');
 
   var obj = {
     useJQuery: this.useJQuery,


### PR DESCRIPTION
for loading the ArangoDB swagger-ui my browser takes 30s. 
I've tried adding the swagger supplied throbber.gif, but that won't animate while the swagger is working. Probably some counters for this.progress would be better.