### PR TITLE
Fix support for "title" tag

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,6 +61,7 @@ var reservedClientTags = [
   'supportedSubmitMethods',
   'swaggerRequestHeaders',
   'tagFromLabel',
+  'title',
   'url',
   'useJQuery'
 ];

--- a/test/client.js
+++ b/test/client.js
@@ -64,6 +64,8 @@ describe('SwaggerClient', function () {
     var cPetStore = _.cloneDeep(petstoreRaw);
 
     cPetStore.tags[1].name = 'help';
+    // see https://github.com/swagger-api/swagger-ui/issues/1615
+    cPetStore.tags.push({ name: 'title' });
 
     _.forEach(cPetStore.paths, function (path) {
       _.forEach(path, function (operation) {
@@ -72,6 +74,8 @@ describe('SwaggerClient', function () {
             operation.tags[index] = 'help';
           }
         });
+        // see https://github.com/swagger-api/swagger-ui/issues/1615
+        operation.tags.push('title');
       });
     });
 
@@ -82,6 +86,9 @@ describe('SwaggerClient', function () {
         expect(client.apis.help).toBeA('function');
         expect(client.pet.help).toBeA('function');
         expect(client._help.help).toBeA('function');
+
+        expect(client.title).toBeA('string');
+        expect(client._title.help).toBeA('function');
 
         expect(Object.keys(client.pet)).toEqual(Object.keys(client.apis.pet));
         expect(client._help).toEqual(client.apis._help);


### PR DESCRIPTION
Add "title" to the list `reservedClientTags` to prevent overriding of `self.title` string with an operation group object.

Fix https://github.com/swagger-api/swagger-ui/issues/1615

@webron could you please review?

I did not include the result of `gulp build` as the change-set is quite large, but I am ok to do that if you like.