### PR TITLE
Fix for readOnly-issue

### DIFF
--- a/lib/schema-markup.js
+++ b/lib/schema-markup.js
@@ -501,6 +501,10 @@ function schemaToHTML(name, schema, models, modelPropertyMacro) {
               html += ', <span class="propOptKey">optional</span>';
             }
 
+            if(property.readOnly) {
+                html += ', <span class="propReadOnly">read only</span>';
+            }
+
             html += ')';
 
             if (!_.isUndefined(cProperty.description)) {

--- a/lib/schema-markup.js
+++ b/lib/schema-markup.js
@@ -514,7 +514,7 @@ function schemaToHTML(name, schema, models, modelPropertyMacro) {
             }
 
             return primitiveToOptionsHTML(cProperty, html);
-          }).join(',</div><div>');
+          }).join(',</div>');
         }
 
         html += '</div>';

--- a/lib/schema-markup.js
+++ b/lib/schema-markup.js
@@ -468,15 +468,13 @@ function schemaToHTML(name, schema, models, modelPropertyMacro) {
       if (schema.$ref) {
         html += '<div>' + addReference(schema, name) + '</div>';
       } else if (type === 'object') {
-        html += '<div>';
-
         if (_.isPlainObject(schema.properties)) {
           html += _.map(schema.properties, function (property, name) {
             var propertyIsRequired = (_.indexOf(schema.required, name) >= 0);
             var cProperty = _.cloneDeep(property);
 
             var requiredClass = propertyIsRequired ? 'required' : '';
-            var html = '<span class="propName ' + requiredClass + '">' + name + '</span> (';
+            var html = '<div' + (property.readOnly ? ' class="readOnly"' : '') + '><span class="propName ' + requiredClass + '">' + name + '</span> (';
             var model;
 
             // Allow macro to set the default value


### PR DESCRIPTION
mentioned in
https://github.com/swagger-api/swagger-ui/issues/1248
https://github.com/swagger-api/swagger-ui/issues/1231

A "read only" string is added to the properties. Additional it is possible to possible to hide the properties via css in specific methods