### PR TITLE
Fix #599: Add support for an Auditor to be used for Req/Res

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -145,6 +145,12 @@ SwaggerClient.prototype.initialize = function (url, options) {
     this.ready = true;
     return this.build();
   }
+
+  // Logger for the req/res
+  this.options.audit = {
+      func: options.auditor || undefined,
+      defaultEnabled: options.audit || false
+  };
 };
 
 SwaggerClient.prototype.build = function (mock) {
@@ -192,7 +198,7 @@ SwaggerClient.prototype.build = function (mock) {
 
           self.isValid = true;
         } else {
-          var converter = new SwaggerSpecConverter();
+          var converter = new SwaggerSpecConverter(self.options);
           self.oldSwaggerObject = self.swaggerObject;
 
           converter.setDocumentationLocation(self.url);

--- a/lib/http.js
+++ b/lib/http.js
@@ -15,8 +15,17 @@ var JQueryHttpClient = function () {};
 
 /*
  * SuperagentHttpClient is a light-weight, node or browser HTTP client
+ * @param {Object} options is the set of options used for the HTTP requests.
  */
-var SuperagentHttpClient = function () {};
+var SuperagentHttpClient = function (options) {
+  this.options = options || {};
+
+  // Resolve the auditor if it is provided by the client API.
+  if (this.options.auditor && typeof this.options.auditor === 'function') {
+    this.auditor = this.options.auditor;
+    this.auditorEnabled = this.options.log !== "undefined";
+  }
+};
 
 /**
  * SwaggerHttp is a wrapper for executing requests
@@ -190,6 +199,11 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     r.set(name, headers[name]);
   }
 
+  // If the auditor is provided, start the latency clock.
+  if (this.auditorEnabled) {
+    var requestTime = new Date().getTime();
+  }
+
   if (obj.body) {
     r.send(obj.body);
   }
@@ -198,7 +212,21 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     r.buffer(); // force superagent to populate res.text with the raw response data
   }
 
+  var self = this;
+
   r.end(function (err, res) {
+
+    if (self.auditorEnabled) {
+      var latency = Date.now() - requestTime;
+      res.headers['x-request-received'] = requestTime;
+      res.headers['x-request-processing-time'] = latency;
+
+      // Provide the log for the request, as it is used by other frameworks and the auditor.
+      res.req.log = self.options.log;
+      // Use the function provided by the user through "opts.auditor"
+      self.auditor(err, res.req, res);
+    }
+
     res = res || {
       status: 0,
       headers: {error: 'no response from server'}

--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -5,10 +5,17 @@ var _ = {
   isObject: require('lodash-compat/lang/isObject')
 };
 
-var SwaggerSpecConverter = module.exports = function () {
+/**
+ * Constructs a new SwaggerSpecConverter.
+ *
+ * @param  {Object} options is the set of options provided by the API client to be propagated
+ * to the HTTP Clients.
+ */
+var SwaggerSpecConverter = module.exports = function (options) {
   this.errors = [];
   this.warnings = [];
   this.modelMap = {};
+  this.options = options || {};
 };
 
 SwaggerSpecConverter.prototype.setDocumentationLocation = function (location) {
@@ -501,7 +508,7 @@ SwaggerSpecConverter.prototype.resourceListing = function(obj, swagger, callback
       this.clientAuthorizations.apply(http);
     }
 
-    new SwaggerHttp().execute(http);
+    new SwaggerHttp().execute(http, this.options);
   }
 };
 


### PR DESCRIPTION
This commit adds the support for the Auditor function as specified
on issue #599. This way, every HTTP request/response from the Swagger
client to the requested api-docs can be logged using the user-provided
logger and audit functions.

Note
-------

This commit is against the tip of the "Promises" pull request off of 324a846. As it is scheduled to be merged on 2.1.6 and I don't see a version branch, I'm pushing it against Master for now.

*	modified:   lib/client.js
- Capturing the auditor function in the set of options for the client.
- Propagating the swagger options to the SwaggerSpecConverter, as it
  will make HTTP Calls calling the SuperagentHttpClient.

*	modified:   lib/http.js
- Propagating the options to the SuperagentHttpClient class so that it
  can be used from the SuperagentHttpClient calls after the spec is
  downloaded and built.
- Creating the properties "auditorEnabled" and "auditor" to reflect the
  client API options used. The log object must be provided.
- Starting a timer for the latency calculation before the request is
  submitted by the SuperagentHttpClient.
- Collecting the end time and creating the headers for latency.
- Adding the logger to the request object as it is done in other
  frameworks.
- Calling the auditor with the parameters.

*	modified:   lib/spec-converter.js
- Adding the options to the constructor as it is propagated from the
  client.
- Calling the SwaggerHTTP with the propagated options.