### PR TITLE
Add support for an req/res Auditor logging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -150,6 +150,12 @@ SwaggerClient.prototype.initialize = function (url, options) {
     this.ready = true;
     return this.build();
   }
+
+  // Logger for the req/res
+  this.options.audit = {
+      func: options.auditor || undefined,
+      defaultEnabled: options.audit || false
+  };
 };
 
 SwaggerClient.prototype.build = function (mock) {
@@ -197,7 +203,7 @@ SwaggerClient.prototype.build = function (mock) {
 
           self.isValid = true;
         } else {
-          var converter = new SwaggerSpecConverter();
+          var converter = new SwaggerSpecConverter(self.options);
           self.oldSwaggerObject = self.swaggerObject;
 
           converter.setDocumentationLocation(self.url);
@@ -343,7 +349,9 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
         operation,
         self.definitions,
         self.models,
-        self.clientAuthorizations);
+        self.clientAuthorizations,
+        self.options
+      );
 
       // bind self operation's execute command to the api
       _.forEach(tags, function (tag) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -15,8 +15,17 @@ var JQueryHttpClient = function () {};
 
 /*
  * SuperagentHttpClient is a light-weight, node or browser HTTP client
+ * @param {Object} options is the set of options used for the HTTP requests.
  */
-var SuperagentHttpClient = function () {};
+var SuperagentHttpClient = function (options) {
+  this.options = options || {};
+
+  // Resolve the auditor if it is provided by the client API.
+  if (this.options.auditor && typeof this.options.auditor === 'function') {
+    this.auditor = this.options.auditor;
+    this.auditorEnabled = this.options.log !== "undefined";
+  }
+};
 
 /**
  * SwaggerHttp is a wrapper for executing requests
@@ -190,6 +199,11 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     r.set(name, headers[name]);
   }
 
+  // If the auditor is provided, start the latency clock.
+  if (this.auditorEnabled) {
+    var requestTime = new Date().getTime();
+  }
+
   if (obj.body) {
     r.send(obj.body);
   }
@@ -198,7 +212,21 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     r.buffer(); // force superagent to populate res.text with the raw response data
   }
 
+  var self = this;
+
   r.end(function (err, res) {
+
+    if (self.auditorEnabled) {
+      var latency = Date.now() - requestTime;
+      res.headers['x-request-received'] = requestTime;
+      res.headers['x-request-processing-time'] = latency;
+
+      // Provide the log for the request, as it is used by other frameworks and the auditor.
+      res.req.log = self.options.log;
+      // Use the function provided by the user through "opts.auditor"
+      self.auditor(err, res.req, res);
+    }
+
     res = res || {
       status: 0,
       headers: {error: 'no response from server'}

--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -5,10 +5,17 @@ var _ = {
   isObject: require('lodash-compat/lang/isObject')
 };
 
-var SwaggerSpecConverter = module.exports = function () {
+/**
+ * Constructs a new SwaggerSpecConverter.
+ *
+ * @param  {Object} options is the set of options provided by the API client to be propagated
+ * to the HTTP Clients.
+ */
+var SwaggerSpecConverter = module.exports = function (options) {
   this.errors = [];
   this.warnings = [];
   this.modelMap = {};
+  this.options = options || {};
 };
 
 SwaggerSpecConverter.prototype.setDocumentationLocation = function (location) {
@@ -507,7 +514,7 @@ SwaggerSpecConverter.prototype.resourceListing = function(obj, swagger, callback
       this.clientAuthorizations.apply(http);
     }
 
-    new SwaggerHttp().execute(http);
+    new SwaggerHttp().execute(http, this.options);
   }
 };
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -4,14 +4,15 @@ var _ = {
   cloneDeep: require('lodash-compat/lang/cloneDeep'),
   isUndefined: require('lodash-compat/lang/isUndefined'),
   isEmpty: require('lodash-compat/lang/isEmpty'),
-  isObject: require('lodash-compat/lang/isObject')
+  isObject: require('lodash-compat/lang/isObject'),
+  merge: require('lodash-compat/object/merge')
 };
 var helpers = require('../helpers');
 var Model = require('./model');
 var SwaggerHttp = require('../http');
 var Q = require('../../node_modules/q/q');
 
-var Operation = module.exports = function (parent, scheme, operationId, httpMethod, path, args, definitions, models, clientAuthorizations) {
+var Operation = module.exports = function (parent, scheme, operationId, httpMethod, path, args, definitions, models, clientAuthorizations, options) {
   var errors = [];
 
   parent = parent || {};
@@ -47,6 +48,8 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.parameterMacro = parent.parameterMacro || function (operation, parameter) {
     return parameter.default;
   };
+
+  this.options = options || {};
 
   this.inlineModels = [];
 
@@ -730,6 +733,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   if (opts.mock === true) {
     return obj;
   } else {
+    opts = _.merge({}, opts, this.options);
     return new SwaggerHttp().execute(obj, opts);
   }
 };


### PR DESCRIPTION
This commit adds the support for the Auditor function as specified
on issue #559. This way, every HTTP request/response from the Swagger
client to the requested api-docs can be logged using the user-provided
logger and audit functions.

*	modified:   lib/client.js
- Capturing the auditor function in the set of options for the client.
- Propagating the swagger options to the SwaggerSpecConverter, as it
  will make HTTP Calls calling the SuperagentHttpClient.

*	modified:   lib/http.js
- Propagating the options to the SuperagentHttpClient class so that it
  can be used from the SuperagentHttpClient calls after the spec is
  downloaded and built.
- Creating the properties "auditorEnabled" and "auditor" to reflect the
  client API options used. The log object must be provided.
- Starting a timer for the latency calculation before the request is
  submitted by the SuperagentHttpClient.
- Collecting the end time and creating the headers for latency.
- Adding the logger to the request object as it is done in other
  frameworks.
- Calling the auditor with the parameters.

*	modified:   lib/spec-converter.js
- Adding the options to the constructor as it is propagated from the
  client.
- Calling the SwaggerHTTP with the propagated options.