### PR TITLE
enableCookies option in client and operations

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -38,6 +38,7 @@ var reservedClientTags = [
   'debug',
   'defaultErrorCallback',
   'defaultSuccessCallback',
+  'enableCookies',
   'fail',
   'failure',
   'finish',
@@ -88,6 +89,7 @@ var SwaggerClient = module.exports = function (url, options) {
   this.authorizationScheme = null;
   this.basePath = null;
   this.debug = false;
+  this.enableCookies = false;
   this.info = null;
   this.isBuilt = false;
   this.isValid = false;
@@ -134,6 +136,10 @@ SwaggerClient.prototype.initialize = function (url, options) {
   if (options.useJQuery) {
     this.useJQuery = options.useJQuery;
   }
+
+  if (options.enableCookies) {
+    this.enableCookies = options.enableCookies;
+  };
 
   this.options = options || {};
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -207,6 +207,10 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     r.set(name, headers[name]);
   }
 
+  if (obj.enableCookies) {
+    r.withCredentials();
+  }
+
   if (obj.body) {
     r.send(obj.body);
   }

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -44,6 +44,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.summary = args.summary || '';
   this.type = null;
   this.useJQuery = parent.useJQuery;
+  this.enableCookies = parent.enableCookies;
   this.parameterMacro = parent.parameterMacro || function (operation, parameter) {
     return parameter.default;
   };
@@ -667,6 +668,11 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   if (typeof opts.useJQuery === 'undefined') {
     opts.useJQuery = this.useJQuery;
   }
+
+  if (typeof opts.enableCookies === 'undefined') {
+    opts.enableCookies = this.enableCookies;
+  }
+
   var missingParams = this.getMissingParams(args);
 
   if (missingParams.length > 0) {
@@ -709,6 +715,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     url: url,
     method: this.method.toUpperCase(),
     body: body,
+    enableCookies: opts.enableCookies,
     useJQuery: opts.useJQuery,
     deferred: deferred,
     headers: headers,


### PR DESCRIPTION
Setting `enableCookies` to true in the options of a new SwaggerClient or in the options object of an operation makes the browser include the cookies and other HTTP credentials in it's requests.

Naming the option 'enableCookies' as suggested by user tonytam in IRC.

More information about sending credentials: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials 

--

I've not written tests and not made the jQuery client honor the option. 
Is this the way to go?