### PR TITLE
adds tests, support for top-level shared and path-level parameters

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -78,8 +78,14 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
       }
       else {
         operation = path[method];
+        var sharedParameters = path.parameters || [];
+        var parameters = operation.parameters || [];
 
-        var parameters = operation.parameters;
+        for (i in sharedParameters) {
+          var parameter = sharedParameters[i];
+          parameters.unshift(parameter);
+        }
+
         for (i in parameters) {
           var parameter = parameters[i];
           location = '/paths' + name + '/' + method + '/parameters';
@@ -130,6 +136,8 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
         }
       }
     }
+    // clear them out to avoid multiple resolutions
+    path.parameters = [];
   }
 
   var expectedCalls = 0, toResolve = [];

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -862,7 +862,7 @@ describe('swagger resolver', function () {
     sample = new SwaggerClient(opts);
   });
 
-  it('resloves absolute references per #587', function(done) {
+  it('resolves absolute references per #587', function(done) {
     var api = new Resolver();
     var sample;
     var opts = opts || {};
@@ -879,5 +879,80 @@ describe('swagger resolver', function () {
     };
 
     sample = new SwaggerClient(opts);
+  });
+
+  it('resolves top-level shared parameters', function(done) {
+    var api = new Resolver();
+    var spec = {
+      parameters: {
+        skip: {
+          in: 'query',
+          name: 'skip',
+          type: 'integer',
+          format: 'int32',
+          required: 'true'
+        }
+      },
+      paths: {
+        '/foo': {
+          get: {
+            parameters: [
+              { $ref: '#/parameters/skip'}
+            ],
+            responses: {
+              200: {
+                description: 'ok'
+              }
+            }
+          }
+        }
+      }
+    };
+    api.resolve(spec, 'http://localhost:8000/v2/swagger.json', function (spec, unresolved) {
+      expect(spec.paths['/foo'].get.parameters[0]).toBeAn('object');
+      done();
+    });
+  });
+
+  it('resolves path-level shared parameters', function(done) {
+    var api = new Resolver();
+    var spec = {
+      paths: {
+        '/foo': {
+          parameters: [
+            {
+              in: 'query',
+              name: 'skip',
+              type: 'integer',
+              format: 'int32',
+              required: 'true'
+            }
+          ],
+          get: {
+            parameters: [
+              {
+                in: 'query',
+                name: 'limit',
+                type: 'integer',
+                format: 'int32',
+                required: 'true'
+              }
+            ],
+            responses: {
+              200: {
+                description: 'ok'
+              }
+            }
+          }
+        }
+      }
+    };
+    api.resolve(spec, 'http://localhost:8000/v2/swagger.json', function (spec, unresolved) {
+      var parameters = spec.paths['/foo'].get.parameters;
+      expect(parameters[0].name).toEqual('skip');
+      expect(parameters[1].name).toEqual('limit');
+      expect(spec.paths['/foo'].parameters.length).toBe(0);
+      done();
+    });
   });
 });


### PR DESCRIPTION
fixes #491 

Shared parameters (`swagger.parameters`) will resolve through references to `#/parameters/{paramName}`.  Shared parameters at the path level will be resolved and removed from the path object after resolution.