### PR TITLE
fix CookieJar reference

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,7 +2,7 @@
 
 var helpers = require('./helpers');
 var btoa = require('btoa'); // jshint ignore:line
-var CookieJar = require('cookiejar');
+var CookieJar = require('cookiejar').CookieJar;
 var _ = {
   each: require('lodash-compat/collection/each'),
   includes: require('lodash-compat/collection/includes'),


### PR DESCRIPTION
cookiejar 2.0.1 code:
`exports.CookieJar = CookieJar;`

Error before fixing:

```
/usr/local/bin/node swa.js
/Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/auth.js:102
  obj.cookieJar = obj.cookieJar || new CookieJar();
                                   ^

TypeError: CookieJar is not a function
    at CookieAuthorization.apply (/Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/auth.js:102:36)
    at /Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/auth.js:62:28
    at /Users/zengxian/workspace/jike-app-service/node_modules/lodash-compat/internal/createBaseFor.js:19:11
    at baseForOwn (/Users/zengxian/workspace/jike-app-service/node_modules/lodash-compat/internal/baseForOwn.js:14:10)
    at /Users/zengxian/workspace/jike-app-service/node_modules/lodash-compat/internal/createBaseEach.js:17:14
    at Object.each (/Users/zengxian/workspace/jike-app-service/node_modules/lodash-compat/internal/createForEach.js:16:9)
    at SwaggerAuthorizations.apply (/Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/auth.js:60:5)
    at SwaggerClient.build (/Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/client.js:217:31)
    at SwaggerClient.initialize (/Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/client.js:148:10)
    at new module.exports (/Users/zengxian/workspace/jike-app-service/node_modules/swagger-client/lib/client.js:102:17)

```