### PR TITLE
Output curl --data in single quotes (instead of double quotes)

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -861,9 +861,9 @@ Operation.prototype.asCurl = function (args1, args2) {
     for (key in obj.headers) {
       var value = obj.headers[key];
       if(typeof value === 'string'){
-        value = value.replace(/"/g, '\\"');
+        value = value.replace(/\'/g, '\\u0027');
       }
-      results.push('--header "' + key + ': ' + value + '"');
+      results.push('--header \'' + key + ': ' + value + '\'');
     }
   }
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -876,7 +876,7 @@ Operation.prototype.asCurl = function (args1, args2) {
       body = obj.body;
     }
 
-    results.push('-d "' + body.replace(/"/g, '\\"') + '"');
+    results.push('-d \'' + body.replace(/"/g, '\\"') + '\'');
   }
 
   return 'curl ' + (results.join(' ')) + ' "' + obj.url + '"';

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -876,7 +876,7 @@ Operation.prototype.asCurl = function (args1, args2) {
       body = obj.body;
     }
 
-    results.push('-d \'' + body.replace(/"/g, '\\"') + '\'');
+    results.push('-d \'' + body.replace(/\'/g, '\\u0027') + '\'');
   }
 
   return 'curl ' + (results.join(' ')) + ' "' + obj.url + '"';

--- a/test/compat/request.js
+++ b/test/compat/request.js
@@ -34,7 +34,7 @@ describe('1.2 request operations', function () {
   it('shows curl syntax', function () {
     var curl = sample.pet.getPetById.asCurl({petId: 1});
 
-    expect(curl).toBe('curl -X GET --header "Accept: application/json" "http://localhost:8001/v1/api/pet/1"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' "http://localhost:8001/v1/api/pet/1"');
   });
 
   it('generate a get request', function () {

--- a/test/help.js
+++ b/test/help.js
@@ -35,7 +35,7 @@ describe('help options', function () {
                                    new auth.SwaggerAuthorizations());
     var curl = op.asCurl({});
 
-    expect(curl).toBe('curl -X GET --header "Accept: application/json" "http://localhost/path"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' "http://localhost/path"');
   });
 
   it('prints a curl statement with headers', function () {
@@ -65,7 +65,7 @@ describe('help options', function () {
       Authorization: 'Oauth:"test"'
     });
 
-    expect(curl).toBe('curl -X GET --header "Accept: application/json" --header "name: tony" --header "age: 42" --header "Authorization: Oauth:\\"test\\"" "http://localhost/path"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' --header \'name: tony\' --header \'age: 42\' --header \'Authorization: Oauth:"test"\' "http://localhost/path"');
   });
 
   it('prints a curl statement with custom content-type', function () {
@@ -75,6 +75,6 @@ describe('help options', function () {
       responseContentType: 'application/xml'
     });
 
-    expect(curl).toBe('curl -X GET --header "Accept: application/xml" "http://localhost/path"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/xml\' "http://localhost/path"');
   });
 });

--- a/test/request.js
+++ b/test/request.js
@@ -303,14 +303,21 @@ describe('swagger request functions', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: {id:10101}});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{\\"id\\":10101}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('prints a curl post statement from a string', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":10101}'});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{\\"id\\":10101}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
+  });
+
+  it('prints a curl post statement from a string containing a single quote', function () {
+    var petApi = sample.pet;
+    var curl = petApi.addPet.asCurl({body: '{"id":"foo\'bar"}'});
+
+    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{"id":"foo\\u0027bar"}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('gets an server side 404, and verifies that the content-type in the response is correct, and different than one in the request', function (done) {

--- a/test/request.js
+++ b/test/request.js
@@ -303,14 +303,14 @@ describe('swagger request functions', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: {id:10101}});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d "{\\"id\\":10101}" "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{\\"id\\":10101}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('prints a curl post statement from a string', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":10101}'});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d "{\\"id\\":10101}" "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{\\"id\\":10101}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('gets an server side 404, and verifies that the content-type in the response is correct, and different than one in the request', function (done) {

--- a/test/request.js
+++ b/test/request.js
@@ -303,21 +303,21 @@ describe('swagger request functions', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: {id:10101}});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('prints a curl post statement from a string', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":10101}'});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('prints a curl post statement from a string containing a single quote', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":"foo\'bar"}'});
 
-    expect(curl).toBe('curl -X POST --header "Content-Type: application/json" --header "Accept: application/json" -d \'{"id":"foo\\u0027bar"}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":"foo\\u0027bar"}\' "http://localhost:8000/v2/api/pet"');
   });
 
   it('gets an server side 404, and verifies that the content-type in the response is correct, and different than one in the request', function (done) {


### PR DESCRIPTION
We have a scenario where we have a "!" character inside our JSON request data:
```
{
  "username": "alice",
  "password": "cooper!00"
}
```

Swagger's `asCurl` method renders this as follows:

```
curl -X POST -d "{
  \"username\": \"alice\",
  \"password\": \"cooper!00\"
}" https://example.com/api
```

bash now tries to interpret the "!" here, which results in this error: `-bash: !00: event not found`.

There's no way to escape "!" in double quotes so we suggest the following output:

```
curl -X POST -d '{
  "username": "alice",
  "password": "cooper!00"
}' https://example.com/api
```

Does the trick and is also much easier to read.

Would you accept this PR? It fixes the problem and updates the corresponding 2 tests.