### PR TITLE
Output curl URL in single quotes

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -885,7 +885,7 @@ Operation.prototype.asCurl = function (args1, args2) {
     results.push('-d \'' + body.replace(/\'/g, '\\u0027') + '\'');
   }
 
-  return 'curl ' + (results.join(' ')) + ' "' + obj.url + '"';
+  return 'curl ' + (results.join(' ')) + ' \'' + obj.url + '\'';
 };
 
 Operation.prototype.encodePathCollection = function (type, name, value) {

--- a/test/compat/request.js
+++ b/test/compat/request.js
@@ -34,7 +34,7 @@ describe('1.2 request operations', function () {
   it('shows curl syntax', function () {
     var curl = sample.pet.getPetById.asCurl({petId: 1});
 
-    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' "http://localhost:8001/v1/api/pet/1"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' \'http://localhost:8001/v1/api/pet/1\'');
   });
 
   it('generate a get request', function () {

--- a/test/help.js
+++ b/test/help.js
@@ -39,7 +39,7 @@ describe('help options', function () {
         {summary: 'test operation'}, {}, {}, new auth.SwaggerAuthorizations());
     var curl = op.asCurl({});
 
-    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' "http://localhost/path"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' \'http://localhost/path\'');
   });
 
   it('does not duplicate api_key in query param per #624', function () {
@@ -56,7 +56,7 @@ describe('help options', function () {
     // repeat to ensure no change
     curl = op.asCurl({});
 
-    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' "http://localhost/path?api_key=abc123"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' \'http://localhost/path?api_key=abc123\'');
   });
 
   it('prints a curl statement with headers', function () {
@@ -86,7 +86,7 @@ describe('help options', function () {
       Authorization: 'Oauth:"test"'
     });
 
-    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' --header \'name: tony\' --header \'age: 42\' --header \'Authorization: Oauth:"test"\' "http://localhost/path"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/json\' --header \'name: tony\' --header \'age: 42\' --header \'Authorization: Oauth:"test"\' \'http://localhost/path\'');
   });
 
   it('prints a curl statement with custom content-type', function () {
@@ -96,6 +96,6 @@ describe('help options', function () {
       responseContentType: 'application/xml'
     });
 
-    expect(curl).toBe('curl -X GET --header \'Accept: application/xml\' "http://localhost/path"');
+    expect(curl).toBe('curl -X GET --header \'Accept: application/xml\' \'http://localhost/path\'');
   });
 });

--- a/test/request.js
+++ b/test/request.js
@@ -303,21 +303,21 @@ describe('swagger request functions', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: {id:10101}});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' \'http://localhost:8000/v2/api/pet\'');
   });
 
   it('prints a curl post statement from a string', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":10101}'});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' \'http://localhost:8000/v2/api/pet\'');
   });
 
   it('prints a curl post statement from a string containing a single quote', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":"foo\'bar"}'});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":"foo\\u0027bar"}\' "http://localhost:8000/v2/api/pet"');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":"foo\\u0027bar"}\' \'http://localhost:8000/v2/api/pet\'');
   });
 
   it('gets an server side 404, and verifies that the content-type in the response is correct, and different than one in the request', function (done) {


### PR DESCRIPTION
Now all the curl arguments are using single quotes for consistency reasons:

```
curl -X POST --header 'Content-Type: text/html' -d '{
  "username": "alice",
  "password": "cooper!00"
}' 'https://example.com/api'
```

See #627