### PR TITLE
Remove Q in favor of promise-native-deferred

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,7 @@ var OperationGroup = require('./types/operationGroup');
 var Resolver = require('./resolver');
 var SwaggerHttp = require('./http');
 var SwaggerSpecConverter = require('./spec-converter');
-var Q = require('q');
+var defer = require('promise-native-deferred');
 
 // We have to keep track of the function/property names to avoid collisions for tag names which are used to allow the
 // following usage: 'client.{tagName}'
@@ -98,7 +98,7 @@ var SwaggerClient = module.exports = function (url, options) {
   this.url = null;
   this.useJQuery = false;
   this.swaggerObject = {};
-  this.deferredClient = Q.defer();
+  this.deferredClient = defer();
 
   this.clientAuthorizations = new auth.SwaggerAuthorizations();
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -9,7 +9,7 @@ var _ = {
 var helpers = require('../helpers');
 var Model = require('./model');
 var SwaggerHttp = require('../http');
-var Q = require('q');
+var defer = require('promise-native-deferred');
 
 var Operation = module.exports = function (parent, scheme, operationId, httpMethod, path, args, definitions, models, clientAuthorizations) {
   var errors = [];
@@ -661,7 +661,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   }
 
   if (this.parent.usePromise) {
-    deferred = Q.defer();
+    deferred = defer();
   } else {
     success = (success || this.parent.defaultSuccessCallback || helpers.log);
     error = (error || this.parent.defaultErrorCallback || helpers.log);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cookiejar": "^2.0.1",
     "js-yaml": "^3.3.0",
     "lodash-compat": "^3.5.0",
-    "q": "^1.4.1",
+    "promise-native-deferred": "^3.0.0",
     "superagent": "^1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This stops Q from being bundled with swagger-js, particularly in the browser where page weight is very important.

Currently the browserify bundle weighs about 850k without the sourcemap (huge!), and Q accounts for more than 150k of that. 

before:

<img width="590" alt="screenshot 2015-12-04 00 14 00" src="https://cloud.githubusercontent.com/assets/755844/11584883/9d398952-9a1c-11e5-8f17-d0e2fc2f0ff4.png">
<img width="628" alt="screenshot 2015-12-04 00 13 56" src="https://cloud.githubusercontent.com/assets/755844/11584878/97bc0d4c-9a1c-11e5-8fdb-39dcfd74b5d3.png">

Removing Q means that:

1) We don't bundle a Promise implementation with a ton of bells and whistles, none of which are used
2) We don't burden users with a Promise implementation if they're not using Promises
3) Users can polyfill Promises on their own (or use the browser's native implementation) and choose the implementation they prefer without using Q's promises.
4) We save more than 150K in the unminified bundle size!

This is technically a breaking change since users need to be aware of what the environment requires for Promises (they'll have to manually add an implementation), and that `Q` promises aren't returned, meaning the API on the returned promises is smaller, and users may be depending on bells and whistles inadvertently.

[Here are some reasons why this is a better approach](https://github.com/wbinnssmith/awesome-promises/blob/master/README.md#convenience-utilities). If you're happy with the direction of this, I'll gladly document the additional step for promises users in the README.

Thanks for swagger! 

after:

<img width="571" alt="screenshot 2015-12-04 00 19 22" src="https://cloud.githubusercontent.com/assets/755844/11584896/bb5f502e-9a1c-11e5-9376-2d10edf7f4e5.png">
