### PR TITLE
#666 fix for local base model properties

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -248,7 +248,7 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
         processedCalls += 1;
 
         if(processedCalls === expectedCalls) {
-          self.finish(spec, root, resolutionTable, resolvedRefs, unresolvedRefs, callback);
+          self.finish(spec, root, resolutionTable, resolvedRefs, unresolvedRefs, callback, true);
         }
       }
       else {
@@ -344,7 +344,7 @@ Resolver.prototype.resolveItem = function(spec, root, resolutionTable, resolvedR
   }
 };
 
-Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs, unresolvedRefs, callback) {
+Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs, unresolvedRefs, callback, retainRoot) {
   // walk resolution table and replace with resolved refs
   var ref;
   for (ref in resolutionTable) {
@@ -355,8 +355,11 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
     if (resolvedTo) {
       spec.definitions = spec.definitions || {};
       if (item.resolveAs === 'ref') {
-        for (key in resolvedTo.obj) {
-          var abs = this.retainRoot(resolvedTo.obj[key], item.root);
+        if (retainRoot !== true) {
+          // don't retain root for local definitions
+          for (key in resolvedTo.obj) {
+            var abs = this.retainRoot(resolvedTo.obj[key], item.root);
+          }
         }
         spec.definitions[resolvedTo.name] = resolvedTo.obj;
         item.obj.$ref = '#/definitions/' + resolvedTo.name;
@@ -366,7 +369,12 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
         delete targetObj.$ref;
 
         for (key in resolvedTo.obj) {
-          var abs = this.retainRoot(resolvedTo.obj[key], item.root);
+          var abs = resolvedTo.obj[key];
+          
+          if (retainRoot !== true) {
+            // don't retain root for local definitions
+            abs = this.retainRoot(resolvedTo.obj[key], item.root);
+          }
           targetObj[key] = abs;
         }
       }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -344,7 +344,7 @@ Resolver.prototype.resolveItem = function(spec, root, resolutionTable, resolvedR
   }
 };
 
-Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs, unresolvedRefs, callback, retainRoot) {
+Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs, unresolvedRefs, callback, localResolve) {
   // walk resolution table and replace with resolved refs
   var ref;
   for (ref in resolutionTable) {
@@ -355,7 +355,7 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
     if (resolvedTo) {
       spec.definitions = spec.definitions || {};
       if (item.resolveAs === 'ref') {
-        if (retainRoot !== true) {
+        if (localResolve !== true) {
           // don't retain root for local definitions
           for (key in resolvedTo.obj) {
             var abs = this.retainRoot(resolvedTo.obj[key], item.root);
@@ -371,7 +371,7 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
         for (key in resolvedTo.obj) {
           var abs = resolvedTo.obj[key];
           
-          if (retainRoot !== true) {
+          if (localResolve !== true) {
             // don't retain root for local definitions
             abs = this.retainRoot(resolvedTo.obj[key], item.root);
           }

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -1110,4 +1110,71 @@ describe('swagger resolver', function () {
       done();
     });
   });
+
+  it('base model properties', function(done) {
+      
+    var api = new Resolver();
+    var spec = {
+     
+      swagger:'2.0',
+      info:{
+      },
+      host:"localhost:9000",
+      schemes:[
+        "http"
+      ],
+      basePath:"/2.0",
+      paths:{
+        '/':{
+          get:{
+            responses:{
+              "200":{
+                description:"Pets",
+                schema:{
+                  "$ref":"#/definitions/Pet"
+                }
+              }
+            },
+            parameters:[
+            ]
+          }
+        }
+      },
+      definitions:{
+        Cat:{
+          allOf: [
+            {
+              "$ref": "#/definitions/Pet"
+            }, 
+            {
+              type: "object",
+              properties:{
+                size:{
+                  type: "number"
+                }
+              }
+            }
+          ]
+        },
+        Pet:{
+          type: "object",
+          properties:{
+            color:{
+              "$ref":"#/definitions/Color"
+            }
+          }
+        },
+        Color:{
+          "type": "string"
+        }
+      }
+    };
+    api.resolve(spec, 'http://localhost:8000/v2/swagger.json', function (spec, unresolved) {
+        
+      expect(spec.definitions.Pet.properties.color['$ref']).toBe('#/definitions/Color');
+      expect(spec.definitions.Cat.properties.color['$ref']).toBe('#/definitions/Color');
+      
+      done();
+    });
+  });
 });


### PR DESCRIPTION
For inhered classes new class definition is processed as inline. That definition is localized in the current file so root element url should not be added for it.