### PR TITLE
an additional null check added

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -540,7 +540,7 @@ Resolver.prototype.resolveTo = function (root, property, resolutionTable, locati
   var sp, i;
   var ref = property.$ref;
   var lroot = root;
-  if (typeof ref !== 'undefined') {
+  if ((typeof ref !== 'undefined') && (ref !== null)) {
     if(ref.indexOf('#') >= 0) {
       var parts = ref.split('#');
 


### PR DESCRIPTION
This additional check prevents invocation of `indexOf()` on possible null `ref` variable and improves therefore error messaging for malformed yaml files. 

Before:
```
Cannot read property 'indexOf' of null
```

After:
```
Uncaught TypeError: Swagger 2.0 does not support null types
```