### PR TITLE
set schema.required instead of schema.enum for required properties

### DIFF
--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -131,7 +131,7 @@ SwaggerSpecConverter.prototype.models = function(obj, swagger) {
   swagger.definitions = swagger.definitions || {};
   for(name in obj) {
     var existingModel = obj[name];
-    var _enum = [];
+    var _required = [];
     var schema = { properties: {}};
     var propertyName;
     for(propertyName in existingModel.properties) {
@@ -145,18 +145,18 @@ SwaggerSpecConverter.prototype.models = function(obj, swagger) {
         property['enum'] = existingProperty['enum'];
       }
       if(typeof existingProperty.required === 'boolean' && existingProperty.required === true) {
-        _enum.push(propertyName);
+        _required.push(propertyName);
       }
       if(typeof existingProperty.required === 'string' && existingProperty.required === 'true') {
-        _enum.push(propertyName);
+        _required.push(propertyName);
       }
       schema.properties[propertyName] = property;
     }
-    if(_enum.length > 0) {
-      schema['enum'] = _enum;
+    if(_required.length > 0) {
+      schema.required = _required;
+    } else {
+      schema.required = existingModel.required;
     }
-
-    schema.required = existingModel.required;
     swagger.definitions[name] = schema;
   }
 };


### PR DESCRIPTION
This patch addresses issues raised in swagger-api/swagger-js#699