### PR TITLE
Fix slowness for all of resolvment

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -199,7 +199,7 @@ SwaggerClient.prototype.build = function (mock) {
         if (responseObj.swagger && parseInt(responseObj.swagger) === 2) {
           self.swaggerVersion = responseObj.swagger;
 
-          new Resolver().resolve(responseObj, self.url, self.buildFromSpec, self);
+          new Resolver(options).resolve(responseObj, self.url, self.buildFromSpec, self);
 
           self.isValid = true;
         } else {
@@ -209,7 +209,7 @@ SwaggerClient.prototype.build = function (mock) {
           converter.setDocumentationLocation(self.url);
           converter.convert(responseObj, self.clientAuthorizations, self.options, function(spec) {
             self.swaggerObject = spec;
-            new Resolver().resolve(spec, self.url, self.buildFromSpec, self);
+            new Resolver(options).resolve(spec, self.url, self.buildFromSpec, self);
             self.isValid = true;
           });
         }
@@ -220,7 +220,7 @@ SwaggerClient.prototype.build = function (mock) {
   if (this.spec) {
     self.swaggerObject = this.spec;
     setTimeout(function () {
-      new Resolver().resolve(self.spec, self.buildFromSpec, self);
+      new Resolver(options).resolve(self.spec, self.buildFromSpec, self);
     }, 10);
   } else {
     this.clientAuthorizations.apply(obj);

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -670,9 +670,6 @@ Resolver.prototype.resolveAllOf = function(spec, obj, depth) {
     if(item === null) {
       throw new TypeError('Swagger 2.0 does not support null types (' + obj + ').  See https://github.com/swagger-api/swagger-spec/issues/229.');
     }
-    if(typeof item === 'object') {
-      this.resolveAllOf(spec, item, depth + 1);
-    }
     if(item && typeof item.allOf !== 'undefined') {
       var allOf = item.allOf;
       if(_.isArray(allOf)) {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -11,7 +11,14 @@ var _ = {
 /**
  * Resolves a spec's remote references
  */
-var Resolver = module.exports = function () {};
+var Resolver = module.exports = function (options) {
+  //Ensures downwards compatibility if no explicit options object is provided
+  var DEFAULT_OPTIONS = {
+    disableAllOfResolving: false
+  };
+
+  this.options = options || DEFAULT_OPTIONS
+};
 
 Resolver.prototype.processAllOf = function(root, name, definition, resolutionTable, unresolvedRefs, spec) {
   var i, location, property;
@@ -405,7 +412,9 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
   var existingUnresolved = this.countUnresolvedRefs(spec);
 
   if(existingUnresolved === 0 || this.iteration > 5) {
-    this.resolveAllOf(spec.definitions);
+    if(!this.options.disableAllOfResolving) {
+      this.resolveAllOf(spec.definitions);
+    }
     callback.call(this.scope, spec, unresolvedRefs);
   }
   else {


### PR DESCRIPTION
Plenty of people are experiencing slowness when using SwaggerUI with complex nested specs [here](https://www.google.de/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#safe=off&q=swagger-ui+slow).

I had the same problem for a project and tracked the issue down to a specific call of `swagger-js`: `resolveAllOf`. This call has several problems:

- It is a recursive call (which is not a problem per se)
- It is always called, regardless of actual usage of `allOf` tags
- **This is the biggest issue:** It is called twice in each recursion (see [here](https://github.com/swagger-api/swagger-js/blob/master/lib/resolver.js#L673-L675) and [here](https://github.com/swagger-api/swagger-js/blob/master/lib/resolver.js#L738-L740) ), causing the call stack to completely explode for nested definitions 

The following screenshots outline the severity of the problem 

## Status Quo

For my (rather simple) api-docs.json, `resolveAllOf` is called **104,000,000** times, resulting in a render time of 4 minutes and a CPU consumption of 90 %.

![default](https://cloud.githubusercontent.com/assets/6770995/13171841/3c5bb32e-d6f5-11e5-8cda-6c6afd3c97a7.png)

##  Deduplication and disableAllOfResolve = false 

The screenshot below shows the behavior after only removing the duplicated recursion in `resolveAllOf` in https://github.com/swagger-api/swagger-js/commit/be29806f56b7c183c4b09d578b6a880d26c1e2ba

`resolveAllOf` is now called "only" **6584** times,  which is still too often, but does not cause problems like hanging of the whole browser. Load time is okayish with 3 seconds

**This is the proposed / implemented default behavior since it does not affect functionality in any way.**

![deduplicatedresolveallcall](https://cloud.githubusercontent.com/assets/6770995/13171839/3bf032d4-d6f5-11e5-80fd-007cd4dc143d.png)

##  Deduplication and disableAllOfResolve = true

`resolveAllOf` is now not called at all. This is the best approach if `allOf` is not used in the swagger docs. Reduces load time to < 1s

![disableallofresolving](https://cloud.githubusercontent.com/assets/6770995/13171840/3c4cb324-d6f5-11e5-8ebe-91c1d701eb3c.png)

