### PR TITLE
quick fix for object title in swagger-ui

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -638,6 +638,10 @@ Resolver.prototype.resolveTo = function (root, property, resolutionTable, locati
   } else {
     if(property && property.properties) {
       var name = this.uniqueName('inline_model');
+      if (property.title) {
+        name = this.uniqueName(property.title);
+      }
+      delete property.title;
       this.spec.definitions[name] = _.cloneDeep(property);
       property['$ref'] = '#/definitions/' + name;
       delete property.type;


### PR DESCRIPTION
I'm using[ swagger-ui](https://github.com/swagger-api/swagger-ui) ([issue in swagger-ui repo](https://github.com/swagger-api/swagger-ui/issues/1925#issuecomment-189260645)) which uses swagger-client. I want to display the title of objects but it only outputs 'inline_model' as title. I found this quick fix in swagger-client but I'm not sure which project is related to the bug. 

Maybe someone could help?