### PR TITLE
Resolving second level references

### DIFF
--- a/test/resolver.js
+++ b/test/resolver.js
@@ -829,6 +829,32 @@ describe('swagger resolver', function () {
     });
   });
 
+  it('resolves second level references', function(done) {
+    var api = new Resolver();
+    var spec = {
+      host: 'http://petstore.swagger.io',
+      basePath: '/v2',
+      paths: {
+        '/health': {
+          $ref: '#/definitions/ref1'
+        }
+      },
+      definitions: {
+        'ref1': {
+          $ref: '#/definitions/ref2'
+        },
+        'ref2': {
+          type: 'string'
+        }
+      }
+    };
+
+    api.resolve(spec, 'http://localhost:8000/v2/swagger.json', function (spec, unresolved) {
+      expect(spec.paths['/health'].type).toBe('string')
+      done();
+    });
+  });
+
   it('resolves a linked reference', function(done) {
     var api = new Resolver();
     var spec = {


### PR DESCRIPTION
I have created a (still broken) test that tests behaviour that I think should be supported.

The general problem that I am facing is that only some `$ref` fields get resolved. Is there a reason for this? To me it would be more consistent to resolve any `$ref` field that is encountered, no matter where and however deeply nested.