### PR TITLE
Avoid deleting the default response on swaggerObject

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -153,7 +153,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     param.responseClassSignature = param.signature;
   }
 
-  var defaultResponseCode, response, responses = this.responses;
+  var defaultResponseCode, response, responses = _.cloneDeep(this.responses);
 
   if (responses['200']) {
     response = responses['200'];

--- a/test/compat/operation.js
+++ b/test/compat/operation.js
@@ -72,7 +72,8 @@ describe('1.2 verifies the get pet operation', function() {
 
     test.object(responses);
 
-    expect(Object.keys(responses).length).toBe(2);
+    expect(Object.keys(responses).length).toBe(3);
+    test.object(responses['200']);
     test.object(responses['400']);
     test.object(responses['404']);
   });


### PR DESCRIPTION
When processing the list of responses for an operation, if there is a default response, the default response would get removed from the client's swaggerObject (which holds the full JSON spec). This can be avoided by operating on a deep clone of the operation's responses. This response typically gets hung on the Operation object as "successResponse", which is useful for the client, but shouldn't do so at the expense of modifying the underlying spec JSON.

This will likely break some tests that assume that the default response will be removed and moved to Operation.successResponse.
