### PR TITLE
Fix for array parameter with defined enums values

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -120,15 +120,17 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
       }
     }
 
-    if (typeof param['enum'] !== 'undefined') {
+    var enumValues = param['enum'] || (param.items && param.items['enum']);
+
+    if (typeof enumValues !== 'undefined') {
       var id;
 
       param.allowableValues = {};
       param.allowableValues.values = [];
       param.allowableValues.descriptiveValues = [];
 
-      for (id = 0; id < param['enum'].length; id++) {
-        var value = param['enum'][id];
+      for (id = 0; id < enumValues.length; id++) {
+        var value = enumValues[id];
         var isDefault = (value === param.default || value+'' === param.default);
 
         param.allowableValues.values.push(value);


### PR DESCRIPTION
Arrays of enums as method parameters stop working with current swagger. They ware broken after clean-up in that commit #198 e30ceecca72409576448410e5c19834b0f5e6abb. Currently values of enums are not taken from item element when array is being used. As the result the text area appear not the select.

The swagger definition:
```
{
  "swagger": "2.0",
  "basePath": "/v1/api",
  "paths": {
    "/article": {
      "get": {
        "parameters": [
          {
            "name": "enumArrayParameter",
            "in": "query",
            "description": "Select for enum values.",
            "required": false,
            "type": "array",
            "items": {
              "type": "string",
              "enum": [
                "OPTION_1",
                "OPTION_2",
                "OPTION_3"
              ]
            },
            "collectionFormat": "multi"
          }    
        ]
      }
    }
  } 
}
```

Current (broken) look of swagger-ui:
![broken](https://cloud.githubusercontent.com/assets/811830/13954617/e844dd18-f041-11e5-997d-bddae5429d29.png)

Expected look of swagger-ui (after fix and before clean-up):
![fixed](https://cloud.githubusercontent.com/assets/811830/13954754/72a0ddae-f042-11e5-8efb-c07c9e54b98d.png)

