### PR TITLE
Resolve refs in responses which contain arrays

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -165,6 +165,12 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
                 responseObj.schema.$ref = '#/definitions/' + name;
                 this.processAllOf(root, name, spec.definitions[name], resolutionTable, unresolvedRefs, spec);
               }
+              else if('array' === responseObj.schema.type) {
+                if(responseObj.schema.items && responseObj.schema.items.$ref) {
+                  // response reference
+                  this.resolveInline(root, spec, responseObj.schema.items, resolutionTable, unresolvedRefs, location);
+                }
+              }
               else {
                 this.resolveTo(root, response.schema, resolutionTable, location);
               }

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -757,6 +757,41 @@ describe('swagger resolver', function () {
     });
   });
 
+
+  it('resolves ref arrays in responses', function(done) {
+    var api = new Resolver();
+    var spec = {
+      host: 'http://petstore.swagger.io',
+      basePath: '/v2',
+      paths: {
+        '/foo': {
+          get: {
+            responses: {
+              200: {
+                description: 'Array of refs',
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: 'http://localhost:8000/v2/models.json#/Health'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    // should look in http://localhost:8000/foo/bar/swagger.yaml#/paths/health
+    api.resolve(spec, 'http://localhost:8000/swagger.json', function (spec, unresolved) {
+
+      expect(spec.paths['/foo'].get.responses['200'].schema.items['$ref']).toBe(undefined);
+      expect(spec.paths['/foo'].get.responses['200'].schema.items['x-resolved-from'][0]).toBe('http://localhost:8000/v2/models.json#/Health');
+
+      done();
+    });
+  });
+  
   it('does not make multiple calls for parameter refs #489', function(done) {
     var api = new Resolver();
     var spec = {


### PR DESCRIPTION
At present, the following response block will not currently resolve the Pet ref:

```
responses:
        200:
          description: "successful operation"
          schema:
            type: "array"
            items:
              $ref: "#/definitions/Pet"
```

This PR adds support for automatically resolving these type of references in responses where the $ref is part of an array response.