### PR TITLE
Added support for proxy with superagent

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -117,8 +117,6 @@ SwaggerClient.prototype.setProxy = function(proxy) {
 }
 
 SwaggerClient.prototype.initialize = function (url, options) {
-  console.log('init with opts', options);
-  
   this.models = {};
   this.sampleModels = {};
 
@@ -172,7 +170,8 @@ SwaggerClient.prototype.initialize = function (url, options) {
 };
 
 SwaggerClient.prototype.build = function (mock) {
-  console.log('running build');
+  console.log('running build', this);
+  
   if (this.isBuilt) {
     return this;
   }
@@ -232,7 +231,6 @@ SwaggerClient.prototype.build = function (mock) {
   };
 
   if (this.spec) {
-    console.log('uses this.spec');
     self.swaggerObject = this.spec;
     setTimeout(function () {
       new Resolver().resolve(self.spec, self.url, self.buildFromSpec, self);
@@ -247,8 +245,6 @@ SwaggerClient.prototype.build = function (mock) {
     this.options = this.options || {};
     this.options.proxy = this.proxy || null;
     
-    console.log('will exec with', this.options);
-
     new SwaggerHttp().execute(obj, this.options);
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -172,6 +172,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
 };
 
 SwaggerClient.prototype.build = function (mock) {
+  console.log('running build');
   if (this.isBuilt) {
     return this;
   }
@@ -231,6 +232,7 @@ SwaggerClient.prototype.build = function (mock) {
   };
 
   if (this.spec) {
+    console.log('uses this.spec');
     self.swaggerObject = this.spec;
     setTimeout(function () {
       new Resolver().resolve(self.spec, self.url, self.buildFromSpec, self);

--- a/lib/client.js
+++ b/lib/client.js
@@ -170,7 +170,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
 };
 
 SwaggerClient.prototype.build = function (mock) {
-  console.log('running build', this);
+  console.log('running build proxy value', this.proxy);
   
   if (this.isBuilt) {
     return this;

--- a/lib/client.js
+++ b/lib/client.js
@@ -367,7 +367,8 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
         operation,
         self.definitions,
         self.models,
-        self.clientAuthorizations);
+        self.clientAuthorizations,
+        self.proxy);
 
       // bind self operation's execute command to the api
       _.forEach(tags, function (tag) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -100,6 +100,7 @@ var SwaggerClient = module.exports = function (url, options) {
   this.useJQuery = false;
   this.swaggerObject = {};
   this.deferredClient = Q.defer();
+  this.proxy = null;
 
   this.clientAuthorizations = new auth.SwaggerAuthorizations();
 
@@ -109,6 +110,10 @@ var SwaggerClient = module.exports = function (url, options) {
     return this;
   }
 };
+
+SwaggerClient.prototype.setProxy = function(proxy) {
+  this.proxy = proxy;
+}
 
 SwaggerClient.prototype.initialize = function (url, options) {
   this.models = {};
@@ -132,6 +137,10 @@ SwaggerClient.prototype.initialize = function (url, options) {
 
   if (typeof options.success === 'function') {
     this.success = options.success;
+  }
+  
+  if (options.proxy) {
+    this.proxy = options.proxy;
   }
 
   if (options.useJQuery) {
@@ -229,6 +238,9 @@ SwaggerClient.prototype.build = function (mock) {
     if (mock) {
       return obj;
     }
+    
+    this.options = this.options || {};
+    this.options.proxy = this.proxy || null;
 
     new SwaggerHttp().execute(obj, this.options);
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -112,10 +112,13 @@ var SwaggerClient = module.exports = function (url, options) {
 };
 
 SwaggerClient.prototype.setProxy = function(proxy) {
+  console.log('Settings proxy to: ', proxy);
   this.proxy = proxy;
 }
 
 SwaggerClient.prototype.initialize = function (url, options) {
+  console.log('init with opts', options);
+  
   this.models = {};
   this.sampleModels = {};
 
@@ -241,6 +244,8 @@ SwaggerClient.prototype.build = function (mock) {
     
     this.options = this.options || {};
     this.options.proxy = this.proxy || null;
+    
+    console.log('will exec with', this.options);
 
     new SwaggerHttp().execute(obj, this.options);
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -114,6 +114,16 @@ var SwaggerClient = module.exports = function (url, options) {
 SwaggerClient.prototype.setProxy = function(proxy) {
   console.log('Settings proxy to: ', proxy);
   this.proxy = proxy;
+  
+  if(this.apis) {
+    _.forEach(this.apis, function(api) {
+      if(api.operations) {
+        _.forEach(api.operations, function(operation) {
+          operation.proxy = proxy;
+        });
+      }
+    });
+  }
 }
 
 SwaggerClient.prototype.initialize = function (url, options) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -112,7 +112,6 @@ var SwaggerClient = module.exports = function (url, options) {
 };
 
 SwaggerClient.prototype.setProxy = function(proxy) {
-  console.log('Settings proxy to: ', proxy);
   this.proxy = proxy;
   
   if(this.apis) {
@@ -180,8 +179,6 @@ SwaggerClient.prototype.initialize = function (url, options) {
 };
 
 SwaggerClient.prototype.build = function (mock) {
-  console.log('running build proxy value', this.proxy);
-  
   if (this.isBuilt) {
     return this;
   }

--- a/lib/http.js
+++ b/lib/http.js
@@ -2,6 +2,7 @@
 
 var helpers = require('./helpers');
 var request = require('superagent');
+require('superagent-proxy')(request);
 var jsyaml = require('js-yaml');
 var _ = {
   isObject: require('lodash-compat/lang/isObject')
@@ -17,8 +18,9 @@ var JQueryHttpClient = function () {
 /*
  * SuperagentHttpClient is a light-weight, node or browser HTTP client
  */
-var SuperagentHttpClient = function () {
+var SuperagentHttpClient = function (opts) {
   this.type = 'SuperagentHttpClient';
+  this.opts = opts || {};
 };
 
 /**
@@ -28,6 +30,14 @@ var SwaggerHttp = module.exports = function () {};
 
 SwaggerHttp.prototype.execute = function (obj, opts) {
   var client;
+  var proxy = null;
+  
+  if (process && process.env && process.env.http_proxy) {
+    proxy = process.env.http_proxy;
+  }
+  else if(opts.proxy && opts.proxy !== null) {
+    proxy = opts.proxy;
+  }
 
   if(opts && opts.client) {
     client = opts.client;
@@ -221,6 +231,13 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   }
   var headers = obj.headers || {};
   var r = request[method](obj.url);
+  
+  console.log("Proxy value:", this.proxy);
+  
+  if (this.proxy) {
+    r.proxy(this.proxy);
+  }
+  
   var name;
   for (name in headers) {
     r.set(name, headers[name]);

--- a/lib/http.js
+++ b/lib/http.js
@@ -240,8 +240,6 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   var headers = obj.headers || {};
   var r = request[method](obj.url);
   
-  console.log("Proxy value:", obj.proxy);
-  
   if (obj.proxy) {
     r.proxy(obj.proxy);
   }

--- a/lib/http.js
+++ b/lib/http.js
@@ -43,7 +43,7 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
   }
   
   if (proxy !== null) {
-    opts.proxy = proxy;
+    opts.proxy = obj.proxy = proxy;
   }
 
   if(opts && opts.client) {
@@ -52,6 +52,7 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
   else {
     client = new SuperagentHttpClient(opts);
   }
+  
   client.opts = opts || {};
 
   // legacy support
@@ -239,10 +240,10 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   var headers = obj.headers || {};
   var r = request[method](obj.url);
   
-  console.log("Proxy value:", this.proxy);
+  console.log("Proxy value:", obj.proxy);
   
-  if (this.proxy) {
-    r.proxy(this.proxy);
+  if (obj.proxy) {
+    r.proxy(obj.proxy);
   }
   
   var name;

--- a/lib/http.js
+++ b/lib/http.js
@@ -38,6 +38,13 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
   else if(opts.proxy && opts.proxy !== null) {
     proxy = opts.proxy;
   }
+  else {
+    proxy = this.proxy;
+  }
+  
+  if (proxy !== null) {
+    opts.proxy = proxy;
+  }
 
   if(opts && opts.client) {
     client = opts.client;

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -23,7 +23,6 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     this.responseInterceptor = parent.options.responseInterceptor || null;
   }
   
-  console.log('oper ctor proxy', proxy);
   this.proxy = proxy || null;
   this.authorizations = args.security;
   this.basePath = parent.basePath || '/';
@@ -659,10 +658,8 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     opts.client = this.client;
   }
   
-  console.log('exec oper', this);
-  
   if (this.proxy) {
-    opts.proxy = proxy;
+    opts.proxy = this.proxy;
   }
 
   // add the request interceptor from parent, if none sent from client

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -22,6 +22,8 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     this.requestInterceptor = parent.options.requestInterceptor || null;
     this.responseInterceptor = parent.options.responseInterceptor || null;
   }
+  
+  console.log('oper ctor proxy', proxy);
   this.proxy = proxy || null;
   this.authorizations = args.security;
   this.basePath = parent.basePath || '/';
@@ -656,6 +658,8 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   if(this.client) {
     opts.client = this.client;
   }
+  
+  console.log('exec oper', this);
   
   if (this.proxy) {
     opts.proxy = proxy;

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -11,7 +11,7 @@ var Model = require('./model');
 var SwaggerHttp = require('../http');
 var Q = require('q');
 
-var Operation = module.exports = function (parent, scheme, operationId, httpMethod, path, args, definitions, models, clientAuthorizations) {
+var Operation = module.exports = function (parent, scheme, operationId, httpMethod, path, args, definitions, models, clientAuthorizations, proxy) {
   var errors = [];
 
   parent = parent || {};
@@ -22,6 +22,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     this.requestInterceptor = parent.options.requestInterceptor || null;
     this.responseInterceptor = parent.options.responseInterceptor || null;
   }
+  this.proxy = proxy || null;
   this.authorizations = args.security;
   this.basePath = parent.basePath || '/';
   this.clientAuthorizations = clientAuthorizations;
@@ -655,6 +656,10 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   if(this.client) {
     opts.client = this.client;
   }
+  
+  if (this.proxy) {
+    opts.proxy = proxy;
+  }
 
   // add the request interceptor from parent, if none sent from client
   if(!opts.requestInterceptor && this.requestInterceptor ) {
@@ -676,7 +681,6 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     success = (success || this.parent.defaultSuccessCallback || helpers.log);
     error = (error || this.parent.defaultErrorCallback || helpers.log);
   }
-
 
   if (typeof opts.useJQuery === 'undefined') {
     opts.useJQuery = this.useJQuery;

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -734,6 +734,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     method: this.method.toUpperCase(),
     body: body,
     enableCookies: opts.enableCookies,
+    proxy: opts.proxy,
     useJQuery: opts.useJQuery,
     deferred: deferred,
     headers: headers,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "js-yaml": "^3.3.0",
     "lodash-compat": "^3.5.0",
     "q": "^1.4.1",
-    "superagent": "^1.2"
+    "superagent": "^1.2",
+    "superagent-proxy": "1.0.0"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
Uses superagent-proxy package . 

The proxy is can be set via "options" when creating the client. 
The http module will use the proccess http_proxy variable first, and later will use the proxy will set. 
Also, it is possible to update the proxy settings via "swaggerClient.setProxy()"
