### PR TITLE
fix to issue  #769 - tsv arrays seem broken but easy to fix

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -919,7 +919,7 @@ Operation.prototype.encodePathCollection = function (type, name, value) {
   if (type === 'ssv') {
     separator = '%20';
   } else if (type === 'tsv') {
-    separator = '\\t';
+    separator = '%09';
   } else if (type === 'pipes') {
     separator = '|';
   } else {
@@ -955,7 +955,7 @@ Operation.prototype.encodeQueryCollection = function (type, name, value) {
     } else if (type === 'ssv') {
       separator = '%20';
     } else if (type === 'tsv') {
-      separator = '\\t';
+      separator = '%09';
     } else if (type === 'pipes') {
       separator = '|';
     } else if (type === 'brackets') {

--- a/test/operation.js
+++ b/test/operation.js
@@ -68,7 +68,7 @@ describe('operations', function () {
     expect(url).toBe('http://localhost/path?quantity=3&weight=100.3');
   });
 
-  it('should generate a url with queryparams array, multi', function () {
+  it('should generate a url with queryparams array, csv', function () {
     var parameters = [
       intArrayQP
     ];
@@ -122,7 +122,7 @@ describe('operations', function () {
       intArray: [3,4,5]
     });
 
-    expect(url).toBe('http://localhost/path?intArray=3\\t4\\t5');
+    expect(url).toBe('http://localhost/path?intArray=3%094%095');
   });
 
   it('should generate a url with queryparams array, spaces', function () {
@@ -145,6 +145,28 @@ describe('operations', function () {
     });
 
     expect(url).toBe('http://localhost/path?intArray=3%204%205');
+  });
+
+  it('should generate a url with queryparams array, multi', function () {
+    var parameters = [
+      {
+        in: 'query',
+        name: 'intArray',
+        type: 'array',
+        items: {
+          type: 'integer',
+          format: 'int32'
+        },
+        collectionFormat: 'multi'
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/path', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    var url = op.urlify({
+      intArray: [3,4,5]
+    });
+
+    expect(url).toBe('http://localhost/path?intArray=3&intArray=4&intArray=5');
   });
 
   it('should generate a url with queryparams array, brackets', function () {


### PR DESCRIPTION
fixed array params with collectionFormat tsv on query and path to urlencode tab as %09. fixed tests. also added proper test for collectionFormat multi.