### PR TITLE
urlify function now removes URL fragment before building URL

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -447,7 +447,7 @@ Operation.prototype.getHeaderParams = function (args) {
 
 Operation.prototype.urlify = function (args) {
   var formParams = {};
-  var requestUrl = this.path;
+  var requestUrl = this.path.replace(/#.*/, ''); // remove URL fragment
   var querystring = ''; // grab params from the args, build the querystring along the way
 
   for (var i = 0; i < this.parameters.length; i++) {

--- a/test/operation.js
+++ b/test/operation.js
@@ -321,6 +321,39 @@ describe('operations', function () {
     expect(url).toBe('http://localhost/2015-01-30');
   });
 
+  it('should generate a url with empty-fragment removed from path', function () {
+    var parameters = [];
+    var op = new Operation({}, 'http', 'test', 'get', '/foo#', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    var url = op.urlify();
+
+    expect(url).toBe('http://localhost/foo');
+  });
+
+  it('should generate a url with fragment removed from path', function () {
+    var parameters = [
+      {
+        in: 'path',
+        name: 'name',
+        type: 'string'
+      },
+      {
+        in: 'query',
+        name: 'age',
+        type: 'integer',
+        format: 'int32'
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/foo/{name}#fragment', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    var url = op.urlify({
+      name: 'tony',
+      age: 42
+    });
+
+    expect(url).toBe('http://localhost/foo/tony?age=42');
+  });
+
   it('should get a string array signature', function () {
     var parameters = [
       { in: 'query', name: 'year', type: 'array', items: {type: 'string'} }
@@ -650,4 +683,3 @@ describe('operations', function () {
     expect(op.getBody({}, {name: 'Douglas Adams', quantity: 42}, {})).toEqual('quantity=42&name=Douglas%20Adams');
   });
 });
-


### PR DESCRIPTION
In the `urlify` function, if `this.path` contains a URL fragment, it blindly adds a URL query _after_ the URL fragment, which is incorrect.

This fix simply removes the URL fragment, before building the URL, because I don't think a user of swagger-js would have a need for URL fragments.

I use URL fragments in paths used with Swagger-UI, as a work-around to overload endpoints, so it would be great to get this fix in for Swagger UI 2.1.5 to incorporate.