### PR TITLE
Allow users to turn off jquery cache busting for get and head requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -66,7 +66,8 @@ var reservedClientTags = [
   'tagFromLabel',
   'title',
   'url',
-  'useJQuery'
+  'useJQuery',
+  'jqueryAjaxCache'
 ];
 // We have to keep track of the function/property names to avoid collisions for tag names which are used to allow the
 // following usage: 'client.apis.{tagName}'
@@ -98,6 +99,7 @@ var SwaggerClient = module.exports = function (url, options) {
   this.resourceCount = 0;
   this.url = null;
   this.useJQuery = false;
+  this.jqueryAjaxCache = false;
   this.swaggerObject = {};
   this.deferredClient = undefined;
 
@@ -138,9 +140,12 @@ SwaggerClient.prototype.initialize = function (url, options) {
   if (typeof options.success === 'function') {
     this.success = options.success;
   }
-
   if (options.useJQuery) {
     this.useJQuery = options.useJQuery;
+  }
+
+  if (options.jqueryAjaxCache) {
+    this.jqueryAjaxCache = options.jqueryAjaxCache;
   }
 
   if (options.enableCookies) {
@@ -175,6 +180,7 @@ SwaggerClient.prototype.build = function (mock) {
 
   var obj = {
     useJQuery: this.useJQuery,
+    jqueryAjaxCache: this.jqueryAjaxCache,
     url: this.url,
     method: 'get',
     headers: {

--- a/lib/http.js
+++ b/lib/http.js
@@ -128,8 +128,9 @@ JQueryHttpClient.prototype.execute = function (obj) {
   }
 
   obj.type = obj.method;
-  obj.cache = false;
+  obj.cache = obj.jqueryAjaxCache;
   obj.data = obj.body;
+  delete obj.jqueryAjaxCache;
   delete obj.useJQuery;
   delete obj.body;
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -45,6 +45,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.summary = args.summary || '';
   this.type = null;
   this.useJQuery = parent.useJQuery;
+  this.jqueryAjaxCache = parent.jqueryAjaxCache;
   this.enableCookies = parent.enableCookies;
   this.parameterMacro = parent.parameterMacro || function (operation, parameter) {
     return parameter.default;
@@ -700,6 +701,10 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     opts.useJQuery = this.useJQuery;
   }
 
+  if (typeof opts.jqueryAjaxCache === 'undefined') {
+    opts.jqueryAjaxCache = this.jqueryAjaxCache;
+  }
+
   if (typeof opts.enableCookies === 'undefined') {
     opts.enableCookies = this.enableCookies;
   }
@@ -748,6 +753,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     body: body,
     enableCookies: opts.enableCookies,
     useJQuery: opts.useJQuery,
+    jqueryAjaxCache: opts.jqueryAjaxCache,
     deferred: deferred,
     headers: headers,
     clientAuthorizations: opts.clientAuthorizations,

--- a/test/client.js
+++ b/test/client.js
@@ -306,6 +306,18 @@ describe('SwaggerClient', function () {
     });
   });
 
+  it('should use jqueryAjaxCache', function(done) {
+    var client = new SwaggerClient({
+      spec: petstoreRaw,
+      jqueryAjaxCache: true,
+      success: function () {
+        var result = client.pet.getPetById({petId: 3}, { mock: true });
+        expect(result.jqueryAjaxCache).toBe(true);
+        done();
+      }
+    });
+  });
+
   it('should force jQuery for options', function(done) {
     var spec = {
       swagger: '2.0',

--- a/test/request.js
+++ b/test/request.js
@@ -246,6 +246,18 @@ describe('swagger request functions', function () {
     expect(req.useJQuery).toBe(true);
   });
 
+  it('verifies jqueryAjaxCache is set', function () {
+    var petApi = sample.pet;
+    var req = petApi.getPetById({petId: 1}, {useJQuery: true, jqueryAjaxCache: true, mock: true});
+
+    test.object(req);
+
+    expect(req.method).toBe('GET');
+    expect(req.headers.Accept).toBe('application/json');
+    expect(req.url).toBe('http://localhost:8000/v2/api/pet/1');
+    expect(req.jqueryAjaxCache).toBe(true);
+  });
+
   it('does not add a query param if not set', function () {
     var petApi = sample.pet;
     var req = petApi.findPetsByStatus({}, {mock: true});


### PR DESCRIPTION
I am using swaggerUi with the `useJQuery` option set to true to be able to use our jquery polyfill for older browsers.
Currently in the JQueryHttpClient `cache: false` is hardcoded in ajax requests which results in all requests to go out and also appends a timestamp to query parameters to bust cache. This pull request tries to expose the option (with a default value of false on both the client and operations) for users to be able to set it to true (default jquery behavior). In each file I tried to do things the way they were already done.