### PR TITLE
Adds typeof check to window check

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -125,7 +125,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
 
   if(this.url && this.url.indexOf('http') === -1) {
     // no protocol, so we can only use window if it exists
-    if(window && window.location) {
+    if(typeof(window) !== 'undefined' && window && window.location) {
       this.url = window.location.origin + this.url;
     }
   }


### PR DESCRIPTION
Client.js needed a `typeof(window) !== 'undefined'` in order to prevent browserless testing in Mocha (and probably other testing suites) from throwing an error. Closes #804 