### PR TITLE
Add "fetching resource list" message for local (non-URL) spec

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -183,7 +183,11 @@ SwaggerClient.prototype.build = function (mock) {
 
   var self = this;
 
-  this.progress('fetching resource list: ' + this.url + '; Please wait.');
+  if (this.spec) {
+    this.progress('fetching resource list; Please wait.');
+  } else {
+    this.progress('fetching resource list: ' + this.url + '; Please wait.');
+  }
 
   var obj = {
     useJQuery: this.useJQuery,


### PR DESCRIPTION
If swagger-js is configured to load a local specification using the `spec` property (rather than a remote one using the `url` property), the loading message is currently:
```
fetching resource list: undefined; Please wait.
```
which is quite ugly.

This PR changes this to:
```
fetching resource list; Please wait.
```
when the `spec` property is defined.