### PR TITLE
Implementing Custom HTTP Headers Support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -63,6 +63,7 @@ var reservedClientTags = [
   'spec',
   'supportedSubmitMethods',
   'swaggerRequestHeaders',
+  'swaggerCustomRequestHeaders',
   'tagFromLabel',
   'title',
   'url',
@@ -102,6 +103,7 @@ var SwaggerClient = module.exports = function (url, options) {
   this.jqueryAjaxCache = false;
   this.swaggerObject = {};
   this.deferredClient = undefined;
+  this.swaggerCustomRequestHeaders = {};
 
   this.clientAuthorizations = new auth.SwaggerAuthorizations();
 
@@ -133,6 +135,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
   options = options || {};
   this.clientAuthorizations.add(options.authorizations);
   this.swaggerRequestHeaders = options.swaggerRequestHeaders || 'application/json;charset=utf-8,*/*';
+  this.swaggerCustomRequestHeaders = options.swaggerCustomRequestHeaders || {};
   this.defaultSuccessCallback = options.defaultSuccessCallback || null;
   this.defaultErrorCallback = options.defaultErrorCallback || null;
   this.modelPropertyMacro = options.modelPropertyMacro || null;
@@ -176,6 +179,14 @@ SwaggerClient.prototype.initialize = function (url, options) {
   }
 };
 
+// Merging Two Properties
+function mergeOptions(obj1,obj2){
+    var obj3 = {};
+    for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+    for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+    return obj3;
+}
+
 SwaggerClient.prototype.build = function (mock) {
   if (this.isBuilt) {
     return this;
@@ -194,9 +205,7 @@ SwaggerClient.prototype.build = function (mock) {
     jqueryAjaxCache: this.jqueryAjaxCache,
     url: this.url,
     method: 'get',
-    headers: {
-      accept: this.swaggerRequestHeaders
-    },
+    headers: mergeOptions(this.swaggerRequestHeaders, this.swaggerCustomRequestHeaders),
     on: {
       error: function (response) {
         if (self.url.substring(0, 4) !== 'http') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -63,7 +63,6 @@ var reservedClientTags = [
   'spec',
   'supportedSubmitMethods',
   'swaggerRequestHeaders',
-  'swaggerCustomRequestHeaders',
   'tagFromLabel',
   'title',
   'url',
@@ -103,7 +102,7 @@ var SwaggerClient = module.exports = function (url, options) {
   this.jqueryAjaxCache = false;
   this.swaggerObject = {};
   this.deferredClient = undefined;
-  this.swaggerCustomRequestHeaders = {};
+  this.customRequestHeaders = {};
 
   this.clientAuthorizations = new auth.SwaggerAuthorizations();
 
@@ -134,14 +133,13 @@ SwaggerClient.prototype.initialize = function (url, options) {
 
   options = options || {};
   this.clientAuthorizations.add(options.authorizations);
-  this.swaggerRequestHeaders = options.swaggerRequestHeaders || 'application/json;charset=utf-8,*/*';
-  this.swaggerCustomRequestHeaders = options.swaggerCustomRequestHeaders || {};
+  this.swaggerRequestHeaders = options.swaggerRequestHeaders || { accept: 'application/json;charset=utf-8,*/*' };
+  this.customRequestHeaders = options.customRequestHeaders || {};
   this.defaultSuccessCallback = options.defaultSuccessCallback || null;
   this.defaultErrorCallback = options.defaultErrorCallback || null;
   this.modelPropertyMacro = options.modelPropertyMacro || null;
   this.parameterMacro = options.parameterMacro || null;
   this.usePromise = options.usePromise || null;
-
 
   if(this.usePromise) {
     this.deferredClient = Q.defer();
@@ -181,6 +179,8 @@ SwaggerClient.prototype.initialize = function (url, options) {
 
 // Merging Two Properties
 function mergeOptions(obj1,obj2){
+    //var obj1 = JSON.parse(input1);
+    //var obj2 = JSON.parse(input2);
     var obj3 = {};
     for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
     for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
@@ -205,7 +205,7 @@ SwaggerClient.prototype.build = function (mock) {
     jqueryAjaxCache: this.jqueryAjaxCache,
     url: this.url,
     method: 'get',
-    headers: mergeOptions(this.swaggerRequestHeaders, this.swaggerCustomRequestHeaders),
+    headers: mergeOptions(this.swaggerRequestHeaders, this.customRequestHeaders),
     on: {
       error: function (response) {
         if (self.url.substring(0, 4) !== 'http') {
@@ -260,7 +260,6 @@ SwaggerClient.prototype.build = function (mock) {
     if (mock) {
       return obj;
     }
-
     new SwaggerHttp().execute(obj, this.options);
   }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -11,46 +11,51 @@ var _ = {
 /*
  * JQueryHttpClient is a light-weight, node or browser HTTP client
  */
-var JQueryHttpClient = function () {
+var JQueryHttpClient = function() {
   this.type = 'JQueryHttpClient';
 };
 
 /*
  * SuperagentHttpClient is a light-weight, node or browser HTTP client
  */
-var SuperagentHttpClient = function () {
+var SuperagentHttpClient = function() {
   this.type = 'SuperagentHttpClient';
 };
 
 /**
  * SwaggerHttp is a wrapper for executing requests
  */
-var SwaggerHttp = module.exports = function () {};
-
-SwaggerHttp.prototype.execute = function (obj, opts) {
+var SwaggerHttp = module.exports = function() {};
+var customHeaders;
+SwaggerHttp.prototype.execute = function(obj, opts) {
   var client;
 
-  if(opts && opts.client) {
-    client = opts.client;
+  // Save Custom Headers
+  if (!customHeaders) {
+    customHeaders = obj.headers;
   }
-  else {
+  obj.headers = customHeaders;
+
+  if (opts && opts.client) {
+    client = opts.client;
+  } else {
     client = new SuperagentHttpClient(opts);
   }
   client.opts = opts || {};
 
   // legacy support
   var hasJQuery = false;
-  if(typeof window !== 'undefined') {
-    if(typeof window.jQuery !== 'undefined') {
+  if (typeof window !== 'undefined') {
+    if (typeof window.jQuery !== 'undefined') {
       hasJQuery = true;
     }
   }
   // OPTIONS support
-  if(obj.method.toLowerCase() === 'options' && client.type === 'SuperagentHttpClient') {
+  if (obj.method.toLowerCase() === 'options' && client.type === 'SuperagentHttpClient') {
     log('forcing jQuery as OPTIONS are not supported by SuperAgent');
     obj.useJQuery = true;
   }
-  if(this.isInternetExplorer() && (obj.useJQuery === false || !hasJQuery )) {
+  if (this.isInternetExplorer() && (obj.useJQuery === false || !hasJQuery)) {
     throw new Error('Unsupported configuration! JQuery is required but not available');
   }
   if ((obj && obj.useJQuery === true) || this.isInternetExplorer() && hasJQuery) {
@@ -61,21 +66,21 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
   var error = obj.on.error;
 
   var requestInterceptor = function(data) {
-    if(opts && opts.requestInterceptor) {
+    if (opts && opts.requestInterceptor) {
       data = opts.requestInterceptor.apply(data);
     }
     return data;
   };
 
   var responseInterceptor = function(data) {
-    if(opts && opts.responseInterceptor) {
+    if (opts && opts.responseInterceptor) {
       data = opts.responseInterceptor.apply(data);
     }
     return success(data);
   };
 
   var errorInterceptor = function(data) {
-    if(opts && opts.responseInterceptor) {
+    if (opts && opts.responseInterceptor) {
       data = opts.responseInterceptor.apply(data);
     }
     error(data);
@@ -91,8 +96,8 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
 
   if (_.isObject(obj) && _.isObject(obj.body)) {
     // special processing for file uploads via jquery
-    if (obj.body.type && obj.body.type === 'formData'){
-      if(opts.useJQuery) {
+    if (obj.body.type && obj.body.type === 'formData') {
+      if (opts.useJQuery) {
         obj.contentType = false;
         obj.processData = false;
         delete obj.headers['Content-Type'];
@@ -112,7 +117,7 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
   return (obj.deferred) ? obj.deferred.promise : obj;
 };
 
-SwaggerHttp.prototype.isInternetExplorer = function () {
+SwaggerHttp.prototype.isInternetExplorer = function() {
   var detectedIE = false;
 
   if (typeof navigator !== 'undefined' && navigator.userAgent) {
@@ -130,12 +135,12 @@ SwaggerHttp.prototype.isInternetExplorer = function () {
   return detectedIE;
 };
 
-JQueryHttpClient.prototype.execute = function (obj) {
+JQueryHttpClient.prototype.execute = function(obj) {
   var jq = this.jQuery || (typeof window !== 'undefined' && window.jQuery);
   var cb = obj.on;
   var request = obj;
 
-  if(typeof jq === 'undefined' || jq === false) {
+  if (typeof jq === 'undefined' || jq === false) {
     throw new Error('Unsupported configuration! JQuery is required but not available');
   }
 
@@ -146,7 +151,7 @@ JQueryHttpClient.prototype.execute = function (obj) {
   delete obj.useJQuery;
   delete obj.body;
 
-  obj.complete = function (response) {
+  obj.complete = function(response) {
     var headers = {};
     var headerArray = response.getAllResponseHeaders().split('\n');
 
@@ -182,7 +187,7 @@ JQueryHttpClient.prototype.execute = function (obj) {
     };
 
     try {
-      var possibleObj =  response.responseJSON || jsyaml.safeLoad(response.responseText);
+      var possibleObj = response.responseJSON || jsyaml.safeLoad(response.responseText);
       out.obj = (typeof possibleObj === 'string') ? {} : possibleObj;
     } catch (ex) {
       // do not set out.obj
@@ -206,7 +211,7 @@ JQueryHttpClient.prototype.execute = function (obj) {
   return jq.ajax(obj);
 };
 
-SuperagentHttpClient.prototype.execute = function (obj) {
+SuperagentHttpClient.prototype.execute = function(obj) {
   var method = obj.method.toLowerCase();
 
   if (method === 'delete') {
@@ -219,61 +224,61 @@ SuperagentHttpClient.prototype.execute = function (obj) {
     r.withCredentials();
   }
 
-  if(obj.body) {
-    if(_.isObject(obj.body)) {
+  if (obj.body) {
+    if (_.isObject(obj.body)) {
       var contentType = obj.headers['Content-Type'] || '';
       if (contentType.indexOf('multipart/form-data') === 0) {
         delete headers['Content-Type'];
-        if({}.toString.apply(obj.body) === '[object FormData]') {
+        if ({}.toString.apply(obj.body) === '[object FormData]') {
           var itr = obj.body.keys();
-          while(true) {
+          while (true) {
             var v = itr.next();
-            if(v.done) {
+            if (v.done) {
               break;
             }
             var key = v.value;
             var value = obj.body.get(key);
             console.log({}.toString.apply(value));
-            if({}.toString.apply(value) === '[object File]') {
+            if ({}.toString.apply(value) === '[object File]') {
               r.attach(key, value);
-            }
-            else {
+            } else {
               r.field(key, value);
             }
           }
-        }
-        else {
+        } else {
           var keyname;
           for (var keyname in obj.body) {
             var value = obj.body[keyname];
             r.field(keyname, value);
           }
         }
-      }
-      else if (_.isObject(obj.body)) {
+      } else if (_.isObject(obj.body)) {
         obj.body = JSON.stringify(obj.body);
         r.send(obj.body);
       }
-    }
-    else {
+    } else {
       r.send(obj.body);
     }
   }
 
   var name;
+
   for (name in headers) {
     r.set(name, headers[name]);
   }
 
-  if(typeof r.buffer === 'function') {
+  if (typeof r.buffer === 'function') {
     r.buffer(); // force superagent to populate res.text with the raw response data
   }
 
-  r.end(function (err, res) {
+  r.end(function(err, res) {
     res = res || {
       status: 0,
-      headers: {error: 'no response from server'}
+      headers: {
+        error: 'no response from server'
+      }
     };
+
     var response = {
       url: obj.url,
       method: obj.method,
@@ -289,12 +294,11 @@ SuperagentHttpClient.prototype.execute = function (obj) {
       response.errObj = err;
       response.status = res ? res.status : 500;
       response.statusText = res ? res.text : err.message;
-      if(res.headers && res.headers['content-type']) {
-        if(res.headers['content-type'].indexOf('application/json') >= 0) {
+      if (res.headers && res.headers['content-type']) {
+        if (res.headers['content-type'].indexOf('application/json') >= 0) {
           try {
             response.obj = JSON.parse(response.statusText);
-          }
-          catch (e) {
+          } catch (e) {
             response.obj = null;
           }
         }
@@ -304,16 +308,16 @@ SuperagentHttpClient.prototype.execute = function (obj) {
       var possibleObj;
 
       // Already parsed by by superagent?
-      if(res.body && _.keys(res.body).length > 0) {
+      if (res.body && _.keys(res.body).length > 0) {
         possibleObj = res.body;
       } else {
-          try {
-            possibleObj = jsyaml.safeLoad(res.text);
-            // can parse into a string... which we don't need running around in the system
-            possibleObj = (typeof possibleObj === 'string') ? null : possibleObj;
-          } catch(e) {
-            helpers.log('cannot parse JSON/YAML content');
-          }
+        try {
+          possibleObj = jsyaml.safeLoad(res.text);
+          // can parse into a string... which we don't need running around in the system
+          possibleObj = (typeof possibleObj === 'string') ? null : possibleObj;
+        } catch (e) {
+          helpers.log('cannot parse JSON/YAML content');
+        }
       }
 
       // null means we can't parse into object


### PR DESCRIPTION
This is my workaround to pass-in custom HTTP Header to the Swagger Client. When the code seems covers the flow, I'm not sure which part that cause the "execute" function executed twice. And on the second call, the HTTP Headers is reset to default. Please review ...