### PR TITLE
add test to resolve $ref within allOf construct

### DIFF
--- a/test/resolver.js
+++ b/test/resolver.js
@@ -938,6 +938,35 @@ describe('swagger resolver', function () {
     sample = new SwaggerClient(opts);
   });
 
+  it('should resolve external references within allOf', function (done) {
+    var sample;
+    var opts = opts || {};
+    opts.url = opts.url || 'http://localhost:8000/v2/externalRefInAllOf.json';
+        
+    opts.success = function () {
+        var response = sample.apis.Queries.operations.getAsync.successResponse;
+
+        expect(response).toExist();
+        expect(response["200"]).toExist();
+           
+        //JSON sample is not resolved is $ref used within allOf
+        var jsonSample = response["200"].createJSONSample();
+            
+        expect(jsonSample).toExist();
+        expect(jsonSample.error).toExist();
+        expect(jsonSample.value).toExist();
+
+        var mockSignature = response['200'].getMockSignature();
+        expect(mockSignature).toExist();
+        expect(mockSignature.indexOf('http://localhost:8000/v2/externalRef.json#/definitions/ErrorResponse')).toBe(-1);
+        expect(mockSignature.indexOf('http://localhost:8000/v2/externalRef.json#/definitions/Order')).toBe(-1);
+
+        done();
+    };
+
+    sample = new SwaggerClient(opts);
+  });
+
   it('resolves absolute references per #587', function(done) {
     var sample;
     var opts = opts || {};

--- a/test/spec/v2/externalRefInAllOf.json
+++ b/test/spec/v2/externalRefInAllOf.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Customer"
+  },
+  "tags": [
+    {
+      "name": "Queries",
+      "description": "Query the Customer domain"
+    }
+  ],
+  "paths": {
+    "/get/{id}": {
+      "get": {
+        "tags": [
+          "Queries"
+        ],
+        "summary": "get Summary",
+        "description": "get Description",
+        "operationId": "getAsync",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "resource id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OrderQueryGetResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+	},
+  "definitions": {
+	"ValidationError": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ]
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValidationError"
+          }
+        }
+      },
+      "required": [
+        "message"
+      ]
+    },
+    "QueryResponse": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "action": {
+          "type": "string"
+        },
+        "error": {
+          "$ref": "#/definitions/ErrorResponse"
+        }
+      },
+      "required": [
+        "source",
+        "schema",
+        "domain",
+        "action"
+      ]
+    },
+    "OrderValue": {
+        "type": "object",
+        "properties": {
+            "value": {
+                "$ref": "http://petstore.swagger.io/v2/swagger.json#/definitions/Order"
+            }
+        },
+        "required": [
+            "value"
+        ]
+    },
+    "OrderQueryGetResponse": {
+        "type": "object",
+        "properties": {
+            "response": {
+                "$ref": "#/definitions/QueryResponse"
+            },
+            "value": {
+                "$ref": "#/definitions/Order"
+            }
+        }
+    }
+  }
+}


### PR DESCRIPTION
Based on issue raised on swagger-ui (#2304) [https://github.com/swagger-api/swagger-ui/issues/2304 ](url), as suggested I added a test case 2 with $ref within an allOf construct that does not resolve correctly within swagger-ui.
