### PR TITLE
Fix {$ref: "/domain/based/path/"} resolving

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -483,7 +483,7 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
 
         for (key in resolvedTo.obj) {
           var abs = resolvedTo.obj[key];
-          
+
           if (localResolve !== true) {
             // don't retain root for local definitions
             abs = this.retainRoot(key, resolvedTo.obj[key], item.root);
@@ -561,6 +561,10 @@ Resolver.prototype.getRefs = function(spec, obj) {
   return output;
 };
 
+function isAbsoluteUrl(url){
+    return url.indexOf('http://') === 0 || url.indexOf('https://') === 0;
+}
+
 Resolver.prototype.retainRoot = function(origKey, obj, root) {
   // walk object and look for relative $refs
   if(_.isObject(obj)) {
@@ -568,24 +572,29 @@ Resolver.prototype.retainRoot = function(origKey, obj, root) {
       var item = obj[key];
       if (key === '$ref' && typeof item === 'string') {
         // stop and inspect
-        if (item.indexOf('http:') !== 0 && item.indexOf('https:') !== 0) {
-          // TODO: check if root ends in '/'.  If not, AND item has no protocol, make relative
-          var appendHash = true;
+        if (!isAbsoluteUrl(item)){
           var oldRoot = root;
           if (root) {
-            var lastChar = root.slice(-1);
-            if (lastChar !== '/' && (item.indexOf('#') !== 0 && item.indexOf('http:') !== 0 && item.indexOf('https:'))) {
-              appendHash = false;
-              var parts = root.split('\/');
-              parts = parts.splice(0, parts.length - 1);
-              root = '';
-              for (var i = 0; i < parts.length; i++) {
-                root += parts[i] + '/';
+            if (item.indexOf('/') === 0 && isAbsoluteUrl(root)){
+              // url isn't relative, root must be domain part only
+              root = root.split('/').splice(0, 3).join('/');
+            } else {
+              // TODO: check if root ends in '/'.  If not, AND item has no protocol, make relative
+              var appendHash = true;
+              var lastChar = root.slice(-1);
+              if (lastChar !== '/' && (item.indexOf('#') !== 0 && item.indexOf('http:') !== 0 && item.indexOf('https:'))) {
+                appendHash = false;
+                var parts = root.split('\/');
+                parts = parts.splice(0, parts.length - 1);
+                root = '';
+                for (var i = 0; i < parts.length; i++) {
+                  root += parts[i] + '/';
+                }
+              }
+              if (item.indexOf('#') !== 0 && appendHash) {
+                item = '#' + item;
               }
             }
-          }
-          if (item.indexOf('#') !== 0 && appendHash) {
-            item = '#' + item;
           }
 
           item = (root || '') + item;

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -561,8 +561,59 @@ Resolver.prototype.getRefs = function(spec, obj) {
   return output;
 };
 
-function isAbsoluteUrl(url){
-    return url.indexOf('http://') === 0 || url.indexOf('https://') === 0;
+function splitUrl(url) {
+  var result = {};
+  var proto = /[a-z]+:\/\//i.exec(url);
+  if (proto) {
+    result.proto = proto[0].slice(0, -3);
+    url = url.slice(result.proto.length + 1);
+  }
+  if (url.slice(0, 2) === '//') {
+    result.domain = url.slice(2).split('/')[0];
+    url = url.slice(2 + result.domain.length);
+  }
+  var p = url.split('#');
+  if (p[0].length) result.path = p[0];
+  if (p.length > 1) result.fragment = p.slice(1).join('#');
+  return result;
+}
+
+function unsplitUrl(url) {
+  var result = url.path;
+  if (result === undefined) result = '';
+  if (url.fragment !== undefined) result += '#' + url.fragment;
+  if (url.domain !== undefined) {
+    if (result.slice(0, 1) === '/') result = result.slice(1);
+    result = '//' + url.domain + '/' + result;
+    if (url.proto !== undefined) result = url.proto + ':' + result;
+  }
+  return result;
+}
+
+function joinUrl(base, rel) {
+  var relsp = splitUrl(rel);
+  if (relsp.domain !== undefined) return rel;
+  var result = splitUrl(base);
+  if (relsp.path === undefined) {
+    // change only fragment part
+    result.fragment = relsp.fragment;
+  } else if (relsp.path.slice(0, 1) === '/') {
+    // relative to domain
+    result.path = relsp.path;
+    result.fragment = relsp.fragment;
+  } else {
+    // relative to path
+    var path = result.path === undefined ? [] : result.path.split('/');
+    var relpath = relsp.path.split('/');
+    if (path.length) path.pop();
+    while (relpath[0] === '..' || relpath[0] === '.') {
+      if (relpath[0] === '..') path.pop();
+      relpath.shift();
+    }
+    result.path = path.concat(relpath).join('/');
+    result.fragment = relsp.fragment;
+  }
+  return unsplitUrl(result);
 }
 
 Resolver.prototype.retainRoot = function(origKey, obj, root) {
@@ -571,35 +622,7 @@ Resolver.prototype.retainRoot = function(origKey, obj, root) {
     for(var key in obj) {
       var item = obj[key];
       if (key === '$ref' && typeof item === 'string') {
-        // stop and inspect
-        if (!isAbsoluteUrl(item)){
-          var oldRoot = root;
-          if (root) {
-            if (item.indexOf('/') === 0 && isAbsoluteUrl(root)){
-              // url isn't relative, root must be domain part only
-              root = root.split('/').splice(0, 3).join('/');
-            } else {
-              // TODO: check if root ends in '/'.  If not, AND item has no protocol, make relative
-              var appendHash = true;
-              var lastChar = root.slice(-1);
-              if (lastChar !== '/' && (item.indexOf('#') !== 0 && item.indexOf('http:') !== 0 && item.indexOf('https:'))) {
-                appendHash = false;
-                var parts = root.split('\/');
-                parts = parts.splice(0, parts.length - 1);
-                root = '';
-                for (var i = 0; i < parts.length; i++) {
-                  root += parts[i] + '/';
-                }
-              }
-              if (item.indexOf('#') !== 0 && appendHash) {
-                item = '#' + item;
-              }
-            }
-          }
-
-          item = (root || '') + item;
-          obj[key] = item;
-        }
+        obj[key] = joinUrl(root, item);
       }
       else if (_.isObject(item)) {
         this.retainRoot(key, item, root);
@@ -607,10 +630,7 @@ Resolver.prototype.retainRoot = function(origKey, obj, root) {
     }
   }
   else if(_.isString(obj) && origKey === '$ref') {
-    // look at the ref?
-    if(obj.indexOf('http:') === -1 && obj.indexOf('https:') === -1) {
-      obj = root + obj;
-    }
+    obj = joinUrl(root, obj);
   }
   return obj;
 };

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -21,7 +21,7 @@ describe('swagger resolver', function () {
     instance.close();
     done();
   });
-  
+
   it('is OK without remote references', function (done) {
     var api = new Resolver();
     var spec = {};
@@ -455,6 +455,26 @@ describe('swagger resolver', function () {
     });
   });
 
+  it('resolves relative references absolute to root multiple times', function(done) {
+    var api = new Resolver();
+    var spec = {
+      host: 'http://petstore.swagger.io',
+      basePath: '/v2',
+      paths: {},
+      definitions: {
+        Pet: {
+          $ref: '/v2/relativeToRoot.json#/definitions/intermediatePet'
+        }
+      }
+    };
+
+    api.resolve(spec, 'http://localhost:8000/foo/bar/swagger.json', function (spec) {
+      // check our double $ref unwrapped into final Pet object
+      expect(spec.definitions.Pet.required).toEqual(["name", "photoUrls"]);
+      done();
+    });
+  });
+
   it('resolves relative references relative to reference', function(done) {
     var api = new Resolver();
     var spec = {
@@ -791,7 +811,7 @@ describe('swagger resolver', function () {
       done();
     });
   });
-  
+
   it('does not make multiple calls for parameter refs #489', function(done) {
     var api = new Resolver();
     var spec = {
@@ -1188,7 +1208,7 @@ describe('swagger resolver', function () {
   it('base model properties', function(done) {
     var api = new Resolver();
     var spec = {
-     
+
       swagger:'2.0',
       info:{
       },
@@ -1218,7 +1238,7 @@ describe('swagger resolver', function () {
           allOf: [
             {
               '$ref': '#/definitions/Pet'
-            }, 
+            },
             {
               type: 'object',
               properties:{
@@ -1243,10 +1263,10 @@ describe('swagger resolver', function () {
       }
     };
     api.resolve(spec, 'http://localhost:8000/v2/swagger.json', function (spec) {
-        
+
       expect(spec.definitions.Pet.properties.color['$ref']).toBe('#/definitions/Color');
       expect(spec.definitions.Cat.properties.color['$ref']).toBe('#/definitions/Color');
-      
+
       done();
     });
   });

--- a/test/spec/v2/relativeToRoot.json
+++ b/test/spec/v2/relativeToRoot.json
@@ -1,0 +1,7 @@
+{
+  "definitions" : {
+    "intermediatePet": {
+      "$ref": "/v2/petstore.json#/definitions/Pet"
+    }
+  }
+}


### PR DESCRIPTION
My spec heavily uses refs like `/api/1/something.json` without domain part, but not relative like `./some.json` or `../../some.json`. Before this fix swagger UI did fail with exception and become unusable.