### PR TITLE
make header parameters case insensitive

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -430,20 +430,26 @@ Operation.prototype.supportedSubmitMethods = function () {
 
 Operation.prototype.getHeaderParams = function (args) {
   var headers = this.setContentTypes(args, {});
+  var headerParamsByLowerCase = {};
 
   for (var i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
 
-    if (typeof args[param.name] !== 'undefined') {
-      if (param.in === 'header') {
-        var value = args[param.name];
+    if (param.in === 'header') {
+      headerParamsByLowerCase[param.name.toLowerCase()] = param;
+    }
+  }
 
-        if (Array.isArray(value)) {
-          value = value.toString();
-        }
+  for (var arg in args) {
+    var headerParam = headerParamsByLowerCase[arg.toLowerCase()];
+    if (typeof headerParam !== 'undefined') {
+      var value = args[arg];
 
-        headers[param.name] = value;
+      if (Array.isArray(value)) {
+        value = value.toString();
       }
+
+      headers[headerParam.name] = value;
     }
   }
 

--- a/test/headers.js
+++ b/test/headers.js
@@ -25,6 +25,24 @@ describe('header extraction', function () {
     expect(headers.myHeader).toBe('tony');
   });
 
+  it('should extract header params with case insensitivity', function () {
+    var parameters = [
+      {
+        in: 'header',
+        name: 'myHeader',
+        type: 'string'
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/path', { parameters: parameters });
+    var args = {
+      MyHeAdeR: 'nick'
+    };
+    var url = op.urlify(args);
+    var headers = op.getHeaderParams(args);
+
+    expect(url).toBe('http://localhost/path');
+    expect(headers.myHeader).toBe('nick');
+  });
 
   it('should not URL encode header string values', function () {
     var parameters = [


### PR DESCRIPTION
Allows header parameters to be passed insensitive to case, conforming to [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)