### PR TITLE
Timeout support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -138,7 +138,13 @@ SwaggerClient.prototype.initialize = function (url, options) {
   this.modelPropertyMacro = options.modelPropertyMacro || null;
   this.parameterMacro = options.parameterMacro || null;
   this.usePromise = options.usePromise || null;
-  this.timeout = options.timeout;
+
+  // operation request timeout default
+  this.timeout = options.timeout || null;
+  // default to request timeout when not specified
+  this.fetchSpecTimeout = typeof options.fetchSpecTimeout !== 'undefined'
+    ? options.fetchSpecTimeout
+    : options.timeout || null;
 
   if(this.usePromise) {
     this.deferredClient = Q.defer();
@@ -160,6 +166,10 @@ SwaggerClient.prototype.initialize = function (url, options) {
   }
 
   this.options = options || {};
+
+  // maybe don't need this?
+  this.options.timeout = this.timeout;
+  this.options.fetchSpecTimeout = this.fetchSpecTimeout;
 
   this.supportedSubmitMethods = options.supportedSubmitMethods || [];
   this.failure = options.failure || function (err) { throw err; };
@@ -194,7 +204,6 @@ SwaggerClient.prototype.build = function (mock) {
     jqueryAjaxCache: this.jqueryAjaxCache,
     url: this.url,
     method: 'get',
-    timeout: this.timeout,
     headers: {
       accept: this.swaggerRequestHeaders
     },
@@ -202,6 +211,8 @@ SwaggerClient.prototype.build = function (mock) {
       error: function (response) {
         if (self.url.substring(0, 4) !== 'http') {
           return self.fail('Please specify the protocol for ' + self.url);
+        } else if (response.errObj && (response.errObj.code === 'ECONNABORTED' || response.errObj.message.indexOf('timeout') != -1)) {
+          return self.fail('Request timed out after ' + self.fetchSpecTimeout + 'ms');
         } else if (response.status === 0) {
           return self.fail('Can\'t read from server.  It may not have the appropriate access-control-origin settings.');
         } else if (response.status === 404) {
@@ -241,10 +252,15 @@ SwaggerClient.prototype.build = function (mock) {
     }
   };
 
+  // only set timeout when specified
+  if (this.fetchSpecTimeout) {
+    obj.timeout = this.fetchSpecTimeout;
+  }
+
   if (this.spec) {
     self.swaggerObject = this.spec;
     setTimeout(function () {
-      new Resolver().resolve(self.spec, self.url, self.buildFromSpec, self, self.timeout);
+      new Resolver().resolve(self.spec, self.url, self.buildFromSpec, self);
     }, 10);
   } else {
     this.clientAuthorizations.apply(obj);

--- a/lib/client.js
+++ b/lib/client.js
@@ -138,7 +138,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
   this.modelPropertyMacro = options.modelPropertyMacro || null;
   this.parameterMacro = options.parameterMacro || null;
   this.usePromise = options.usePromise || null;
-
+  this.timeout = options.timeout;
 
   if(this.usePromise) {
     this.deferredClient = Q.defer();
@@ -194,6 +194,7 @@ SwaggerClient.prototype.build = function (mock) {
     jqueryAjaxCache: this.jqueryAjaxCache,
     url: this.url,
     method: 'get',
+    timeout: this.timeout,
     headers: {
       accept: this.swaggerRequestHeaders
     },
@@ -243,7 +244,7 @@ SwaggerClient.prototype.build = function (mock) {
   if (this.spec) {
     self.swaggerObject = this.spec;
     setTimeout(function () {
-      new Resolver().resolve(self.spec, self.url, self.buildFromSpec, self);
+      new Resolver().resolve(self.spec, self.url, self.buildFromSpec, self, self.timeout);
     }, 10);
   } else {
     this.clientAuthorizations.apply(obj);

--- a/lib/http.js
+++ b/lib/http.js
@@ -208,12 +208,18 @@ JQueryHttpClient.prototype.execute = function (obj) {
 
 SuperagentHttpClient.prototype.execute = function (obj) {
   var method = obj.method.toLowerCase();
+  var timeout = obj.timeout;
 
   if (method === 'delete') {
     method = 'del';
   }
   var headers = obj.headers || {};
   var r = request[method](obj.url);
+
+  if (timeout) {
+    console.log('Timeout specified:', timeout);
+    r.timeout(timeout);
+  }
 
   if (obj.enableCookies) {
     r.withCredentials();

--- a/lib/http.js
+++ b/lib/http.js
@@ -217,7 +217,6 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   var r = request[method](obj.url);
 
   if (timeout) {
-    console.log('Timeout specified:', timeout);
     r.timeout(timeout);
   }
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -39,11 +39,19 @@ Resolver.prototype.processAllOf = function(root, name, definition, resolutionTab
 Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
   this.spec = spec;
   var root = arg1, callback = arg2, scope = arg3, opts = {}, location, i;
+
   if(typeof arg1 === 'function') {
     root = null;
     callback = arg1;
     scope = arg2;
   }
+
+  var timeout;
+
+  if (scope) {
+    timeout = scope.timeout;
+  }
+
   var _root = root;
   this.scope = (scope || this);
   this.iteration = this.iteration || 0;
@@ -327,6 +335,7 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
       }
       else if(self.failedUrls.indexOf(item.root) === -1) {
         var obj = {
+          timeout: timeout,
           useJQuery: false,  // TODO
           url: item.root,
           method: 'get',

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -39,19 +39,11 @@ Resolver.prototype.processAllOf = function(root, name, definition, resolutionTab
 Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
   this.spec = spec;
   var root = arg1, callback = arg2, scope = arg3, opts = {}, location, i;
-
   if(typeof arg1 === 'function') {
     root = null;
     callback = arg1;
     scope = arg2;
   }
-
-  var timeout;
-
-  if (scope) {
-    timeout = scope.timeout;
-  }
-
   var _root = root;
   this.scope = (scope || this);
   this.iteration = this.iteration || 0;
@@ -335,7 +327,6 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
       }
       else if(self.failedUrls.indexOf(item.root) === -1) {
         var obj = {
-          timeout: timeout,
           useJQuery: false,  // TODO
           url: item.root,
           method: 'get',
@@ -376,6 +367,11 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
             }
           } // jshint ignore:line
         };
+
+        // apply timeout only when specified
+        if (scope && scope.fetchSpecTimeout) {
+          obj.timeout = scope.fetchSpecTimeout;
+        }
 
         if (scope && scope.clientAuthorizations) {
           scope.clientAuthorizations.apply(obj);
@@ -492,7 +488,7 @@ Resolver.prototype.finish = function (spec, root, resolutionTable, resolvedRefs,
 
         for (key in resolvedTo.obj) {
           var abs = resolvedTo.obj[key];
-          
+
           if (localResolve !== true) {
             // don't retain root for local definitions
             abs = this.retainRoot(key, resolvedTo.obj[key], item.root);

--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -496,7 +496,8 @@ SwaggerSpecConverter.prototype.resourceListing = function(obj, swagger, opts, ca
       url: absolutePath,
       headers: { accept: swaggerRequestHeaders },
       on: {},
-      method: 'get'
+      method: 'get',
+      timeout: opts.timeout
     };
     /* jshint ignore:start */
     http.on.response = function(data) {

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -43,6 +43,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.schemes = args.schemes || parent.schemes;
   this.security = args.security || parent.security;
   this.summary = args.summary || '';
+  this.timeout = parent.timeout;
   this.type = null;
   this.useJQuery = parent.useJQuery;
   this.jqueryAjaxCache = parent.jqueryAjaxCache;
@@ -705,19 +706,17 @@ Operation.prototype.do = function (args, opts, callback, error, parent) {
  **/
 Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   var args = arg1 || {};
-  var timeout;
-
-  if (args.timeout) {
-    timeout = args.timeout;
-  }
-
-  var opts = {}, success, error, deferred;
+  var opts = {}, success, error, deferred, timeout;
 
   if (_.isObject(arg2)) {
     opts = arg2;
     success = arg3;
     error = arg4;
   }
+
+  timeout = typeof opts.timeout !== 'undefined'
+    ? opts.timeout
+    : this.timeout;
 
   if(this.client) {
     opts.client = this.client;
@@ -795,7 +794,6 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   }
 
   var obj = {
-    timeout: timeout || this.parent.timeout,
     url: url,
     method: this.method.toUpperCase(),
     body: body,
@@ -824,6 +822,10 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
       }
     }
   };
+
+  if (timeout) {
+    obj.timeout = timeout;
+  }
 
   this.clientAuthorizations.apply(obj, this.operation.security);
   if (opts.mock === true) {

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -705,6 +705,12 @@ Operation.prototype.do = function (args, opts, callback, error, parent) {
  **/
 Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   var args = arg1 || {};
+  var timeout;
+
+  if (args.timeout) {
+    timeout = args.timeout;
+  }
+
   var opts = {}, success, error, deferred;
 
   if (_.isObject(arg2)) {
@@ -789,6 +795,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
   }
 
   var obj = {
+    timeout: timeout || this.parent.timeout,
     url: url,
     method: this.method.toUpperCase(),
     body: body,

--- a/test/operation.js
+++ b/test/operation.js
@@ -682,4 +682,32 @@ describe('operations', function () {
                                    {}, {}, new auth.SwaggerAuthorizations());
     expect(op.getBody({}, {name: 'Douglas Adams', quantity: 42}, {})).toEqual('quantity=42&name=Douglas%20Adams');
   });
+
+  // options.timeout
+  it('should use timeout specified on client by default', function () {
+    var parent = {
+      timeout: 1
+    };
+
+    var op = new Operation(parent, 'http', 'test', 'get', '/path', {},
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    var result = op.execute({}, {mock: true});
+
+    expect(result.timeout).toBe(1, "Operation.execute timeout was not applied from client");
+  });
+  //
+  it('should prefer timeout passed in execute options over client', function () {
+    var parent = {
+      timeout: 1
+    };
+
+    var op = new Operation(parent, 'http', 'test', 'get', '/path', {},
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    var result = op.execute({}, {
+      mock: true,
+      timeout: 2
+    });
+
+    expect(result.timeout).toBe(2, "Operation.execute timeout was not applied from options");
+  })
 });


### PR DESCRIPTION
Adds support for configuring timeouts on spec and operation requests.

`timeout` option:
- configured in `ms` for requests at the client and operation level
- pass as option when creating a client to set a timeout for all requests
- pass as an option when executing an operation to set a timeout for a specific request

`fetchSpecTimeout` option:
-  option will override `timeout` when specified
- when a value is passed to`timeout`,  pass `null` or `false` to for `fetchSpecTimeout` use agent default when fetching a spec

Will fail with an informative message when a timeout occurs (tested with `superagent` in unit tests and manually in the browser with jQuery's `$.ajax`)

Possible nice-to-haves in the future:
- `x-timeout` vendor extension to specify timeouts at the spec, route, or operation level