### PR TITLE
Topic/preserve slashes option

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -137,6 +137,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
   this.defaultErrorCallback = options.defaultErrorCallback || null;
   this.modelPropertyMacro = options.modelPropertyMacro || null;
   this.parameterMacro = options.parameterMacro || null;
+  this.preserveSlashes = options.preserveSlashes || false;
   this.usePromise = options.usePromise || null;
 
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -38,6 +38,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
   this.parameters = args !== null ? (args.parameters || []) : {};
   this.parent = parent;
   this.path = (path || errors.push('Operation ' + this.nickname + ' is missing path.'));
+  this.preserveSlashes = parent.preserveSlashes || false;
   this.responses = (args.responses || {});
   this.scheme = scheme || parent.scheme || 'http';
   this.schemes = args.schemes || parent.schemes;
@@ -466,7 +467,7 @@ Operation.prototype.urlify = function (args) {
         if (Array.isArray(value)) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         } else {
-          if(this.parent.preserveSlashes) {
+          if(this.preserveSlashes) {
             var pathParts = value.split('/');
             if(pathParts.length > 1) {
               pathParts.forEach(function encodePathPart(part, index) {

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -468,15 +468,11 @@ Operation.prototype.urlify = function (args) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         } else {
           if(this.preserveSlashes) {
-            var pathParts = value.split('/');
-            if(pathParts.length > 1) {
-              pathParts.forEach(function encodePathPart(part, index) {
-                pathParts[index] = encodeURIComponent(part);
-              });
-              value = pathParts.join('/');
-            } else {
-              value = this.encodePathParam(value);
-            }
+            value = value.split('/')
+              .map(function encodePathPart(part) {
+                return encodeURIComponent(part);
+              })
+              .join('/');
           } else {
             value = this.encodePathParam(value);
           }

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -466,7 +466,19 @@ Operation.prototype.urlify = function (args) {
         if (Array.isArray(value)) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         } else {
-          value = this.encodePathParam(value);
+          if(this.parent.preserveSlashes) {
+            var pathParts = value.split('/');
+            if(pathParts.length > 1) {
+              pathParts.forEach(function encodePathPart(part, index) {
+                pathParts[index] = encodeURIComponent(part);
+              });
+              value = pathParts.join('/');
+            } else {
+              value = this.encodePathParam(value);
+            }
+          } else {
+            value = this.encodePathParam(value);
+          }
         }
 
         requestUrl = requestUrl.replace(reg, value);

--- a/test/operation.js
+++ b/test/operation.js
@@ -274,6 +274,29 @@ describe('operations', function () {
     expect(url).toBe('http://localhost/foo/qux/baz.txt');
   });
 
+  it('should generate a url with path param with proper escaping, ignoring slashes if told to do so, with multiple slashes', function () {
+    var parameters = [
+      {
+        in: 'path',
+        name: 'type',
+        type: 'string'
+      },
+      {
+        in: 'path',
+        name: 'location',
+        type: 'string'
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/foo/{type}/{location}', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    op.preserveSlashes = true;
+    var url = op.urlify({
+      type: 'bar/bar',
+      location: 'qux/baz.txt'
+    });
+
+    expect(url).toBe('http://localhost/foo/bar/bar/qux/baz.txt');
+  });
 
   it('should generate a url with path param string array', function () {
     var parameters = [

--- a/test/operation.js
+++ b/test/operation.js
@@ -256,6 +256,25 @@ describe('operations', function () {
     expect(url).toBe('http://localhost/foo/tony%20tam/bar');
   });
 
+  it('should generate a url with path param with proper escaping, ignoring slashes if told to do so', function () {
+    var parameters = [
+      {
+        in: 'path',
+        name: 'location',
+        type: 'string'
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/foo/{location}', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    op.preserveSlashes = true;
+    var url = op.urlify({
+      location: 'qux/baz.txt'
+    });
+
+    expect(url).toBe('http://localhost/foo/qux/baz.txt');
+  });
+
+
   it('should generate a url with path param string array', function () {
     var parameters = [
       {


### PR DESCRIPTION
We have an issue where one of the parameters to an endpoint can be a path; for example, the spec is defined as

```
  "paths": {
    "/{foo}/{bar}": {
    ...
```

but bar itself can be of the format 'qux/baz.txt'. This means the slash gets urlencoded, which breaks things.

This patch allows the client to take a preserveSlashes option, so that qux/baz.txt stays intact, instead of coming out as qux%2Fbaz.txt.

Thanks for your consideration.