### PR TITLE
Headers should be case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,46 @@ You can add it to the swagger-client like such:
 client.clientAuthorizations.add('my-auth', new CustomRequestSigner());
 ```
 
+### Setting headers
+
+Headers are a type of `parameter`, and can be passed with the other parameters. For example, if you supported translated pet details via the `Accept-Language` header:
+
+```js
+"parameters": [
+  {
+    "name": "petId",
+    "description": "ID of pet that needs to be fetched",
+    "required": true,
+    "type": "integer",
+    "format": "int64",
+    "paramType": "path",
+    "minimum": "1.0",
+    "defaultValue": 3,
+    "maximum": "100000.0"
+  },
+  "LanguageHeader": {
+    "name": "Accept-Language",
+    "in": "header",
+    "description": "Specify the user's language",
+    "required": false,
+    "type": "string"
+  }
+...
+```
+
+Then you would pass the header value via the parameters ([header parameters are case-insenstive](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)):
+
+```js
+
+client.pet.getPetById({
+  petId: 7,
+  'accept-language': 'fr'
+}, function(pet){
+  console.log('pet', pet);
+});
+
+```
+
 ### Using your own HTTP client
 
 Don't like [superagent](https://github.com/visionmedia/superagent)? Despise [JQuery](https://github.com/jquery/jquery)?  Well, you're in luck.  You can plug your own HTTP library easily:

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -431,20 +431,26 @@ Operation.prototype.supportedSubmitMethods = function () {
 
 Operation.prototype.getHeaderParams = function (args) {
   var headers = this.setContentTypes(args, {});
+  var headerParamsByLowerCase = {};
 
   for (var i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
 
-    if (typeof args[param.name] !== 'undefined') {
-      if (param.in === 'header') {
-        var value = args[param.name];
+    if (param.in === 'header') {
+      headerParamsByLowerCase[param.name.toLowerCase()] = param;
+    }
+  }
 
-        if (Array.isArray(value)) {
-          value = value.toString();
-        }
+  for (var arg in args) {
+    var headerParam = headerParamsByLowerCase[arg.toLowerCase()];
+    if (typeof headerParam !== 'undefined') {
+      var value = args[arg];
 
-        headers[param.name] = value;
+      if (Array.isArray(value)) {
+        value = value.toString();
       }
+
+      headers[headerParam.name] = value;
     }
   }
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -155,6 +155,11 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
       }
     }
 
+    // Make header params case insensitive RFC 2616
+    if (param.in === 'header') {
+      param.name = param.name.toLowerCase();
+    }
+
     param.modelSignature = {type: innerType, definitions: this.models};
     param.signature = this.getModelSignature(innerType, this.models).toString();
     param.sampleJSON = this.getModelSampleJSON(innerType, this.models);
@@ -431,27 +436,36 @@ Operation.prototype.supportedSubmitMethods = function () {
 
 Operation.prototype.getHeaderParams = function (args) {
   var headers = this.setContentTypes(args, {});
-  var headerParamsByLowerCase = {};
+  var headerParams = {};
+  var headersSpecified = false;
 
   for (var i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
 
     if (param.in === 'header') {
-      headerParamsByLowerCase[param.name.toLowerCase()] = param;
+      headerParams[param.name] = param;
+      headersSpecified = true;
     }
   }
 
+  if (!headersSpecified) {
+    return headers;
+  }
+
+  // Look in args for for case-insenstive headers
   for (var arg in args) {
-    var headerParam = headerParamsByLowerCase[arg.toLowerCase()];
-    if (typeof headerParam !== 'undefined') {
-      var value = args[arg];
-
-      if (Array.isArray(value)) {
-        value = value.toString();
-      }
-
-      headers[headerParam.name] = value;
+    var headerParam = headerParams[arg.toLowerCase()];
+    if (!headerParam) {
+      continue;
     }
+
+    var value = args[arg];
+
+    if (Array.isArray(value)) {
+      value = value.toString();
+    }
+
+    headers[headerParam.name] = value;
   }
 
   return headers;

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -155,11 +155,6 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
       }
     }
 
-    // Make header params case insensitive RFC 2616
-    if (param.in === 'header') {
-      param.name = param.name.toLowerCase();
-    }
-
     param.modelSignature = {type: innerType, definitions: this.models};
     param.signature = this.getModelSignature(innerType, this.models).toString();
     param.sampleJSON = this.getModelSampleJSON(innerType, this.models);
@@ -436,36 +431,27 @@ Operation.prototype.supportedSubmitMethods = function () {
 
 Operation.prototype.getHeaderParams = function (args) {
   var headers = this.setContentTypes(args, {});
-  var headerParams = {};
-  var headersSpecified = false;
+  var headerParamsByLowerCase = {};
 
   for (var i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
 
     if (param.in === 'header') {
-      headerParams[param.name] = param;
-      headersSpecified = true;
+      headerParamsByLowerCase[param.name.toLowerCase()] = param;
     }
   }
 
-  if (!headersSpecified) {
-    return headers;
-  }
-
-  // Look in args for for case-insenstive headers
   for (var arg in args) {
-    var headerParam = headerParams[arg.toLowerCase()];
-    if (!headerParam) {
-      continue;
+    var headerParam = headerParamsByLowerCase[arg.toLowerCase()];
+    if (typeof headerParam !== 'undefined') {
+      var value = args[arg];
+
+      if (Array.isArray(value)) {
+        value = value.toString();
+      }
+
+      headers[headerParam.name] = value;
     }
-
-    var value = args[arg];
-
-    if (Array.isArray(value)) {
-      value = value.toString();
-    }
-
-    headers[headerParam.name] = value;
   }
 
   return headers;

--- a/test/client.js
+++ b/test/client.js
@@ -699,7 +699,7 @@ describe('SwaggerClient', function () {
             parameters: [
               {
                 in: 'header',
-                name: 'username',
+                name: 'UserNaMe',
                 type: 'string'
               }
             ],
@@ -731,7 +731,7 @@ describe('SwaggerClient', function () {
            **/
 
           // ensure the headers are present
-          expect(requestObj.headers.username).toBe('bob');
+          expect(requestObj.headers.username).toBe('Bob');
 
           // rewrite this request to something that'll work locally
           requestObj.method = 'GET';
@@ -747,7 +747,7 @@ describe('SwaggerClient', function () {
       usePromise: true,
       requestInterceptor: interceptor.requestInterceptor
     }).then(function(client) {
-      client.nada.addFoo({username: 'bob'}).then(function (){
+      client.nada.addFoo({Username: 'Bob'}).then(function (){
         done();
       });
     }).catch(function(exception) {

--- a/test/client.js
+++ b/test/client.js
@@ -731,7 +731,7 @@ describe('SwaggerClient', function () {
            **/
 
           // ensure the headers are present
-          expect(requestObj.headers.username).toBe('Bob');
+          expect(requestObj.headers.UserNaMe).toBe('Bob');
 
           // rewrite this request to something that'll work locally
           requestObj.method = 'GET';

--- a/test/headers.js
+++ b/test/headers.js
@@ -25,6 +25,24 @@ describe('header extraction', function () {
     expect(headers.myHeader).toBe('tony');
   });
 
+  it('should extract header params with case insensitivity', function () {
+    var parameters = [
+      {
+        in: 'header',
+        name: 'myHeader',
+        type: 'string'
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/path', { parameters: parameters });
+    var args = {
+      MyHeAdeR: 'nick'
+    };
+    var url = op.urlify(args);
+    var headers = op.getHeaderParams(args);
+
+    expect(url).toBe('http://localhost/path');
+    expect(headers.myHeader).toBe('nick');
+  });
 
   it('should not URL encode header string values', function () {
     var parameters = [

--- a/test/headers.js
+++ b/test/headers.js
@@ -35,13 +35,13 @@ describe('header extraction', function () {
     ];
     var op = new Operation({}, 'http', 'test', 'get', '/path', { parameters: parameters });
     var args = {
-      MyHeAdeR: 'nick'
+      MyHeAdeR: 'tony'
     };
     var url = op.urlify(args);
     var headers = op.getHeaderParams(args);
 
     expect(url).toBe('http://localhost/path');
-    expect(headers.myHeader).toBe('nick');
+    expect(headers.myHeader).toBe('tony');
   });
 
   it('should not URL encode header string values', function () {

--- a/test/spec/v2/spec3.json
+++ b/test/spec/v2/spec3.json
@@ -25,6 +25,9 @@
             "description": "Status values that need to be considered for filter",
             "required": false,
             "type": "string"
+          },
+          {
+            "$ref": "#/parameters/LanguageHeader"
           }
         ],
         "responses": {
@@ -39,6 +42,15 @@
           }
         }
       }
+    }
+  },
+  "parameters": {
+    "LanguageHeader": {
+      "name": "Accept-Language",
+      "in": "header",
+      "description": "Specify the user's language",
+      "required": false,
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
Hi @fehguy we've been using swagger-client for about a year, its a great project! We noticed that our headers weren't being passed if they didn't match the case of the swagger spec.

I added some docs to #840 Nick's PR, let us know if there is anything else we can do to help get this merged in!

http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html
```
HTTP header fields, which include general-header (section 4.5), request-header (section 5.3), 
response-header (section 6.2), and entity-header (section 7.1) fields, follow the same generic format 
as that given in Section 3.1 of RFC 822 [9]. Each header field consists of a name followed by a 
colon (":") and the field value. Field names are case-insensitive.
```