### PR TITLE
The param is not given value when loop all formParams

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -589,6 +589,7 @@ Operation.prototype.getBody = function (headers, args, opts) {
       bodyParam.type = 'formData';
 
       for (key in formParams) {
+        var param = formParams[key].param;
         value = args[key];
 
         if (typeof value !== 'undefined') {


### PR DESCRIPTION
The variable param should be given value when looping the formParams.