### PR TITLE
Fixes incorrect protocol bug

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -317,7 +317,7 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
     if (typeof this.scheme === 'undefined' && typeof this.schemes === 'undefined' || this.schemes.length === 0) {
       if(typeof window !== 'undefined') {
         // use the window scheme
-        this.scheme = window.location.scheme;
+        this.scheme = window.location.protocol.replace(':','');
       }
       else {
         this.scheme = location.scheme || 'http';


### PR DESCRIPTION
The protocol is incorrectly assigned here - window.location.scheme is not a thing. Please create a new release as v2.1.19 is broken with a bug where a request sent from a https swagger-ui is calling an http endpoint which the browser disallows because of security reasons.