### PR TITLE
add support for adding a custom http(s) agent

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -136,6 +136,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
   this.defaultSuccessCallback = options.defaultSuccessCallback || null;
   this.defaultErrorCallback = options.defaultErrorCallback || null;
   this.modelPropertyMacro = options.modelPropertyMacro || null;
+  this.connectionAgent = options.connectionAgent || null;
   this.parameterMacro = options.parameterMacro || null;
   this.usePromise = options.usePromise || null;
 
@@ -201,6 +202,7 @@ SwaggerClient.prototype.build = function (mock) {
   var obj = {
     useJQuery: this.useJQuery,
     jqueryAjaxCache: this.jqueryAjaxCache,
+    connectionAgent: this.connectionAgent,
     url: this.url,
     method: 'get',
     headers: {

--- a/lib/http.js
+++ b/lib/http.js
@@ -207,6 +207,7 @@ JQueryHttpClient.prototype.execute = function (obj) {
 };
 
 SuperagentHttpClient.prototype.execute = function (obj) {
+  var connectionAgent = obj.connectionAgent;
   var method = obj.method.toLowerCase();
   var timeout = obj.timeout;
 
@@ -216,6 +217,10 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   var headers = obj.headers || {};
   var r = request[method](obj.url);
 
+  if (connectionAgent) {
+    r.agent(connectionAgent);
+  }
+  
   if (timeout) {
     r.timeout(timeout);
   }


### PR DESCRIPTION
Node, by default, uses a hardcoded list of CAs instead of the system CAs. In order to use a CA that is not on that list, you have to hack it into the list by patching the global https agent. Unfortunately, superagent explicitly turns off the global agent which makes patching it a no-op. So this PR adds the ability to supply the CA for superagent as an option.