### PR TITLE
Use superagent.send to avoid mangling FormData

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -245,33 +245,7 @@ SuperagentHttpClient.prototype.execute = function (obj) {
       if (contentType.indexOf('multipart/form-data') === 0) {
         delete headers['Content-Type'];
         if({}.toString.apply(obj.body) === '[object FormData]') {
-          var itr = _.keys(obj);
-          var p = [];
-          while(true) {
-            var v = itr.next();
-            if(v.done) {
-              break;
-            }
-            var key = v.value;
-            // only once
-            if(p.indexOf(key) === -1) {
-              p.push(key);
-              var value = obj.body.getAll(key);
-              if({}.toString.apply(value) === '[object File]') {
-                r.attach(key, value);
-              }
-              else {
-                if (Array.isArray(value)) {
-                  for (var t in value) {
-                    r.field(key, value[t]);
-                  }
-                }
-                else {
-                  r.field(key, value);
-                }
-              }
-            }
-          }
+          r.send(obj.body);
         }
         else {
           var keyname, value, v;


### PR DESCRIPTION
The merged fix for https://github.com/swagger-api/swagger-js/issues/877 doesn't work since actually in older chrome, safari and IE there's no way to get access to FormData contents ( http://stackoverflow.com/a/33821488/1924141 ) however `SuperAgent` supports getting a ready FormData, so could we just give it to it?

This fixes basic POST support in Safari and older chrome, but I'm not sure if it breaks some other use-cases since the `FormData` branches seem to be not covered with unit tests