### PR TITLE
Allow x-escape to be part of a parameter to prevent urlencoding.

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -483,13 +483,7 @@ Operation.prototype.urlify = function (args) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         } else {
 
-          if(param['x-escape'] === false ) {
-            value = value.split('/')
-              .map(function encodePathPart(part) {
-                return encodeURIComponent(part);
-              })
-              .join('/');
-          } else {
+          if((typeof(param['x-escape']) === 'undefined') || (param['x-escape'] === true)) {
             value = this.encodePathParam(value);
           }
         }

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -482,7 +482,16 @@ Operation.prototype.urlify = function (args) {
         if (Array.isArray(value)) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         } else {
-          value = this.encodePathParam(value);
+
+          if(param['x-escape'] === false ) {
+            value = value.split('/')
+              .map(function encodePathPart(part) {
+                return encodeURIComponent(part);
+              })
+              .join('/');
+          } else {
+            value = this.encodePathParam(value);
+          }
         }
 
         requestUrl = requestUrl.replace(reg, value);

--- a/test/operation.js
+++ b/test/operation.js
@@ -269,6 +269,52 @@ describe('operations', function () {
     expect(url).toBe('http://localhost/foo/tony%20tam/bar');
   });
 
+  it('should generate a url with path param with proper escaping, ignoring slashes if told to do so', function () {
+    var parameters = [
+      {
+        in: 'path',
+        name: 'location',
+        type: 'string',
+        'x-escape': false
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/foo/{location}', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    op.preserveSlashes = true;
+    var url = op.urlify({
+      location: 'qux/baz.txt'
+    });
+
+    expect(url).toBe('http://localhost/foo/qux/baz.txt');
+  });
+
+  it('should generate a url with path param with proper escaping, ignoring slashes if told to do so, with multiple slashes', function () {
+    var parameters = [
+      {
+        in: 'path',
+        name: 'type',
+        type: 'string',
+        'x-escape': false
+      },
+      {
+        in: 'path',
+        name: 'location',
+        type: 'string',
+        'x-escape': false
+      }
+    ];
+    var op = new Operation({}, 'http', 'test', 'get', '/foo/{type}/{location}', { parameters: parameters },
+                                   {}, {}, new auth.SwaggerAuthorizations());
+    op.preserveSlashes = true;
+    var url = op.urlify({
+      type: 'bar/bar',
+      location: 'qux/baz.txt'
+    });
+
+    expect(url).toBe('http://localhost/foo/bar/bar/qux/baz.txt');
+  });
+
+
   it('should generate a url with path param string array', function () {
     var parameters = [
       {

--- a/test/operation.js
+++ b/test/operation.js
@@ -280,7 +280,6 @@ describe('operations', function () {
     ];
     var op = new Operation({}, 'http', 'test', 'get', '/foo/{location}', { parameters: parameters },
                                    {}, {}, new auth.SwaggerAuthorizations());
-    op.preserveSlashes = true;
     var url = op.urlify({
       location: 'qux/baz.txt'
     });
@@ -305,7 +304,6 @@ describe('operations', function () {
     ];
     var op = new Operation({}, 'http', 'test', 'get', '/foo/{type}/{location}', { parameters: parameters },
                                    {}, {}, new auth.SwaggerAuthorizations());
-    op.preserveSlashes = true;
     var url = op.urlify({
       type: 'bar/bar',
       location: 'qux/baz.txt'


### PR DESCRIPTION
Re: the discussion here

https://github.com/swagger-api/swagger-js/pull/847

I've made this an extensible parameter. Will this work?

Thanks!
