### PR TITLE
Adds ability to override request agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var client = new Swagger({
 });
 ```
 
-NOTE: we're explicitly setting the responseContentType, because we don't want you getting stuck when 
+NOTE: we're explicitly setting the responseContentType, because we don't want you getting stuck when
 there is more than one content type available.
 
 That's it!  You'll get a JSON response with the default callback handler:
@@ -299,8 +299,24 @@ var client = new SwaggerClient({
 });
 ```
 
+You can also pass in your own version superagent (if, for example, you have other superagent plugins etc that you want to use)
+
+var agent = require('some-other-special-superagent');
+
+var client = new SwaggerClient({
+  spec: petstoreRaw,
+  requestAgent: agent,
+  success: function () {
+    client.pet.getPetById({petId: 3}, function(data){
+      expect(data).toBe('ok');
+      done();
+    });
+  }
+});
+```
+
 ### Using custom http(s) agent
-In case if you need to sign all requests to petstore with custom certificate 
+In case if you need to sign all requests to petstore with custom certificate
 
 ```js
 var connectionAgent = {

--- a/lib/http.js
+++ b/lib/http.js
@@ -38,6 +38,10 @@ SwaggerHttp.prototype.execute = function (obj, opts) {
   }
   client.opts = opts || {};
 
+  if (opts && opts.requestAgent) {
+    request = opts.requestAgent;
+  }
+
   // legacy support
   var hasJQuery = false;
   if(typeof window !== 'undefined') {
@@ -221,7 +225,7 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   }
 
   var r = request[method](obj.url);
-  
+
   if (timeout) {
     r.timeout(timeout);
   }

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -21,6 +21,7 @@ var Operation = module.exports = function (parent, scheme, operationId, httpMeth
     this.client = parent.options.client || null;
     this.requestInterceptor = parent.options.requestInterceptor || null;
     this.responseInterceptor = parent.options.responseInterceptor || null;
+    this.requestAgent = parent.options.requestAgent;
   }
   this.authorizations = args.security;
   this.basePath = parent.basePath || '/';
@@ -771,6 +772,10 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
 
   if(this.client) {
     opts.client = this.client;
+  }
+
+  if(this.requestAgent) {
+    opts.requestAgent = this.requestAgent;
   }
 
   // add the request interceptor from parent, if none sent from client


### PR DESCRIPTION
Even though the current API supports passing in a different http client, you may want to just use a different instance of superagent.  For our use case, we have a number of plugins that get wired up into superagent so we want to use that instead. 
