### PR TITLE
Pass enableCookies option from SwaggerClient options to SwaggerHttp

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -203,6 +203,7 @@ SwaggerClient.prototype.build = function (mock) {
     useJQuery: this.useJQuery,
     jqueryAjaxCache: this.jqueryAjaxCache,
     connectionAgent: this.connectionAgent,
+    enableCookies: this.enableCookies,
     url: this.url,
     method: 'get',
     headers: {


### PR DESCRIPTION
Currently, in combination with SwaggerUI, the enableCookies information set in the SwaggerUI options is lost because of the SwaggerClient. This should not happen because in the SwaggerUI project this option is used to set the "xhr.withCredentials" flag. However, in the current version this "enableCookies" flag can never be true.