### PR TITLE
Don't treat File interface like an object in the browser

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -221,7 +221,7 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   }
 
   var r = request[method](obj.url);
-  
+
   if (timeout) {
     r.timeout(timeout);
   }
@@ -241,7 +241,7 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   }
 
   if(obj.body) {
-    if(_.isObject(obj.body)) {
+    if(_.isObject(obj.body) && !(typeof window !=='undefined' && obj.body instanceof File)) {
       var contentType = obj.headers['Content-Type'] || '';
       if (contentType.indexOf('multipart/form-data') === 0) {
         delete headers['Content-Type'];


### PR DESCRIPTION
Files don't need to be attached as FormData, or sent as multipart/form-data.
This conditional assumes that's the case, but for an `application/octet-stream`, for instance, this code with stringify the body resulting in an invalid payload.

I'm proposing to ignore this logic if a File interface is passed as the `obj.body` since it will erroneously be identified as an `object` by `isObject`, but it needs to be handled differently from JS objects.

Related: https://github.com/swagger-api/swagger-js/issues/893