### PR TITLE
Use Array.forEach instead of for...in

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -136,10 +136,10 @@ Resolver.prototype.resolve = function (spec, arg1, arg2, arg3) {
           var sharedParameters = path.parameters || [];
           var parameters = operation.parameters || [];
 
-          for (i in sharedParameters) {
-            parameter = sharedParameters[i];
+          sharedParameters.forEach(function(parameter) {
             parameters.unshift(parameter);
-          }
+          });
+
           if (method !== 'parameters' && _.isObject(operation)) {
             operation.parameters = operation.parameters || parameters;
           }


### PR DESCRIPTION
Had the problem that in the application where I use this library all `Array` objects get enriched with some extra methods. So when using the `for...in` I always had the problem hat also these extra methods where added to the `parameters` array leading to a recursion problem in the end (like in #29 or #773). Would be great if you could merge this. I could also bring this to the browser version. Then we would need to check if the `Array.forEach` method is available before (e.g. IE8 does not have it). 