### PR TITLE
Fix errors in embedded sourcemaps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var header = require('gulp-header');
 var istanbul = require('gulp-istanbul');
 var jshint = require('gulp-jshint');
 var mocha  = require('gulp-mocha');
+var sourcemaps = require('gulp-sourcemaps');
 var pkg = require('./package');
 var source = require('vinyl-source-stream');
 // Browser Unit Tests
@@ -18,7 +19,7 @@ var assign = require('object.assign');
 var connect = require('gulp-connect');
 var cors = require('connect-cors');
 
-// This is a workaround for this bug...https://github.com/feross/buffer/issues/79 
+// This is a workaround for this bug...https://github.com/feross/buffer/issues/79
 // Please refactor this, when the bug is resolved!
 // PS: you need to depend on buffer@3.4.3
 var OldBuffer = require.resolve('buffer/');
@@ -89,12 +90,18 @@ gulp.task('build', function (cb) {
       b.transform({global: true}, 'uglifyify');
     }
 
-    b.transform('brfs')
+    var p = b.transform('brfs')
       .bundle()
       .pipe(source(basename + (!useDebug ? '.min' : '') + '.js'))
       .pipe(buffer())
-      .pipe(header(banner, {pkg: pkg}))
-      .pipe(gulp.dest('./browser/'))
+      .pipe(sourcemaps.init({loadMaps: true}))
+      .pipe(header(banner, {pkg: pkg}));
+
+    if (useDebug) {
+      p = p.pipe(sourcemaps.write());
+    }
+
+    p.pipe(gulp.dest('./browser/'))
       .on('error', function (err) {
         callback(err);
       })

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-istanbul": "^0.5.0",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
-    "gulp-sourcemaps": "^2.2.0",
+    "gulp-sourcemaps": "^1.0.0",
     "http-server": "^0.8.0",
     "jshint-stylish": "^1.0.1",
     "karma": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gulp-istanbul": "^0.5.0",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
+    "gulp-sourcemaps": "^2.2.0",
     "http-server": "^0.8.0",
     "jshint-stylish": "^1.0.1",
     "karma": "^0.13.0",


### PR DESCRIPTION
The sourcemaps in the browserified libraries were incorrect due to the addition
of the header. We can fix this using gulp-sourcemaps to export correct
sourcemaps.