### PR TITLE
Pass the operation down to SwaggerHttp client so that interceptors ca…

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -859,6 +859,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     deferred: deferred,
     headers: headers,
     clientAuthorizations: opts.clientAuthorizations,
+    operation: this.operation,
     on: {
       response: function (response) {
         if (deferred) {


### PR DESCRIPTION
…n get it.

The use case is that we are using request/response interceptors to log Prometheus metrics, but using the URL as the counter name is suboptimal. By passing the operation that caused the HTTP call, we can get cleaner metrics.