### PR TITLE
Fix connectionAgent behavior to apply to both spec fetch and requests…

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -406,7 +406,7 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
   }
 
   // get paths, create functions for each operationId
-  
+
   // Bind help to 'client.apis'
   self.apis.help = _.bind(self.help, self);
 
@@ -447,6 +447,7 @@ SwaggerClient.prototype.buildFromSpec = function (response) {
         self.models,
         self.clientAuthorizations);
 
+      operationObject.connectionAgent = self.connectionAgent;
       operationObject.vendorExtensions = {};
       for(i in operation) {
         helpers.extractExtensions(i, operationObject, operation[i]);

--- a/lib/http.js
+++ b/lib/http.js
@@ -216,7 +216,6 @@ JQueryHttpClient.prototype.execute = function (obj) {
 };
 
 SuperagentHttpClient.prototype.execute = function (obj) {
-  var connectionAgent = obj.connectionAgent;
   var method = obj.method.toLowerCase();
   var timeout = obj.timeout;
 
@@ -225,11 +224,11 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   }
   var headers = obj.headers || {};
 
-  if (connectionAgent) {
-      request = request.agent(connectionAgent);
-  }
-
   var r = request[method](obj.url);
+
+  if (obj.connectionAgent) {
+    r.agent(obj.connectionAgent);
+  }
 
   if (timeout) {
     r.timeout(timeout);

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -860,6 +860,7 @@ Operation.prototype.execute = function (arg1, arg2, arg3, arg4, parent) {
     headers: headers,
     clientAuthorizations: opts.clientAuthorizations,
     operation: this.operation,
+    connectionAgent: this.connectionAgent,
     on: {
       response: function (response) {
         if (deferred) {


### PR DESCRIPTION
…, and to leave the request object alone in favor of the INSTANCE of the request

The previous attempt at this was targeted at fetching the swagger spec, but it didn't do anything for the actual outbound requests. This PR carries the connectionAgent option forward to the operation, as well as fixing it so it doesn't affect the global request object but instead the operation's instance of a request.