### PR TITLE
shouldnt remove 0 values from query params

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -1242,7 +1242,7 @@ Operation.prototype.encodeQueryParam = function (arg, maskPasswords) {
   if(maskPasswords) {
     return "******";
   }
-  if(arg) {
+  if(arg !== undefined && arg !== null) {
     return encodeURIComponent(arg);
   }
   else {

--- a/test/client.js
+++ b/test/client.js
@@ -1619,6 +1619,41 @@ describe('SwaggerClient', function () {
     });
   });
 
+
+  it('doesnt remove 0 from query params', function(done) {
+    var spec = {
+      basePath: '/double/',
+      paths: {
+        '/foo': {
+          get: {
+            tags: [
+              'test'
+            ],
+            operationId: 'slash',
+            parameters: [{
+              in: 'query',
+              name: 'bar',
+              type: 'integer',
+              required: false
+            }],
+          }
+        }
+      }
+    };
+    new SwaggerClient({
+      url: 'http://localhost:8000/v2/swagger.json',
+      spec: spec,
+      usePromise: true
+    }).then(function(client) {
+      var mock = client.test.slash({bar: 0}, {mock: true});
+      expect(mock.url).toBe('http://localhost:8000/double/foo?bar=0');
+
+      done();
+    }).catch(function(exception) {
+      done(exception);
+    });
+  });
+
   it('honors allowEmptyValue #825 in arrays', function(done) {
     var spec = {
       basePath: '/double/',


### PR DESCRIPTION
Hi guys, 

We pulled in the latest version 2.1.31 and found a breaking change from 2.1.2x

It seems to be converting `bar=0` into `bar=`, I added a test to show with a sample parameter and resulting url 

```
$ npm test

> swagger-client@2.1.31 test /Users/gina/git/swagger-js
> gulp test

[12:52:09] Using gulpfile ~/git/swagger-js/gulpfile.js
[12:52:09] Starting 'test'...


  SwaggerClient
    1) doesnt remove 0 from query params


  0 passing (85ms)
  1 failing

  1) SwaggerClient doesnt remove 0 from query params:

      AssertionError: 'http://localhost:8000/double/foo?bar=' === 'http://localhost:8000/double/foo?bar=0'
      + expected - actual

      -http://localhost:8000/double/foo?bar=
      +http://localhost:8000/double/foo?bar=0
```

If the value is not falsy, (for example 1) the test passes we found that https://github.com/swagger-api/swagger-js/pull/935/files#diff-e9afd75580721a5b884cc82272c23984R1245 is cleaning falsey values

```
$ npm test

> swagger-client@2.1.31 test /Users/gina/git/swagger-js
> gulp test

[12:52:53] Using gulpfile ~/git/swagger-js/gulpfile.js
[12:52:53] Starting 'test'...


  SwaggerClient
    ✓ doesnt remove 0 from query params


  1 passing (80ms)
```