### PR TITLE
Fix for #947 & #948 - cURL changes

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -1116,8 +1116,16 @@ Operation.prototype.asCurl = function (args1, args2) {
             }
             if (paramValue) {
               if (parameter.type === 'file') {
-                if(paramValue.name) {
-                  body += '-F ' + parameter.name + '=@"' + paramValue.name + '" ';
+                if (Array.isArray(paramValue)) {
+                  for(var fileValue in paramValue) {
+                    if(paramValue[fileValue].name) {
+                      body += '-F ' + parameter.name + '=@"' + paramValue[fileValue].name + '" ';
+                    }
+                  }
+                } else {
+                  if (paramValue.name) {
+                    body += '-F ' + parameter.name + '=@"' + paramValue.name + '" ';
+                  }
                 }
               }
               else {
@@ -1144,18 +1152,19 @@ Operation.prototype.asCurl = function (args1, args2) {
     } else {
       body = obj.body;
     }
-    // escape @ => %40, ' => %27
-    body = body.replace(/\'/g, '%27').replace(/\n/g, ' \\ \n ');
 
-    if(!isFormData) {
-      // escape & => %26
-      body = body.replace(/&/g, '%26');
+    if(isFormData && !isMultipart) {
+      // escape @ => %40, ' => %27
+      body = body.replace(/\'/g, '%27').replace(/@/g, '%40');
+    }
+    else {
+      body = body.replace(/\'/g, '\\u0027')
     }
     if(isMultipart) {
       results.push(body);
     }
     else {
-      results.push('-d \'' + body.replace(/@/g, '%40') + '\'');
+      results.push('--data-raw \'' + body + '\'');
     }
   }
 

--- a/test/help.js
+++ b/test/help.js
@@ -233,7 +233,7 @@ describe('help options', function () {
         var msg = client.test.sample.asCurl({body: {
           description: '<h1>hello world<script>alert(\'test\')</script></h1>'
         }});
-        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"description":"<h1>hello world<script>alert(\u0027test\u0027)</script></h1>"}\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"description":"<h1>hello world<script>alert(\\u0027test\\u0027)</script></h1>"}\' \'http://localhost:8080/foo\'');
         done();
       }
     });

--- a/test/help.js
+++ b/test/help.js
@@ -199,7 +199,7 @@ describe('help options', function () {
         var msg = client.test.sample.asCurl({body: {
           description: '<b>Test</b>'
         }});
-        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"description":"<b>Test</b>"}\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"description":"<b>Test</b>"}\' \'http://localhost:8080/foo\'');
         done();
       }
     });
@@ -233,7 +233,7 @@ describe('help options', function () {
         var msg = client.test.sample.asCurl({body: {
           description: '<h1>hello world<script>alert(\'test\')</script></h1>'
         }});
-        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"description":"<h1>hello world<script>alert(%27test%27)</script></h1>"}\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"description":"<h1>hello world<script>alert(\u0027test\u0027)</script></h1>"}\' \'http://localhost:8080/foo\'');
         done();
       }
     });
@@ -275,7 +275,7 @@ describe('help options', function () {
       spec: spec,
       success: function () {
         var msg = client.test.sample.asCurl({body: body});
-        expect(msg).toBe('curl -X POST --header \'Content-Type: application\/json\' --header \'Accept: application\/json\' -d \'%40prefix nif:<http:\/\/persistence.uni-leipzig.org\/nlp2rdf\/ontologies\/nif-core#> . \\ \n %40prefix itsrdf: <http:\/\/www.w3.org\/2005\/11\/its\/rdf#> . \\ \n %40prefix xsd: <http:\/\/www.w3.org\/2001\/XMLSchema#> . \\ \n <http:\/\/example.org\/document\/1#char=0,21> \\ \n a nif:String , nif:Context, nif:RFC5147String ; \\ \n nif:isString "Welcome to Berlin"^^xsd:string; \\ \n nif:beginIndex "0"^^xsd:nonNegativeInteger; \\ \n nif:endIndex "21"^^xsd:nonNegativeInteger; \\ \n nif:sourceUrl <http:\/\/differentday.blogspot.com\/2007_01_01_archive.html>.\' \'http:\/\/localhost:8080\/foo\'');
+        expect(msg).toBe('curl -X POST --header \'Content-Type: application\/json\' --header \'Accept: application\/json\' --data-raw \'@prefix nif:<http:\/\/persistence.uni-leipzig.org\/nlp2rdf\/ontologies\/nif-core#> .\n@prefix itsrdf: <http:\/\/www.w3.org\/2005\/11\/its\/rdf#> .\n@prefix xsd: <http:\/\/www.w3.org\/2001\/XMLSchema#> .\n<http:\/\/example.org\/document\/1#char=0,21>\na nif:String , nif:Context, nif:RFC5147String ;\nnif:isString "Welcome to Berlin"^^xsd:string;\nnif:beginIndex "0"^^xsd:nonNegativeInteger;\nnif:endIndex "21"^^xsd:nonNegativeInteger;\nnif:sourceUrl <http:\/\/differentday.blogspot.com\/2007_01_01_archive.html>.\' \'http:\/\/localhost:8080\/foo\'');
         done();
       }
     });
@@ -330,7 +330,7 @@ describe('help options', function () {
       spec: spec,
       success: function () {
         var msg = client.test.sample.asCurl({name: 'fred'});
-        expect(msg).toBe('curl -X DELETE --header \'Content-Type: application/x-www-form-urlencoded\' --header \'Accept: application/json\' -d \'name=fred\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X DELETE --header \'Content-Type: application/x-www-form-urlencoded\' --header \'Accept: application/json\' --data-raw \'name=fred\' \'http://localhost:8080/foo\'');
         done();
       }
     });
@@ -389,7 +389,7 @@ describe('help options', function () {
       spec: spec,
       success: function () {
         var msg = client.test.sample.asCurl({names: ['tony', 'tam']});
-        expect(msg).toBe('curl -X POST --header \'Content-Type: application/x-www-form-urlencoded\' --header \'Accept: application/json\' -d \'names[]=tony&names[]=tam\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X POST --header \'Content-Type: application/x-www-form-urlencoded\' --header \'Accept: application/json\' --data-raw \'names[]=tony&names[]=tam\' \'http://localhost:8080/foo\'');
         done();
       }
     });
@@ -423,7 +423,7 @@ describe('help options', function () {
       spec: spec,
       success: function () {
         var msg = client.test.sample.asCurl({complexBody: '{"name":"tony"}'},{requestContentType: 'application/json; version=1'});
-        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json; version=1\' --header \'Accept: application/json; version=1\' -d \'{"name":"tony"}\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X POST --header \'Content-Type: application/json; version=1\' --header \'Accept: application/json; version=1\' --data-raw \'{"name":"tony"}\' \'http://localhost:8080/foo\'');
         done();
       }
     });
@@ -521,7 +521,7 @@ describe('help options', function () {
       spec: spec,
       success: function () {
         var msg = client.test.sample.asCurl({password: 'hidden!'});
-        expect(msg).toBe('curl -X DELETE --header \'Content-Type: application/x-www-form-urlencoded\' --header \'Accept: application/json\' -d \'password=******\' \'http://localhost:8080/foo\'');
+        expect(msg).toBe('curl -X DELETE --header \'Content-Type: application/x-www-form-urlencoded\' --header \'Accept: application/json\' --data-raw \'password=******\' \'http://localhost:8080/foo\'');
 
         var obj = client.test.sample({password: 'hidden!'}, {mock: true});
         expect(obj.body).toBe('password=hidden!');

--- a/test/request.js
+++ b/test/request.js
@@ -339,21 +339,28 @@ describe('swagger request functions', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: {id:10101}});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' \'http://localhost:8000/v2/api/pet\'');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"id":10101}\' \'http://localhost:8000/v2/api/pet\'');
   });
 
   it('prints a curl post statement from a string', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":10101}'});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":10101}\' \'http://localhost:8000/v2/api/pet\'');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"id":10101}\' \'http://localhost:8000/v2/api/pet\'');
   });
 
   it('prints a curl post statement from a string containing a single quote', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":"foo\'bar"}'});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' -d \'{"id":"foo%27bar"}\' \'http://localhost:8000/v2/api/pet\'');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"id":"foo\u0027bar"}\' \'http://localhost:8000/v2/api/pet\'');
+  });
+
+  it('prints a curl post statement from an object containing a file', function () {
+    var petApi = sample.pet;
+    var curl = petApi.uploadFile.asCurl({petId: 1234, file: {name: 'testfile', type: 'file'}});
+
+    expect(curl).toBe('curl -X POST --header \'Content-Type: multipart/form-data\' --header \'Accept: application/json\' -F file=@\"testfile"  \'http://localhost:8000/v2/api/pet/1234/uploadImage\'');
   });
 
   it('gets an server side 404, and verifies that the content-type in the response is correct, and different than one in the request', function (done) {

--- a/test/request.js
+++ b/test/request.js
@@ -353,7 +353,7 @@ describe('swagger request functions', function () {
     var petApi = sample.pet;
     var curl = petApi.addPet.asCurl({body: '{"id":"foo\'bar"}'});
 
-    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"id":"foo\u0027bar"}\' \'http://localhost:8000/v2/api/pet\'');
+    expect(curl).toBe('curl -X POST --header \'Content-Type: application/json\' --header \'Accept: application/json\' --data-raw \'{"id":"foo\\u0027bar"}\' \'http://localhost:8000/v2/api/pet\'');
   });
 
   it('prints a curl post statement from an object containing a file', function () {


### PR DESCRIPTION
Fix for #947 & #948 - curl changes - 

- only form encode form content type data (it doesn't make sense to URL encode values in JSON data)
- still ensure apostrophe ' is encoded via unicode if not URL encoding
- remove the new line patterns that prevent cURL commands from executing (for me at least)
- ensure @ is literal outside of file usage (--data-raw usage - 'post body with special chars' use case) - an alternative to this might have been unicode
- fix file submission support

Some test expectations were changed:
- I wouldn't expect the values in my JSON to be received with URL encoding on the server
- I wouldn't expect JS escaping to happen via cURL, this should be the responsibility of the server and the client rendering any feedback.

I have not regenerated the swagger-client.js and swagger-client-min.js as this seemed to introduce more than the desired changes building locally.

I have checked this works for cURL commands with file uploads, and cURL commands with special characters in JSON body with respective server interpretation. Happy to amend this PR - but thought I'd suggest something.