### PR TITLE
fix usage options.client in specConverter

### DIFF
--- a/lib/spec-converter.js
+++ b/lib/spec-converter.js
@@ -470,6 +470,10 @@ SwaggerSpecConverter.prototype.resourceListing = function(obj, swagger, opts, ca
     _opts.responseInterceptor = opts.responseInterceptor;
   }
 
+  if(opts && opts.client){
+    _opts.client = opts.client;
+  }
+
   var swaggerRequestHeaders = 'application/json';
 
   if(opts && opts.swaggerRequestHeaders) {


### PR DESCRIPTION
specConverter not use client from options, I fix this.

- [x] Test runned
- [x] Linter runned 