### PR TITLE
Buffer object in request body

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -264,7 +264,7 @@ SuperagentHttpClient.prototype.execute = function (obj) {
   }
 
   if(obj.body) {
-    if(_.isObject(obj.body)) {
+    if(_.isObject(obj.body) && !Buffer.isBuffer(obj.body)) {
       var contentType = obj.headers['Content-Type'] || '';
       if (contentType.indexOf('multipart/form-data') === 0) {
         delete headers['Content-Type'];


### PR DESCRIPTION
This consider the case where the request body is a buffer, the client is sending raw data to the server and superagent will send the buffer correctly.