### PR TITLE
add open object authorizations

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -26,10 +26,17 @@ export const PARAMETER_BUILDERS = {
 // Execute request, with the given operationId and parameters
 // pathName/method or operationId is optional
 export function execute({
-  fetch, spec, operationId, pathName, method, parameters, securities, ...extras
+  http: userHttp,
+  spec,
+  operationId,
+  pathName,
+  method,
+  parameters,
+  securities,
+  ...extras
 }) {
   // Provide default fetch implementation
-  fetch = fetch || http
+  userHttp = userHttp || extras.fetch || http // Default to _our_ http
 
   // Prefer pathName/method if it exists
   if (pathName && method) {
@@ -39,7 +46,7 @@ export function execute({
   const request = self.buildRequest({spec, operationId, parameters, securities, ...extras})
 
   // Build request and execute it
-  return fetch(request)
+  return userHttp(request)
 }
 
 // Build a request, which can be handled by the `http.js` implementation.

--- a/src/execute.js
+++ b/src/execute.js
@@ -27,6 +27,7 @@ export const PARAMETER_BUILDERS = {
 // pathName/method or operationId is optional
 export function execute({
   http: userHttp,
+  fetch, // This is legacy
   spec,
   operationId,
   pathName,
@@ -36,7 +37,7 @@ export function execute({
   ...extras
 }) {
   // Provide default fetch implementation
-  userHttp = userHttp || extras.fetch || http // Default to _our_ http
+  userHttp = userHttp || fetch || http // Default to _our_ http
 
   // Prefer pathName/method if it exists
   if (pathName && method) {

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,8 @@ Swagger.prototype = {
   execute(argHash) {
     return Swagger.execute({
       spec: this.spec,
-      fetch: this.http.bind(this),
+      http: this.http.bind(this),
+      securities: {authorized: this.authorizations},
       ...argHash
     })
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import expect from 'expect'
+import expect, {createSpy} from 'expect'
 import xmock from 'xmock'
 import Swagger from '../src/index'
 
@@ -148,6 +148,216 @@ describe('constructor', () => {
           expect(text).toEqual('[')
           expect(body).toEqual()
         })
+    })
+  })
+
+  describe('#execute', function () {
+    it('should be able to execute a simple operation', function () {
+      const spec = {
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets'
+            }
+          }
+        }
+      }
+      return Swagger({spec}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {},
+          method: 'GET',
+          url: '/pet'
+        })
+      })
+    })
+
+    it('should add basic auth to a request', function () {
+      const spec = {
+        securityDefinitions: {
+          myBasic: {
+            type: 'basic'
+          }
+        },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets',
+              security: [{myBasic: []}]
+            }
+          }
+        }
+      }
+
+      const authorizations = {
+        myBasic: {
+          username: 'foo',
+          password: 'bar'
+        }
+      }
+
+      return Swagger({spec, authorizations}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {
+            authorization: 'Basic Zm9vOmJhcg=='
+          },
+          method: 'GET',
+          url: '/pet'
+        })
+      })
+    })
+
+    it('should add apiKey (header) auth to a request', function () {
+      const spec = {
+        securityDefinitions: {
+          petKey: {
+            type: 'apiKey',
+            name: 'petKey',
+            in: 'header'
+          }
+        },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets',
+              security: [{petKey: []}]
+            }
+          }
+        }
+      }
+
+      const authorizations = {
+        petKey: 'fooBar'
+      }
+
+      return Swagger({spec, authorizations}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {
+            petKey: 'fooBar'
+          },
+          method: 'GET',
+          url: '/pet'
+        })
+      })
+    })
+
+    it('should add apiKey (query) auth to a request', function () {
+      const spec = {
+        securityDefinitions: {
+          petKey: {
+            type: 'apiKey',
+            name: 'petKey',
+            in: 'query'
+          }
+        },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets',
+              security: [{petKey: []}]
+            }
+          }
+        }
+      }
+
+      const authorizations = {
+        petKey: 'barFoo'
+      }
+
+      return Swagger({spec, authorizations}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: { },
+          method: 'GET',
+          url: '/pet?petKey=barFoo'
+        })
+      })
+    })
+
+    it('should add oAuth to a request', function () {
+      const spec = {
+        securityDefinitions: {
+          ohYou: {
+            type: 'oauth2',
+          }
+        },
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets',
+              security: [{ohYou: []}]
+            }
+          }
+        }
+      }
+
+      const authorizations = {
+        ohYou: {
+          token: {
+            access_token: 'one two'
+          }
+        }
+      }
+
+      return Swagger({spec, authorizations}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {
+            authorization: 'Bearer one two'
+          },
+          method: 'GET',
+          url: '/pet'
+        })
+      })
+    })
+
+    it('should add global securites', function () {
+      const spec = {
+        securityDefinitions: {
+          petKey: {
+            type: 'apiKey',
+            in: 'header',
+            name: 'Auth'
+          }
+        },
+        security: [{petKey: []}],
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets',
+            }
+          }
+        }
+      }
+
+      const authorizations = {
+        petKey: 'yup'
+      }
+
+      return Swagger({spec, authorizations}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {
+            Auth: 'yup'
+          },
+          method: 'GET',
+          url: '/pet'
+        })
+      })
     })
   })
 


### PR DESCRIPTION
helps with: https://github.com/swagger-api/swagger-js/issues/971
This is the first pass at adding back authorizations to the instance methods.

```javascript
Swagger({ 
  spec,
  authorizations: {
    someApiKey: 'hello',
    someBasicAuth: { username: 'foo', password: 'bar' },
    someOAuth: { token: { access_token: 'foo bar' } }
  }
}).then( client => {
  client.apis.pet.addPet() // If this has any `securities`... they'll be added to the request
})
```

Next step is to create classes for the above. 
PS: I don't see cookie authorizations... not sure if we can easily implement.

ping @webron, @fehguy