### PR TITLE
fix standalone bundle... now points to where 2.x did.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ notes/
 .DS_Store
 .deps_check
 test/specmap/data/private
+browser

--- a/webpack.bundle.config.js
+++ b/webpack.bundle.config.js
@@ -9,7 +9,11 @@ module.exports = deepMerge(
     },
 
     output: {
-      filename: 'bundle.js'
-    }
+      path: path.join(__dirname, 'browser'),
+      library: 'SwaggerClient',
+      libraryTarget: 'umd',
+      filename: 'swagger-client.js'
+    },
+
   }
 )

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -19,7 +19,7 @@ module.exports = {
       test: /\.js/,
       loader: 'babel-loader',
       exclude: [
-        'node_modules'
+        /node_modules/
       ]
     }]
   },


### PR DESCRIPTION
This makes it work with <script/>
The standalone bundle now lives in `browser/swagger-client.js` which matches 2.x
It also expose `SwaggerClient` on the window object ( to be precise, it does so via UMD ).

ping @webron 