### PR TITLE
Fixing bug swagger-ui#2785: Encoding only characters with a reserved purpose in path segments

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -153,7 +153,9 @@ export function headerBuilder({req, parameter, value}) {
 
 // Replace path paramters, with values ( ie: the URL )
 export function pathBuilder({req, value, parameter}) {
-  req.url = req.url.replace(`{${parameter.name}}`, encodeURIComponent(value))
+  const encodedValue = value.toString().replace('%', '%25').replace('/', '%2F').replace('?', '%3F')
+    .replace('#', '%23')
+  req.url = req.url.replace(`{${parameter.name}}`, encodedValue)
 }
 
 // Add a query to the `query` object, which will later be stringified into the URL's search

--- a/test/execute.js
+++ b/test/execute.js
@@ -1270,7 +1270,7 @@ describe('execute', () => {
         })
       })
 
-      it('should encode path parameter', function () {
+      it('should encode slashes in a path parameter', function () {
         const spec = {
           host: 'swagger.io',
           basePath: '/v1',
@@ -1293,6 +1293,118 @@ describe('execute', () => {
 
         expect(req).toEqual({
           url: 'http://swagger.io/v1/foo%2Fbar',
+          method: 'DELETE',
+          headers: { }
+        })
+      })
+
+      it('should encode hashtags in a path parameter', function () {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/{id}': {
+              delete: {
+                operationId: 'deleteMe',
+                parameters: [{
+                  in: 'path',
+                  name: 'id',
+                  type: 'string',
+                  required: true
+                }]
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({spec, operationId: 'deleteMe', parameters: {id: 'foo#bar'}})
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/foo%23bar',
+          method: 'DELETE',
+          headers: { }
+        })
+      })
+
+      it('should encode question marks in a path parameter', function () {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/{id}': {
+              delete: {
+                operationId: 'deleteMe',
+                parameters: [{
+                  in: 'path',
+                  name: 'id',
+                  type: 'string',
+                  required: true
+                }]
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({spec, operationId: 'deleteMe', parameters: {id: 'foo?bar'}})
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/foo%3Fbar',
+          method: 'DELETE',
+          headers: { }
+        })
+      })
+
+      it('should encode percent signs in a path parameter', function () {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/{id}': {
+              delete: {
+                operationId: 'deleteMe',
+                parameters: [{
+                  in: 'path',
+                  name: 'id',
+                  type: 'string',
+                  required: true
+                }]
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({spec, operationId: 'deleteMe', parameters: {id: 'foo%bar'}})
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/foo%25bar',
+          method: 'DELETE',
+          headers: { }
+        })
+      })
+
+      it('should not encode colons in a path parameter', function () {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/{id}': {
+              delete: {
+                operationId: 'deleteMe',
+                parameters: [{
+                  in: 'path',
+                  name: 'id',
+                  type: 'string',
+                  required: true
+                }]
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({spec, operationId: 'deleteMe', parameters: {id: 'foo:bar'}})
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/foo:bar',
           method: 'DELETE',
           headers: { }
         })


### PR DESCRIPTION
AFAIK, the only characters with a reserved purpose in path segments are the percent sign (used to encode the other reserved characters), the slash (used to separate path segments), the question mark (used to separate the path from the query) and the hashtag (used to separate the path or the query from the fragment). Please see https://tools.ietf.org/html/rfc3986#section-3