### PR TITLE
send cookies

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -62,6 +62,7 @@ export function buildRequest({
   // Base Template
   let req = {
     url: baseUrl({spec, scheme, contextUrl}),
+    credentials: 'same-origin',
     headers: {
       // This breaks CORSs... removing this line... probably breaks oAuth. Need to address that
       // This also breaks tests

--- a/test/execute.js
+++ b/test/execute.js
@@ -32,6 +32,7 @@ describe('execute', () => {
       expect(req).toEqual({
         method: 'GET',
         url: 'http://swagger.io/v1/one',
+        credentials: 'same-origin',
         headers: {},
       })
     })
@@ -49,6 +50,7 @@ describe('execute', () => {
       // Then
       expect(req).toEqual({
         url: 'http://swagger.io/v1',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -66,6 +68,7 @@ describe('execute', () => {
       // Then
       expect(req).toEqual({
         url: 'http://foo.com:8081/v1',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -91,6 +94,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -121,6 +125,7 @@ describe('execute', () => {
       expect(spy.calls[0].arguments[0]).toEqual({
         method: 'GET',
         url: 'https://swagger.io/one',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -147,6 +152,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one?petId=123',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -177,6 +183,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one?fields=%5Barticles%5D%3Dtitle',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -207,6 +214,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one?petId=true',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -235,6 +243,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one?petId=3',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -348,6 +357,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/pets/findByStatus?status=',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -390,6 +400,7 @@ describe('execute', () => {
       // Then
       expect(req).toEqual({
         url: 'http://swagger.io/one',
+        credentials: 'same-origin',
         headers: {
           accept: 'application/josh',
         },
@@ -425,6 +436,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one?username=fred&password=meyer',
         method: 'GET',
+        credentials: 'same-origin',
         headers: { }
       })
     })
@@ -445,6 +457,7 @@ describe('execute', () => {
         headers: {
           'content-type': 'application/josh',
         },
+        credentials: 'same-origin',
         method: 'GET'
       })
     })
@@ -512,6 +525,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'whoop://swagger.io/api/one/2?question=answer',
         method: 'PUT',
+        credentials: 'same-origin',
         headers: {
           head: 'justTheHead',
         },
@@ -743,6 +757,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?petId=a%2Cb',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -788,6 +803,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?ids=1,2,3&the%20names=a%2Cb|mary',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -822,6 +838,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?petId=1,2,3',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -856,6 +873,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?petId=1%202%203',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -890,6 +908,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?petId=1&petId=2&petId=3',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -924,6 +943,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?petId=1%092%093',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -958,6 +978,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one?name=john|smith',
           method: 'GET',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -1030,6 +1051,7 @@ describe('execute', () => {
           expect(req).toEqual({
             url: 'http://swagger.io/v1/blob/image.png?someQuery=foo',
             method: 'POST',
+            credentials: 'same-origin',
             body: {
               name: 'johny',
               id: '123',
@@ -1046,6 +1068,7 @@ describe('execute', () => {
             url: 'http://swagger.io/v1/one',
             method: 'POST',
             body: 123,
+            credentials: 'same-origin',
             headers: { }
           })
         })
@@ -1058,6 +1081,7 @@ describe('execute', () => {
             url: 'http://swagger.io/v1/one',
             method: 'POST',
             body: undefined,
+            credentials: 'same-origin',
             headers: { }
           })
         })
@@ -1087,6 +1111,7 @@ describe('execute', () => {
             url: 'http://swagger.io/v1/one',
             method: 'DELETE',
             body: undefined,
+            credentials: 'same-origin',
             headers: { }
           })
         })
@@ -1098,6 +1123,7 @@ describe('execute', () => {
             url: 'http://swagger.io/v1/one',
             method: 'DELETE',
             body: 123,
+            credentials: 'same-origin',
             headers: { }
           })
         })
@@ -1128,6 +1154,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one',
           method: 'DELETE',
+          credentials: 'same-origin',
           headers: {
             api_key: 123,
           }
@@ -1159,6 +1186,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/one',
           method: 'GET',
+          credentials: 'same-origin',
           headers: {
             accept: 'application/json',
           }
@@ -1191,6 +1219,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/123',
           method: 'GET',
+          credentials: 'same-origin',
           headers: {
           }
         })
@@ -1229,6 +1258,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: "http://swagger.io/v1/pet/123?test=567",
           headers: {},
+          credentials: 'same-origin',
           method: "GET"
         })
       })
@@ -1266,6 +1296,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: "http://swagger.io/v1/pet/123?test=567",
           headers: {},
+          credentials: 'same-origin',
           method: "GET"
         })
       })
@@ -1294,6 +1325,7 @@ describe('execute', () => {
         expect(req).toEqual({
           url: 'http://swagger.io/v1/foo%2Fbar',
           method: 'DELETE',
+          credentials: 'same-origin',
           headers: { }
         })
       })
@@ -1327,6 +1359,7 @@ describe('execute', () => {
       expect(req).toEqual({
         url: 'http://swagger.io/v1/one',
         method: 'POST',
+        credentials: 'same-origin',
         headers: {
           'content-type': 'application/x-www-form-urlencoded',
         },

--- a/test/index.js
+++ b/test/index.js
@@ -169,6 +169,7 @@ describe('constructor', () => {
         expect(http.calls[0].arguments[0]).toEqual({
           headers: {},
           method: 'GET',
+          credentials: 'same-origin',
           url: '/pet'
         })
       })
@@ -206,6 +207,7 @@ describe('constructor', () => {
           headers: {
             authorization: 'Basic Zm9vOmJhcg=='
           },
+          credentials: 'same-origin',
           method: 'GET',
           url: '/pet'
         })
@@ -243,6 +245,7 @@ describe('constructor', () => {
           headers: {
             petKey: 'fooBar'
           },
+          credentials: 'same-origin',
           method: 'GET',
           url: '/pet'
         })
@@ -279,6 +282,7 @@ describe('constructor', () => {
         expect(http.calls[0].arguments[0]).toEqual({
           headers: { },
           method: 'GET',
+          credentials: 'same-origin',
           url: '/pet?petKey=barFoo'
         })
       })
@@ -317,6 +321,7 @@ describe('constructor', () => {
           headers: {
             authorization: 'Bearer one two'
           },
+          credentials: 'same-origin',
           method: 'GET',
           url: '/pet'
         })
@@ -354,6 +359,7 @@ describe('constructor', () => {
           headers: {
             Auth: 'yup'
           },
+          credentials: 'same-origin',
           method: 'GET',
           url: '/pet'
         })


### PR DESCRIPTION
follow up to https://github.com/swagger-api/swagger-js/pull/970

----------------------------

For issue https://github.com/swagger-api/swagger-ui/issues/2744

When Swagger UI is hosted behind user authorization(eg. http basic), the user enters username and password, and gets a cookie to access Swagger UI.
However when the swagger spec is downloaded from the same origin, the cookies are not sent in the request.

Also see https://github.com/github/fetch#sending-cookies
