### PR TITLE
Fix problem cannot resolve relative references

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "deps_check_dir": ".deps_check"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack -p --config ./webpack.config.js && NODE_ENV=production webpack -p --config ./webpack.bundle.config.js ",
+    "build": "NODE_ENV=production webpack -p --config ./webpack.config.js",
+    "build-bundle": "NODE_ENV=production webpack -p --config ./webpack.bundle.config.js",
     "watch": "webpack --config webpack.config.js --watch --progress",
     "test": "NODE_ENV=test node --debug ./node_modules/.bin/_mocha --recursive --compilers js:babel-core/register",
     "inspector": "node-debug",

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -20,7 +20,11 @@ export function clearCache() {
   plugins.refs.clearCache()
 }
 
-export default function resolve({http, fetch, spec, baseDoc, mode, allowMetaPatches = true}) {
+export default function resolve({http, fetch, spec, url, baseDoc, mode, allowMetaPatches = true}) {
+  // @TODO Swagger-UI uses baseDoc instead of url, this is to allow both
+  // need to fix and pick one.
+  baseDoc = baseDoc || url
+
   // Provide a default fetch implementation
   // TODO fetch should be removed, and http used instead
   http = fetch || http || Http

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -20,7 +20,7 @@ export function clearCache() {
   plugins.refs.clearCache()
 }
 
-export default function resolve({http, fetch, spec, url, mode, allowMetaPatches = true}) {
+export default function resolve({http, fetch, spec, baseDoc, mode, allowMetaPatches = true}) {
   // Provide a default fetch implementation
   // TODO fetch should be removed, and http used instead
   http = fetch || http || Http
@@ -28,11 +28,11 @@ export default function resolve({http, fetch, spec, url, mode, allowMetaPatches 
   if (!spec) {
     // We create a spec, that has a single $ref to the url
     // This is how we'll resolve it based on a URL only
-    spec = {$ref: url}
+    spec = {$ref: baseDoc}
   }
   else {
     // Store the spec into the url provided, to cache it
-    plugins.refs.docCache[url] = spec
+    plugins.refs.docCache[baseDoc] = spec
   }
 
   // Build a json-fetcher ( ie: give it a URL and get json out )
@@ -47,7 +47,7 @@ export default function resolve({http, fetch, spec, url, mode, allowMetaPatches 
   // mapSpec is where the hard work happens, see https://github.com/swagger-api/specmap for more details
   return mapSpec({
     spec,
-    context: {baseDoc: url},
+    context: {baseDoc},
     plugins: plugs,
     allowMetaPatches // allows adding .meta patches, which include adding `$$ref`s to the spec
   }).then(normalizeSwagger)

--- a/src/specmap/lib/context-tree.js
+++ b/src/specmap/lib/context-tree.js
@@ -60,7 +60,7 @@ export default class ContextTree {
       const children = branch.children
 
       if (!children[token] && ensureExists) {
-        children[token] = createNode()
+        children[token] = createNode(null, branch)
       }
 
       return children[token]
@@ -79,7 +79,7 @@ function createNode(value, parent) {
 function updateNode(node, value, parent) {
   node.value = value || {}
   node.protoValue = parent
-    ? Object.assign(Object.create(parent.protoValue), node.value)
+    ? {...parent.protoValue, ...node.value}
     : node.value
 
   Object.keys(node.children).forEach((prop) => {

--- a/src/specmap/lib/refs.js
+++ b/src/specmap/lib/refs.js
@@ -104,7 +104,7 @@ const plugin = {
     }
 
     const patch = lib.replace(parent, promOrVal, {$$ref: ref})
-    if (basePath) {
+    if (basePath && basePath !== baseDoc) {
       return [patch, lib.context(parent, {baseDoc: basePath})]
     }
 

--- a/test/index-authorizations.js
+++ b/test/index-authorizations.js
@@ -17,6 +17,7 @@ describe('(instance) #execute', function () {
       client.execute({http, operationId: 'getPets'})
       expect(http.calls.length).toEqual(1)
       expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
         headers: {},
         method: 'GET',
         url: '/pet'
@@ -50,6 +51,7 @@ describe('(instance) #execute', function () {
       client.execute({http, operationId: 'getPets'})
       expect(http.calls.length).toEqual(1)
       expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
         headers: {
           authorization: 'Basic Zm9vOmJhcg=='
         },
@@ -87,6 +89,7 @@ describe('(instance) #execute', function () {
       client.execute({http, operationId: 'getPets'})
       expect(http.calls.length).toEqual(1)
       expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
         headers: {
           petKey: 'fooBar'
         },
@@ -124,6 +127,7 @@ describe('(instance) #execute', function () {
       client.execute({http, operationId: 'getPets'})
       expect(http.calls.length).toEqual(1)
       expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
         headers: { },
         method: 'GET',
         url: '/pet?petKey=barFoo'
@@ -161,6 +165,7 @@ describe('(instance) #execute', function () {
       client.execute({http, operationId: 'getPets'})
       expect(http.calls.length).toEqual(1)
       expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
         headers: {
           authorization: 'Bearer one two'
         },
@@ -198,6 +203,7 @@ describe('(instance) #execute', function () {
       client.execute({http, operationId: 'getPets'})
       expect(http.calls.length).toEqual(1)
       expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
         headers: {
           Auth: 'yup'
         },
@@ -207,4 +213,3 @@ describe('(instance) #execute', function () {
     })
   })
 })
-

--- a/test/index.js
+++ b/test/index.js
@@ -383,7 +383,6 @@ describe('constructor', () => {
           req.url = 'http://petstore.swagger.io/v2/pet/4'
         }
       }).then((client) => {
-        console.log(client.apis)
         client.apis.pet.getPetById({petId: 3}).then((data) => {
           expect(data.body.id).toEqual(4)
           cb()

--- a/test/index.js
+++ b/test/index.js
@@ -383,6 +383,7 @@ describe('constructor', () => {
           req.url = 'http://petstore.swagger.io/v2/pet/4'
         }
       }).then((client) => {
+        console.log(client.apis)
         client.apis.pet.getPetById({petId: 3}).then((data) => {
           expect(data.body.id).toEqual(4)
           cb()

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -51,7 +51,7 @@ describe('resolver', () => {
     xmock().get(url, (req, res) => res.send({one: 1}))
 
     // When
-    return Swagger.resolve({url, allowMetaPatches: false})
+    return Swagger.resolve({baseDoc: url, allowMetaPatches: false})
       .then(handleResponse)
 
     // Then

--- a/test/specmap/context-tree.js
+++ b/test/specmap/context-tree.js
@@ -37,6 +37,13 @@ describe('ContextTree', function () {
     expect(tree.get(['one', 'two']).root).toEqual('rooty')
   })
 
+  it('should retrieve root after setting a sibling', function () {
+    const tree = new ContextTree()
+    tree.set([], {baseDoc: 'rooty'})
+    tree.set(['one', 'two', 'four'], {two: 2})
+    expect(tree.get(['one', 'three', 'four']).baseDoc).toEqual('rooty')
+  })
+
   it('should allow setting the root from contructor and get without arg, returns root', function () {
     const tree = new ContextTree({two: 2})
     const res = tree.get()


### PR DESCRIPTION
See https://github.com/swagger-api/swagger-ui/issues/2767#issuecomment-289913619

There are 2 problems:

* SwaggerUI passes in the wrong parameter name. To avoid having to change SwaggerUI, I change SwaggerJS to allow both names (because the correct name is used both internally and possibly other clients). We should clean up interface anyway in the next refactor.

* There's a certain behavior in the context-tree component that causes the baseDoc to be clear for all but the first reference. I talked to Josh and it was confirmed as a bug. Already add failed test and fix it.

I've tested the latest code with UI & the reported spec, it works without problem.  (Also, unrelated, but I also fixed some failed tests after merging from upstream master, we should enforce code change better and avoid code not passing tests to land into master.)

cc @webron @shockey @ponelat 