### PR TITLE
Use .buffer() for binary responses when .blob() is not available

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -54,7 +54,7 @@ function shouldDownloadAsText(contentType) {
 }
 
 // Serialize the response, returns a promise with headers and the body part of the hash
-export function serializeRes(oriRes, url, {loadSpec = false}) {
+export function serializeRes(oriRes, url, {loadSpec = false} = {}) {
   const res = {
     ok: oriRes.ok,
     url: oriRes.url || url,

--- a/src/http.js
+++ b/src/http.js
@@ -65,7 +65,10 @@ export function serializeRes(oriRes, url, {loadSpec = false}) {
 
   const useText = loadSpec || shouldDownloadAsText(res.headers['content-type'])
 
-  return oriRes[useText ? 'text' : 'blob']().then((body) => {
+  // Note: Response.blob not implemented in node-fetch 1.  Use buffer instead.
+  const getBody = useText ? oriRes.text : (oriRes.blob || oriRes.buffer)
+
+  return getBody.call(oriRes).then((body) => {
     res.text = body
     res.data = body
 

--- a/test/http.js
+++ b/test/http.js
@@ -172,12 +172,10 @@ describe('http', () => {
       headers.append('Authorization', 'Basic hoop-la')
       headers.append('Authorization', 'Advanced hoop-la')
 
-      const mockRes = new Request('http://swagger.io', {headers})
+      const res = fetchMock.mock('http://swagger.io', {headers})
 
-      const res = fetchMock.mock('http://swagger.io', mockRes)
-
-      fetch('http://swagger.io').then((_res) => {
-        return serializeRes(_res, 'https://swagger.io')
+      return fetch('http://swagger.io').then((_res) => {
+        return serializeRes(_res, 'https://swagger.io', {})
       }).then((resSerialize) => {
         expect(resSerialize.headers).toEqual({authorization: ['Basic hoop-la', 'Advanced hoop-la']})
       }).then(fetchMock.restore)

--- a/test/http.js
+++ b/test/http.js
@@ -180,5 +180,43 @@ describe('http', () => {
         expect(resSerialize.headers).toEqual({authorization: ['Basic hoop-la', 'Advanced hoop-la']})
       }).then(fetchMock.restore)
     })
+
+    it('should set .text and .data to body Blob or Buffer for binary response', function () {
+      const headers = {
+        'Content-Type': 'application/octet-stream'
+      }
+
+      const body = 'body data'
+      const res = fetchMock.mock('http://swagger.io', {body, headers})
+
+      return fetch('http://swagger.io').then((_res) => {
+        return serializeRes(_res, 'https://swagger.io', {})
+      }).then((resSerialize) => {
+        expect(resSerialize.data).toBe(resSerialize.text)
+        if (typeof Blob !== 'undefined') {
+          expect(resSerialize.data).toBeA(Blob)
+        }
+        else {
+          expect(resSerialize.data).toBeA(Buffer)
+          expect(resSerialize.data).toEqual(new Buffer(body))
+        }
+      }).then(fetchMock.restore)
+    })
+
+    it('should set .text and .data to body string for text response', function () {
+      const headers = {
+        'Content-Type': 'application/json'
+      }
+
+      const body = 'body data'
+      const res = fetchMock.mock('http://swagger.io', {body, headers})
+
+      return fetch('http://swagger.io').then((_res) => {
+        return serializeRes(_res, 'https://swagger.io', {})
+      }).then((resSerialize) => {
+        expect(resSerialize.data).toBe(resSerialize.text)
+        expect(resSerialize.data).toBe(body)
+      }).then(fetchMock.restore)
+    })
   })
 })

--- a/test/http.js
+++ b/test/http.js
@@ -168,9 +168,9 @@ describe('http', () => {
 
   describe('serializeRes', function () {
     it('should serialize fetch-like response and call serializeHeaders', function () {
-      const headers = new Headers()
-      headers.append('Authorization', 'Basic hoop-la')
-      headers.append('Authorization', 'Advanced hoop-la')
+      const headers = {
+        Authorization: ['Basic hoop-la', 'Advanced hoop-la']
+      }
 
       const res = fetchMock.mock('http://swagger.io', {headers})
 

--- a/test/http.js
+++ b/test/http.js
@@ -175,7 +175,7 @@ describe('http', () => {
       const res = fetchMock.mock('http://swagger.io', {headers})
 
       return fetch('http://swagger.io').then((_res) => {
-        return serializeRes(_res, 'https://swagger.io', {})
+        return serializeRes(_res, 'https://swagger.io')
       }).then((resSerialize) => {
         expect(resSerialize.headers).toEqual({authorization: ['Basic hoop-la', 'Advanced hoop-la']})
       }).then(fetchMock.restore)
@@ -190,7 +190,7 @@ describe('http', () => {
       const res = fetchMock.mock('http://swagger.io', {body, headers})
 
       return fetch('http://swagger.io').then((_res) => {
-        return serializeRes(_res, 'https://swagger.io', {})
+        return serializeRes(_res, 'https://swagger.io')
       }).then((resSerialize) => {
         expect(resSerialize.data).toBe(resSerialize.text)
         if (typeof Blob !== 'undefined') {
@@ -212,7 +212,7 @@ describe('http', () => {
       const res = fetchMock.mock('http://swagger.io', {body, headers})
 
       return fetch('http://swagger.io').then((_res) => {
-        return serializeRes(_res, 'https://swagger.io', {})
+        return serializeRes(_res, 'https://swagger.io')
       }).then((resSerialize) => {
         expect(resSerialize.data).toBe(resSerialize.text)
         expect(resSerialize.data).toBe(body)


### PR DESCRIPTION
This PR implements the fix requested in https://github.com/swagger-api/swagger-js/issues/979#issuecomment-290249977 by using `.buffer()` to get the binary response body when `.blob()` is not available, which occurs with `node-fetch` prior to version 2 (currently in alpha).

It also fixes the existing test for `serializeRes` which would always pass due to not returning the Promise value it created.  If you would prefer this to be split into a separate PR, let me know.

Thanks,
Kevin