### PR TITLE
Add path parameters to operation parameters

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -144,7 +144,6 @@ export function normalizeSwagger(parsedSpec) {
           toBeInherit.parameters = pathParameters
           inheritsList.push(toBeInherit)
         }
-        
 
         if (inheritsList.length !== 0) {
           for (const inherits of inheritsList) {
@@ -153,7 +152,8 @@ export function normalizeSwagger(parsedSpec) {
             for (const inhName in inherits) {
               if (!operation[inhName]) {
                 operation[inhName] = inherits[inhName]
-              } else if(inhName === "parameters") {
+              }
+              else if(inhName === "parameters") {
                 var exists = false
                 for(const item in inherits[inhName]) {
 
@@ -169,9 +169,9 @@ export function normalizeSwagger(parsedSpec) {
                 }
               }
             }
-
           }
         }
+
       }
     }
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -144,7 +144,7 @@ export function normalizeSwagger(parsedSpec) {
           toBeInherit.parameters = pathParameters
           inheritsList.push(toBeInherit)
         }
-
+        
 
         if (inheritsList.length !== 0) {
           for (const inherits of inheritsList) {
@@ -153,6 +153,10 @@ export function normalizeSwagger(parsedSpec) {
             for (const inhName in inherits) {
               if (!operation[inhName]) {
                 operation[inhName] = inherits[inhName]
+              } else if(inhName === "parameters") {
+                for(const item in inherits[inhName]) {
+                  operation[inhName].push(inherits[inhName][item])
+                }
               }
             }
           }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -154,11 +154,22 @@ export function normalizeSwagger(parsedSpec) {
               if (!operation[inhName]) {
                 operation[inhName] = inherits[inhName]
               } else if(inhName === "parameters") {
+                var exists = false
                 for(const item in inherits[inhName]) {
-                  operation[inhName].push(inherits[inhName][item])
+
+                  for(const param in operation[inhName]) {
+                    if(operation[inhName][param].name === inherits[inhName][item].name) {
+                      exists = true
+                    }
+                  }
+
+                  if(!exists) {
+                    operation[inhName].push(inherits[inhName][item])
+                  }
                 }
               }
             }
+
           }
         }
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -153,17 +153,17 @@ export function normalizeSwagger(parsedSpec) {
               if (!operation[inhName]) {
                 operation[inhName] = inherits[inhName]
               }
-              else if(inhName === "parameters") {
+              else if (inhName === "parameters") {
                 var exists = false
-                for(const item in inherits[inhName]) {
+                for (const item in inherits[inhName]) {
 
-                  for(const param in operation[inhName]) {
-                    if(operation[inhName][param].name === inherits[inhName][item].name) {
+                  for (const param in operation[inhName]) {
+                    if (operation[inhName][param].name === inherits[inhName][item].name) {
                       exists = true
                     }
                   }
 
-                  if(!exists) {
+                  if (!exists) {
                     operation[inhName].push(inherits[inhName][item])
                   }
                 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -355,6 +355,61 @@ describe('helpers', function () {
           }
         }})
       })
+
+      it('should not override operation parameters with the same name', function () {
+        const spec = {spec: {
+          paths: {
+            '/two': {
+              parameters: [
+                {
+                  name: 'user',
+                  in: 'path'
+                }
+              ],
+              get: {
+                parameters: [
+                  {
+                    name: 'user',
+                    in: 'query'
+                  },
+                  {
+                    name: 'test',
+                    in: 'query'
+                  }
+                ]
+              }
+            }
+          }
+        }}
+
+        const resultSpec = normalizeSwagger(spec)
+
+        expect(resultSpec).toEqual({spec: {
+          paths: {
+            '/two': {
+              parameters: [
+                {
+                  name: 'user',
+                  in: 'path'
+                }
+              ],
+              get: {
+                parameters: [
+                  {
+                    name: 'user',
+                    in: 'query'
+                  },
+                  {
+                    name: 'test',
+                    in: 'query'
+                  }
+                ]
+              }
+            }
+          }
+        }})
+      })
+
     })
   })
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -254,14 +254,18 @@ describe('helpers', function () {
     })
 
     describe('parameters', function () {
-      it('should not overwrite parameters from path when exists in operation', function () {
+      it('should add parameters from path to operation without overwriting', function () {
         const spec = {spec: {
           paths: {
             '/two': {
               parameters: [
                 {
                   name: 'user',
-                  in: 'query'
+                  in: 'path'
+                },
+                {
+                  name: 'blah',
+                  in: 'path'
                 }
               ],
               get: {
@@ -284,7 +288,11 @@ describe('helpers', function () {
               parameters: [
                 {
                   name: 'user',
-                  in: 'query'
+                  in: 'path'
+                },
+                {
+                  name: 'blah',
+                  in: 'path'
                 }
               ],
               get: {
@@ -292,6 +300,14 @@ describe('helpers', function () {
                   {
                     name: 'test',
                     in: 'query'
+                  },
+                  {
+                    name: 'user',
+                    in: 'path'
+                  },
+                  {
+                    name: 'blah',
+                    in: 'path'
                   }
                 ],
               }
@@ -307,7 +323,7 @@ describe('helpers', function () {
               parameters: [
                 {
                   name: 'user',
-                  in: 'query'
+                  in: 'path'
                 }
               ],
               get: {
@@ -324,14 +340,14 @@ describe('helpers', function () {
               parameters: [
                 {
                   name: 'user',
-                  in: 'query'
+                  in: 'path'
                 }
               ],
               get: {
                 parameters: [
                   {
                     name: 'user',
-                    in: 'query'
+                    in: 'path'
                   }
                 ]
               }


### PR DESCRIPTION
Currently path params are not being added to operation params, therefore path params are not shown in the `Try It Out` section.

This PR is fixing it.