### PR TITLE
Fixed sending header parameters when value is not set.

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -150,7 +150,9 @@ export function formDataBuilder({req, value, parameter}) {
 // Add a header to the request
 export function headerBuilder({req, parameter, value}) {
   req.headers = req.headers || {}
-  req.headers[parameter.name] = value
+  if (typeof value !== 'undefined') {
+    req.headers[parameter.name] = value
+  }
 }
 
 // Replace path paramters, with values ( ie: the URL )

--- a/test/execute.js
+++ b/test/execute.js
@@ -1161,6 +1161,62 @@ describe('execute', () => {
         })
       })
 
+      it('should process a delete request without headers of value undefined', function () {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/one': {
+              delete: {
+                operationId: 'deleteMe',
+                parameters: [{
+                  in: 'header',
+                  name: 'api_key',
+                  type: 'integer'
+                }]
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({spec, operationId: 'deleteMe', parameters: {api_key: undefined}})
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/one',
+          method: 'DELETE',
+          credentials: 'same-origin',
+          headers: {}
+        })
+      })
+
+      it('should process a delete request without headers wich are not provided', function () {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/one': {
+              delete: {
+                operationId: 'deleteMe',
+                parameters: [{
+                  in: 'header',
+                  name: 'api_key',
+                  type: 'integer'
+                }]
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({spec, operationId: 'deleteMe', parameters: {}})
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/one',
+          method: 'DELETE',
+          credentials: 'same-origin',
+          headers: {}
+        })
+      })
+
       it('should accept the format', function () {
         const spec = {
           host: 'swagger.io',


### PR DESCRIPTION
When user API specification contains custom header input parameter which is optional (required field equals false) and user doesn't provide value for it then client sends header with value of undefined. Example:
```
POST http://localhost:8080/example/url HTTP/1.1
Content-Length: 2
Content-Type: application/json
X-Customer-Header: undefined

{}
```

When header is optional and allowEmptyValue is set to false then header should not be sent. Example:
```
POST http://localhost:8080/example/url HTTP/1.1
Content-Length: 2
Content-Type: application/json

{}
```

When header is optional and allowEmptyValue is set to true then header should be sent with empty value. Example:
```
POST http://localhost:8080/example/url HTTP/1.1
Content-Length: 2
Content-Type: application/json

{}
```

According to https://tools.ietf.org/html/rfc7230 empty header value is valid.

