### PR TITLE
Fix error handling

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -11,7 +11,7 @@ export const self = {
 
 // Handles fetch-like syntax and the case where there is only one object passed-in
 // (which will have the URL as a property). Also serilizes the response.
-export default function http(url, request={}) {
+export default function http(url, request = {}) {
   if (typeof url === 'object') {
     request = url
     url = request.url
@@ -30,13 +30,18 @@ export default function http(url, request={}) {
 
   // for content-type=multipart\/form-data remove content-type from request before fetch
   // so that correct one with `boundary` is set
-  let contentType = request.headers["content-type"] || request.headers["Content-Type"]
+  const contentType = request.headers['content-type'] || request.headers['Content-Type']
   if (/multipart\/form-data/i.test(contentType)) {
     delete request.headers['content-type']
     delete request.headers['Content-Type']
   }
 
   return fetch(request.url, request).then((res) => {
+    if (!res.ok) {
+      const error = new Error(res.statusText)
+      error.statusCode = error.status = res.status
+      throw error
+    }
     return self.serializeRes(res, url, request).then((_res) => {
       if (request.responseInterceptor) {
         _res = request.responseInterceptor(_res) || _res
@@ -178,7 +183,7 @@ export function mergeInQueryOrForm(req = {}) {
       return isFile(form[key].value)
     })
 
-    let contentType = req.headers["content-type"] || req.headers["Content-Type"]
+    const contentType = req.headers['content-type'] || req.headers['Content-Type']
 
     if (hasFile || /multipart\/form-data/i.test(contentType)) {
       const FormData = require('isomorphic-form-data') // eslint-disable-line global-require

--- a/test/client.js
+++ b/test/client.js
@@ -7,15 +7,15 @@ import fs from 'fs'
 import Swagger from '../src/index'
 
 describe('http', () => {
-  var server
-  before(function() {
+  let server
+  before(function () {
     server = http.createServer(function (req, res) {
-      var accept = req.headers.accept
-      var contentType
-      var uri = url.parse(req.url).pathname;
-      var filename = path.join('test', 'data', uri);
+      const accept = req.headers.accept
+      let contentType
+      const uri = url.parse(req.url).pathname
+      const filename = path.join('test', 'data', uri)
 
-      if(filename.indexOf('.yaml') > 0) {
+      if (filename.indexOf('.yaml') > 0) {
         contentType = 'application/yaml'
       }
       else {
@@ -30,66 +30,66 @@ describe('http', () => {
         }
 
         if (accept.indexOf('application/json') >= 0) {
-          contentType = accept;
-          res.setHeader('Content-Type', contentType);
+          contentType = accept
+          res.setHeader('Content-Type', contentType)
         }
         if (filename.indexOf('.yaml') > 0) {
-          res.setHeader('Content-Type', 'application/yaml');
+          res.setHeader('Content-Type', 'application/yaml')
         }
       }
 
       fs.exists(filename, function (exists) {
-        if(exists) {
-          let fileStream = fs.createReadStream(filename);
+        if (exists) {
+          const fileStream = fs.createReadStream(filename)
           res.setHeader('Access-Control-Allow-Origin', '*')
           res.writeHead(200, contentType)
-          fileStream.pipe(res);
+          fileStream.pipe(res)
         }
         else {
-          res.writeHead(404, {'Content-Type': 'text/plain'});
-          res.write('404 Not Found\n');
-          res.end();
+          res.writeHead(404, {'Content-Type': 'text/plain'})
+          res.write('404 Not Found\n')
+          res.end()
         }
       })
     }).listen(8000)
   })
 
-  after(function() {
+  after(function () {
     server.close()
   })
 
   afterEach(function () {
   })
 
-  it.skip('should get the petstore api and build it', done => {
+  it.skip('should get the petstore api and build it', (done) => {
     Swagger('http://localhost:8000/petstore.json')
-      .then(client => {
+      .then((client) => {
         expect(client).toExist()
 
         // we have 3 tags
         expect(Object.keys(client.apis).length).toBe(3)
 
         // the pet tag exists
-        expect(client.apis['pet']).toExist()
+        expect(client.apis.pet).toExist()
 
         // the get pet operation
-        expect(client.apis['pet'].getPetById).toExist()
+        expect(client.apis.pet.getPetById).toExist()
 
         done()
-    })
+      })
   })
 
   /**
    * See https://github.com/swagger-api/swagger-js/issues/1005
    */
-  it.skip('should get a pet from the petstore', done => {
+  it.skip('should get a pet from the petstore', (done) => {
     Swagger('http://localhost:8000/petstore.json')
-      .then(client => {
-        client.apis['pet'].getPetById({petId: -1})
-          .then(data => {
+      .then((client) => {
+        client.apis.pet.getPetById({petId: -1})
+          .then((data) => {
             done('shoulda thrown an error!')
           })
-          .catch(err => {
+          .catch((err) => {
             done()
           })
       })
@@ -98,12 +98,12 @@ describe('http', () => {
   /**
    * See https://github.com/swagger-api/swagger-js/issues/1002
    */
-  it.skip('should return an error when a spec doesnt exist', done => {
+  it.skip('should return an error when a spec doesnt exist', (done) => {
     Swagger('http://localhost:8000/absent.yaml')
-      .then(client => {
+      .then((client) => {
         done('expected an error')
       })
-      .catch(error => {
+      .catch((error) => {
         done()
       })
   })
@@ -111,11 +111,11 @@ describe('http', () => {
   /**
    * See https://github.com/swagger-api/swagger-js/issues/1004
    */
-  it.skip('fail with invalid verbs', done => {
+  it.skip('fail with invalid verbs', (done) => {
     Swagger('http://localhost:8000/invalid-operation.yaml')
-      .then(client => {
-        expect(client.apis['default']).toExist()
-        expect(client.apis['default']['not-a-valid-verb']).toBeAn('undefined')
+      .then((client) => {
+        expect(client.apis.default).toExist()
+        expect(client.apis.default['not-a-valid-verb']).toBeAn('undefined')
         done()
       })
   })
@@ -124,15 +124,15 @@ describe('http', () => {
    * Loads a spec where the `host` and `schema` are not defined
    * See https://github.com/swagger-api/swagger-js/issues/1000
    */
-  it('use the host from whence the spec was fetched', done => {
+  it('use the host from whence the spec was fetched', (done) => {
     Swagger('http://localhost:8000/pathless.yaml')
-      .then(client => {
-        client.apis['default'].tryMe().then(data => {
-          expect(data.status).toBe(404)
+      .then((client) => {
+        client.apis.default.tryMe().catch((err) => {
+          expect(err.status).toBe(404)
           done()
         })
       })
-      .catch(err => {
+      .catch((err) => {
         done(err)
       })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,7 @@ describe('constructor', () => {
   })
 
   it('should return an instance, without "new"', function (cb) {
-    Swagger().then((instance) => {
+    Swagger({spec: {}}).then((instance) => {
       expect(instance).toBeA(Swagger)
       cb()
     })
@@ -94,6 +94,21 @@ describe('constructor', () => {
   })
 
   describe('#http', function () {
+    it('should throw if fetch error', function (cb) {
+      const xapp = xmock()
+      xapp.get('http://petstore.swagger.io/404', (req, res) => {
+        res.status(404)
+        res.send('not found')
+      })
+
+      new Swagger({url: 'http://petstore.swagger.io/404'})
+        .catch((err) => {
+          expect(err.status).toBe(404)
+          expect(err.message).toBe('Not Found')
+          cb()
+        })
+    })
+
     it('should serialize the response', function () {
       // Given
       require('isomorphic-fetch') // To ensure global.Headers


### PR DESCRIPTION
This fixes #1014 and #1002.

@fehguy please take a look. One thing of note: because fetch is shared for both spec loading & operation execution, the change affects operations, see https://github.com/swagger-api/swagger-js/compare/master...buunguyen:fix-error-handling-2?expand=1#diff-7e3bd8e7059a21bfd255649cbfc84b33R130 (must change from `then` to `catch`). This can be considered a breaking change from semver perspective. UI/editor might need to change.
