### PR TITLE
Fix for IE10 failed to parse JSON/YAML response

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -126,7 +126,7 @@ SwaggerClient.prototype.initialize = function (url, options) {
   if(this.url && this.url.indexOf('http:') === -1 && this.url.indexOf('https:') === -1) {
     // no protocol, so we can only use window if it exists
     if(typeof(window) !== 'undefined' && typeof(window.location) !== 'undefined') {
-      this.url = window.location.origin + this.url;
+      this.url = window.location.protocol + "//" + window.location.host + this.url;
     }
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -126,7 +126,11 @@ SwaggerClient.prototype.initialize = function (url, options) {
   if(this.url && this.url.indexOf('http:') === -1 && this.url.indexOf('https:') === -1) {
     // no protocol, so we can only use window if it exists
     if(typeof(window) !== 'undefined' && typeof(window.location) !== 'undefined') {
-      this.url = window.location.protocol + "//" + window.location.host + this.url;
+      // window.location.origin fix for IE
+      if (!window.location.origin) {
+        window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+      }
+      this.url = window.location.origin + this.url;
     }
   }
 


### PR DESCRIPTION
lib/client.js line 129 changed to this.url = window.location.protocol + // + window.location.host + this.url; to fix error in IE10 and other browsers that has a window object that does not have an 'origin' key in it's location.

explanation in my answer here:

http://stackoverflow.com/questions/43458634/ie10-swagger-error-failed-to-parse-json-yaml

@webron 
Referencing my issue #1018 