### PR TITLE
stringify request.body in #execute

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -1,5 +1,6 @@
 import assign from 'lodash/assign'
 import getIn from 'lodash/get'
+import isObject from 'lodash/isObject'
 import btoa from 'btoa'
 import url from 'url'
 import http, {mergeInQueryOrForm} from './http'
@@ -46,6 +47,10 @@ export function execute({
   }
 
   const request = self.buildRequest({spec, operationId, parameters, securities, ...extras})
+
+  if (request.body && isObject(request.body)) {
+    request.body = JSON.stringify(request.body)
+  }
 
   // Build request and execute it
   return userHttp(request)

--- a/test/execute.js
+++ b/test/execute.js
@@ -737,6 +737,29 @@ describe('execute', () => {
     expect(fetchSpy.calls.length).toEqual(1)
     expect(fetchSpy.calls[0].arguments[0].body).toEqual('{"one":1,"two":{"three":3}}')
   })
+
+  it('should NOT stringify body, if its a non-object', function () {
+    // Given
+    const spec = {
+      host: 'swagger.io',
+      paths: {'/me': {post: {parameters: [{name: 'body', in: 'body'}], operationId: 'makeMe'}}}
+    }
+
+    const fetchSpy = createSpy().andReturn({then() { }})
+
+    execute({
+      fetch: fetchSpy,
+      spec,
+      operationId: 'makeMe',
+      parameters: {
+        body: 'hello'
+      }
+    })
+
+    expect(fetchSpy.calls.length).toEqual(1)
+    expect(fetchSpy.calls[0].arguments[0].body).toEqual('hello')
+  })
+
   describe('applySecurities', function () {
     it('should NOT add any securities, if the operation does not require it', function () {
       const spec = {


### PR DESCRIPTION
and NOT in buildRequest, so as to allow other code to modify the body,
before finally getting processed by execute