### PR TITLE
Fix cyclic ref problem when baseDoc is specified

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -38,7 +38,9 @@ export default function resolve({http, fetch, spec, url, baseDoc, mode, allowMet
   return doResolve(spec)
 
   function doResolve(_spec) {
-    plugins.refs.docCache[baseDoc] = _spec
+    if (baseDoc) {
+      plugins.refs.docCache[baseDoc] = _spec
+    }
 
     // Build a json-fetcher ( ie: give it a URL and get json out )
     plugins.refs.fetchJSON = makeFetchJSON(http)

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,38 @@ describe('constructor', () => {
       })
     })
 
+    it('should resolve a cyclic spec when baseDoc is specified', function (cb) {
+      const spec = {
+        paths: {
+          post: {
+            parameters: [
+              {
+                $ref: '#/definitions/list',
+              }
+            ]
+          }
+        },
+        definitions: {
+          item: {
+            items: {
+              $ref: '#/definitions/item'
+            }
+          },
+          list: {
+            items: {
+              $ref: '#/definitions/item'
+            }
+          }
+        }
+      }
+
+      Swagger.resolve({spec, baseDoc: 'http://whatever/'}).then((swag) => {
+        expect(swag.errors).toEqual([])
+        cb()
+      })
+    })
+
+
     it('should keep resolve errors in #errors', function () {
       // Given
       const spec = {


### PR DESCRIPTION
Fix root cause of https://github.com/swagger-api/swagger-ui/issues/2892#event-1064243022. Pretty subtle bug. The fix isn't elegant, but that's to avoid changing the internal structure too much, better leave that for more significant refactoring.

cc @webron @shockey 