### PR TITLE
Do not depend the Authorization header on the token type.

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -241,7 +241,6 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
       const schema = securityDef[key]
       const {type} = schema
       const accessToken = token && token.access_token
-      const tokenType = token && token.token_type
 
       if (auth) {
         if (type === 'apiKey') {
@@ -259,7 +258,7 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'oauth2') {
-          result.headers.authorization = `${tokenType || 'Bearer'} ${accessToken}`
+          result.headers.authorization = `Bearer ${accessToken}`
         }
       }
     }

--- a/test/execute.js
+++ b/test/execute.js
@@ -924,6 +924,55 @@ describe('execute', () => {
         api_key: 'hello'
       })
     })
+
+    it('should use the correct authorization scheme with OAuth2', function() {
+      const spec = {
+        host: 'swagger.io',
+        basePath: '/v1',
+        security: [{oauth2app: []}],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getMe',
+              security: [{oauth2app: []}]
+            }
+          }
+        },
+        securityDefinitions: {
+          oauth2app: {
+            type: 'oauth2',
+            flow: 'application',
+            tokenUrl: 'https://swagger.io/oauth2/token',
+            scopes: {
+              read: 'read access'
+            }
+          }
+        }
+      }
+
+      const request = {
+        url: 'http://swagger.io/v1/one',
+        method: 'GET',
+        query: {}
+      }
+
+      const securities = {
+        authorized: {
+          oauth2app: {
+            token: {
+              access_token: 'one two',
+              token_type: 'bearer'
+            }
+          }
+        }
+      }
+
+      const applySecurity = applySecurities({request, securities, operation: spec.paths['/one'].get, spec})
+
+      expect(applySecurity.headers).toEqual({
+        authorization: 'Bearer one two'
+      })
+    })
   })
 
   describe('parameterBuilders', function () {


### PR DESCRIPTION
The token type is case insensitive.
The authorization scheme of the Authorization header is case sensitive.

Fixes #1040