### PR TITLE
Ensure we don't stringify FormData, and fix a multipart regression.

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -1,6 +1,6 @@
 import assign from 'lodash/assign'
 import getIn from 'lodash/get'
-import isObject from 'lodash/isObject'
+import isPlainObject from 'lodash/isPlainObject'
 import btoa from 'btoa'
 import url from 'url'
 import http, {mergeInQueryOrForm} from './http'
@@ -48,7 +48,7 @@ export function execute({
 
   const request = self.buildRequest({spec, operationId, parameters, securities, ...extras})
 
-  if (request.body && isObject(request.body)) {
+  if (request.body && isPlainObject(request.body)) {
     request.body = JSON.stringify(request.body)
   }
 
@@ -126,8 +126,6 @@ export function buildRequest({
 
   // Add securities, which are applicable
   req = applySecurities({request: req, securities, operation, spec})
-  // Will add the query object into the URL, if it exists
-  mergeInQueryOrForm(req)
 
   if (req.body || req.form) {
     if (requestContentType) {
@@ -142,6 +140,11 @@ export function buildRequest({
       req.headers['content-type'] = "application/x-www-form-urlencoded"
     }
   }
+
+  // Will add the query object into the URL, if it exists
+  // ... will also create a FormData instance, if multipart/form-data (eg: a file)
+  mergeInQueryOrForm(req)
+
   return req
 }
 

--- a/src/execute.js
+++ b/src/execute.js
@@ -1,5 +1,6 @@
 import assign from 'lodash/assign'
 import getIn from 'lodash/get'
+import isObject from 'lodash/isObject'
 import btoa from 'btoa'
 import url from 'url'
 import http, {mergeInQueryOrForm} from './http'
@@ -46,6 +47,10 @@ export function execute({
   }
 
   const request = self.buildRequest({spec, operationId, parameters, securities, ...extras})
+
+  if (request.body && isObject(request.body)) {
+    request.body = JSON.stringify(request.body)
+  }
 
   // Build request and execute it
   return userHttp(request)

--- a/test/execute.js
+++ b/test/execute.js
@@ -737,6 +737,29 @@ describe('execute', () => {
     expect(fetchSpy.calls.length).toEqual(1)
     expect(fetchSpy.calls[0].arguments[0].body).toEqual('{"one":1,"two":{"three":3}}')
   })
+
+  it('should NOT stringify body, if its a non-object', function () {
+    // Given
+    const spec = {
+      host: 'swagger.io',
+      paths: {'/me': {post: {parameters: [{name: 'body', in: 'body'}], operationId: 'makeMe'}}}
+    }
+
+    const fetchSpy = createSpy().andReturn({then() { }})
+
+    execute({
+      fetch: fetchSpy,
+      spec,
+      operationId: 'makeMe',
+      parameters: {
+        body: 'hello'
+      }
+    })
+
+    expect(fetchSpy.calls.length).toEqual(1)
+    expect(fetchSpy.calls[0].arguments[0].body).toEqual('hello')
+  })
+
   describe('applySecurities', function () {
     it('should NOT add any securities, if the operation does not require it', function () {
       const spec = {


### PR DESCRIPTION
Ensure we don't stringify FormData ( ie: files ) bodies. From https://github.com/swagger-api/swagger-js/pull/1034#event-1066274328

NOTE:
While testing, I bumped into a regression... file uploads were broken :/

I verified this works in the awesome commercial product SwaggerHub, which I think is super cool.
But doesn't work in editor.swagger.io ( also cool ).

```yaml
swagger: '2.0'
info:
  version: "1.0.0"
  description: Test file uploads
  title: Test File Uploads
host: httpbin.org

schemes:
  - https

paths:
  /post:
    post:
      consumes:
      - multipart/form-data
      produces:
      - application/json
      parameters:
      - name: "file"
        in: "formData"
        description: "file to upload"
        type: "file"
      responses:
        200: 
          description: ok

# The response from httpbin.org should include the filename under `files`
```
The spec I used to test. 

Anywhoo, this PR should fix it ( I say should, as I don't have time to wire up editor+ui+js right now ).

