### PR TITLE
[Fix] Wrong isomorphic-fetch import

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-fetch'
+import 'isomorphic-fetch'
 import qs from 'qs'
 import jsYaml from 'js-yaml'
 import assign from 'lodash/assign'


### PR DESCRIPTION
Change the import method for fetch (Recommended by : https://github.com/matthew-andrews/isomorphic-fetch).

I have a problem with the current exported `fetch` of `isomorphic-fetch` : 
I want to mock fetch for unit testing (Not just swagger part), and actually its impossible because of webpack.
Ex : 
This es6 code :
```js
import fetch from 'isomorphic-fetch'
```
will be transpiled by babel, transformed by webpack and the result something like this : 
```js
var _isomorphicFetch2 = _interopRequireDefault(_isomorphicFetch);
var _isomorphicFetch = __webpack_require__(15);
// And the webpack require =>
/* 15 */
/***/ (function(module, exports) {
module.exports = require("isomorphic-fetch");
/***/ })
```
If we look at es6 swagger code for fetch
```js
  return fetch(request.url, request).then((res) => {
    const serialized = self.serializeRes(res, url, request).then((_res) => {
```
The transform result is
```js
return (0, _isomorphicFetch2.default)(request.url, request).then(function (res) {
    var serialized = self.serializeRes(res, url, request).then(function (_res) {
```
but `_isomorphicFetch2.default` is the export of package `isomorphic-fetch` at loading time (In browser this is the native fetch function), so it will use `_isomorphicFetch2.default` not `global.fetch` and you cannot mock the fetch.


