### PR TITLE
helpers/getOperationRaw: find operations with escapable characters

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,10 +37,12 @@ export function getOperationRaw(spec, id) {
       return false
     }
 
+    const rawOperationId = operation.operationId // straight from the source
     const operationId = opId(operation, pathName, method)
     const legacyOperationId = legacyIdFromPathMethod(pathName, method)
 
-    return operationId && (operationId === id || id === legacyOperationId)
+    return [operationId, legacyOperationId, rawOperationId]
+      .some(val => val === id)
   })
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,7 +49,7 @@ export function getOperationRaw(spec, id) {
 // Will stop iterating over the operations and return the operationObj
 // as soon as predicate returns true
 export function findOperation(spec, predicate) {
-  return eachOperation(spec, predicate, true) || {}
+  return eachOperation(spec, predicate, true) || null
 }
 
 // iterate over each operation, and fire a callback with details

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,14 +42,14 @@ export function getOperationRaw(spec, id) {
     const legacyOperationId = legacyIdFromPathMethod(pathName, method)
 
     return [operationId, legacyOperationId, rawOperationId]
-      .some(val => val === id)
+      .some(val => val && val === id)
   })
 }
 
 // Will stop iterating over the operations and return the operationObj
 // as soon as predicate returns true
 export function findOperation(spec, predicate) {
-  return eachOperation(spec, predicate, true)
+  return eachOperation(spec, predicate, true) || {}
 }
 
 // iterate over each operation, and fire a callback with details

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -36,6 +36,27 @@ describe('helpers', function () {
       })
     })
 
+    it('should return the operation object, given an explicit operationId with special characters', function () {
+      // Given
+      const spec = {
+        paths: {
+          '/one': {
+            get: {operationId: 'A.Very_Special-operationID!'}
+          }
+        }
+      }
+
+      // When
+      const op = getOperationRaw(spec, 'A.Very_Special-operationID!')
+
+      // Then
+      expect(op).toInclude({
+        operation: spec.paths['/one'].get,
+        pathName: '/one',
+        method: 'GET'
+      })
+    })
+
     it('should return the operationObj, given a generated operationId', function () {
       // Given`
       const spec = {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,6 +57,23 @@ describe('helpers', function () {
       })
     })
 
+    it('should return null, given an explicit operationId that does not exist', function () {
+      // Given
+      const spec = {
+        paths: {
+          '/one': {
+            get: {operationId: 'getOne'}
+          }
+        }
+      }
+
+      // When
+      const op = getOperationRaw(spec, 'ThisOperationIdDoesNotExist')
+
+      // Then
+      expect(op).toEqual({})
+    })
+
     it('should return the operationObj, given a generated operationId', function () {
       // Given`
       const spec = {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -71,7 +71,7 @@ describe('helpers', function () {
       const op = getOperationRaw(spec, 'ThisOperationIdDoesNotExist')
 
       // Then
-      expect(op).toEqual({})
+      expect(op).toEqual(null)
     })
 
     it('should return the operationObj, given a generated operationId', function () {


### PR DESCRIPTION
Modifies `getOperationRaw` to support matching an operation by raw operationId (for https://github.com/swagger-api/swagger-ui/issues/3146).

Also, modifies `findOperation` to return an `null` instead of `undefined` when an operation can't be found - to indicate intentionally returning nothing.