### PR TITLE
Node 8.0 + npm@3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
 - '4.7'
 - '6.9'
+- '8.0'
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
This PR:

- Starts running tests in Node 8.0 as well
- Deploys to npm using `npm@5` (publishes with sha512 subresource integrity!)