### PR TITLE
Add same-origin credentials policy to makeFetchJSON

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -9,7 +9,8 @@ export function makeFetchJSON(http) {
       loadSpec: true,
       headers: {
         Accept: 'application/json'
-      }
+      },
+      credentials: 'same-origin' // same-origin to send cookies and auth headers
     })
     .then((res) => {
       return res.body


### PR DESCRIPTION
Adds [credentials: same-origin](https://github.com/github/fetch#sending-cookies) to resolved fetch options. This will instruct the browser to send cookies and authorization headers when fetching external definitions.

Existing issue: https://github.com/swagger-api/swagger-js/issues/1025
Symptom issue in swagger-ui: https://github.com/swagger-api/swagger-ui/issues/3220

Note on testing: Since these tests do not run in a browser, it would be difficult to assert that cookies are being set properly in a test. We could however create a spy that ensures that `fetch` is getting the `credentials: same-origin` option passed to it. 

@shockey 