### PR TITLE
Add repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.14",
   "description": "SwaggerJS - a collection of interfaces for OAI specs",
   "main": "dist/index.js",
+  "repository": "git@github.com:swagger-api/swagger-js.git",
   "contributors": [
     "(in alphabetical order)",
     "Anna Bodnia <anna.bodnia@gmail.com>",


### PR DESCRIPTION
When viewing this package on npm.org, there is no link to the source code in this repo. This is especially confusing because the package name and repo name are different (swagger-js vs swagger-client).

We could also consider renaming the repository to `swagger-client`: git will automatically handle redirecting old urls that still reference `swagger-js`...