### PR TITLE
clean up the http stuff and make a fetch method injectable

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -36,7 +36,6 @@ export const PARAMETER_BUILDERS = {
 // pathName/method or operationId is optional
 export function execute({
   http: userHttp,
-  fetch, // This is legacy
   spec,
   operationId,
   pathName,
@@ -46,7 +45,7 @@ export function execute({
   ...extras
 }) {
   // Provide default fetch implementation
-  userHttp = userHttp || fetch || http // Default to _our_ http
+  userHttp = userHttp || http // Default to _our_ http
 
   if (pathName && method && !operationId) {
     operationId = legacyIdFromPathMethod(pathName, method)
@@ -66,7 +65,7 @@ export function execute({
 export function buildRequest({
   spec, operationId, parameters, securities, requestContentType,
   responseContentType, parameterBuilders, scheme,
-  requestInterceptor, responseInterceptor, contextUrl
+  requestInterceptor, responseInterceptor, contextUrl, fetch
 }) {
   parameterBuilders = parameterBuilders || PARAMETER_BUILDERS
 
@@ -86,6 +85,9 @@ export function buildRequest({
   }
   if (responseInterceptor) {
     req.responseInterceptor = responseInterceptor
+  }
+  if (fetch) {
+    req.fetch = fetch
   }
 
   // Mostly for testing

--- a/src/http.js
+++ b/src/http.js
@@ -141,7 +141,7 @@ function formatValue({ value, collectionFormat, allowEmptyValue }, skipEncoding)
     return value;
   }
 
-  let encodeFn = encodeURIComponent
+  let encodeFn = encodeURIComponent;
   if (skipEncoding) {
     encodeFn = isString(value) ? str => str : obj => JSON.stringify(obj);
   }
@@ -229,6 +229,3 @@ export function makeHttp(httpFn, preFetch = a => a, postFetch = a => a) {
     )
   );
 }
-process.on('unhandledRejection', (reason) => {
-    console.log(eason);
-});

--- a/src/http.js
+++ b/src/http.js
@@ -8,101 +8,90 @@ import isString from 'lodash/isString'
 export const self = {
   serializeRes,
   mergeInQueryOrForm
-}
+};
 
 // Handles fetch-like syntax and the case where there is only one object passed-in
 // (which will have the URL as a property). Also serilizes the response.
-export default function http(url, request = {}) {
-  if (typeof url === 'object') {
-    request = url
-    url = request.url
+export default function http(arg1, arg2 = {}) {
+  let request = arg2;
+  if (typeof arg1 === 'object') {
+    request = arg1;
+  } else {
+    request.url = arg1;
   }
 
-  request.headers = request.headers || {}
+  request.headers = request.headers || {};
 
   // Serializes query, for convenience
   // Should be the last thing we do, as its hard to mutate the URL with
   // the search string, but much easier to manipulate the req.query object
-  self.mergeInQueryOrForm(request)
-
-  if (request.requestInterceptor) {
-    request = request.requestInterceptor(request) || request
-  }
+  request = (req => (request.requestInterceptor || (req => req))(req) || req)(
+    self.mergeInQueryOrForm(request)
+  );
 
   // for content-type=multipart\/form-data remove content-type from request before fetch
   // so that correct one with `boundary` is set
-  const contentType = request.headers['content-type'] || request.headers['Content-Type']
-  if (/multipart\/form-data/i.test(contentType)) {
-    delete request.headers['content-type']
-    delete request.headers['Content-Type']
+  if ((request.headers['content-type'] || request.headers['Content-Type'] || "").toLowerCase().includes("multipart/form-data")) {
+    delete request.headers['content-type'];
+    delete request.headers['Content-Type'];
   }
 
-  return fetch(request.url, request).then((res) => {
-    const serialized = self.serializeRes(res, url, request).then((_res) => {
-      if (request.responseInterceptor) {
-        _res = request.responseInterceptor(_res) || _res
-      }
-      return _res
-    })
+  return (request.fetch || fetch)(request.url, request).then((res) => {
+    const serialized = self
+      .serializeRes(res, request.url, request)
+      .then((_res) => (request.responseInterceptor || (res => res))(_res) || _res);
 
     if (!res.ok) {
-      const error = new Error(res.statusText)
-      error.statusCode = error.status = res.status
+      const error = new Error(res.statusText);
+      error.statusCode = error.status = res.status;
       return serialized.then(
         (_res) => {
-          error.response = _res
-          throw error
+          error.response = _res;
+          throw error;
         },
         (resError) => {
-          error.responseError = resError
-          throw error
+          error.responseError = resError;
+          throw error;
         }
-      )
+      );
     }
 
-    return serialized
-  })
+    return serialized;
+  });
 }
 
-function shouldDownloadAsText(contentType) {
-  return /json/.test(contentType) ||
-         /xml/.test(contentType) ||
-         /yaml/.test(contentType) ||
-         /text/.test(contentType)
+function shouldDownloadAsText(contentType = "") {
+  return ["json", "xml", "yaml", "text"].some(str => contentType.includes(str));
 }
 
 // Serialize the response, returns a promise with headers and the body part of the hash
-export function serializeRes(oriRes, url, {loadSpec = false} = {}) {
+export function serializeRes(oriRes, url, { loadSpec = false } = {}) {
   const res = {
     ok: oriRes.ok,
     url: oriRes.url || url,
     status: oriRes.status,
     statusText: oriRes.statusText,
     headers: serializeHeaders(oriRes.headers)
-  }
+  };
 
-  const useText = loadSpec || shouldDownloadAsText(res.headers['content-type'])
+  const useText = loadSpec || shouldDownloadAsText(res.headers['content-type']);
 
   // Note: Response.blob not implemented in node-fetch 1.  Use buffer instead.
-  const getBody = useText ? oriRes.text : (oriRes.blob || oriRes.buffer)
+  const getBody = useText ? oriRes.text : (oriRes.blob || oriRes.buffer);
 
   return getBody.call(oriRes).then((body) => {
-    res.text = body
-    res.data = body
+    res.text = res.data = body;
 
     if (useText) {
       try {
         // Optimistically try to convert all bodies
-        const obj = jsYaml.safeLoad(body)
-        res.body = obj
-        res.obj = obj
-      }
-      catch (e) {
-        res.parseError = e
+        res.body = res.obj = jsYaml.safeLoad(body);
+      } catch (e) {
+        res.parseError = e;
       }
     }
-    return res
-  })
+    return res;
+  });
 }
 
 // Serialize headers into a hash, where mutliple-headers result in an array.
@@ -111,63 +100,62 @@ export function serializeRes(oriRes, url, {loadSpec = false} = {}) {
 //     Cookie: two
 //  =  { Cookie: [ "one", "two" ]
 export function serializeHeaders(headers = {}) {
-  const obj = {}
+  const obj = {};
 
   // Iterate over headers, making multiple-headers into an array
   if (typeof headers.forEach === 'function') {
     headers.forEach((headerValue, header) => {
       if (obj[header] !== undefined) {
-        obj[header] = Array.isArray(obj[header]) ? obj[header] : [obj[header]]
-        obj[header].push(headerValue)
+        obj[header] = Array.isArray(obj[header]) ? obj[header] : [obj[header]];
+        obj[header].push(headerValue);
       }
       else {
-        obj[header] = headerValue
+        obj[header] = headerValue;
       }
     })
-    return obj
+    return obj;
   }
 
-  return obj
+  return obj;
 }
 
 function isFile(obj) {
   if (typeof File !== 'undefined') {
-    return obj instanceof File
+    return obj instanceof File;
   }
-  return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function'
+  return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function';
 }
 
-function formatValue({value, collectionFormat, allowEmptyValue}, skipEncoding) {
+function formatValue({ value, collectionFormat, allowEmptyValue }, skipEncoding) {
   const SEPARATORS = {
     csv: ',',
     ssv: '%20',
     tsv: '%09',
     pipes: '|'
-  }
+  };
 
-  if (typeof value === 'undefined' && allowEmptyValue) {
-    return ''
+  if (value === undefined && allowEmptyValue) {
+    return '';
   }
   if (isFile(value)) {
-    return value
+    return value;
   }
 
   let encodeFn = encodeURIComponent
   if (skipEncoding) {
-    if (isString(value)) encodeFn = str => str
-    else encodeFn = obj => JSON.stringify(obj)
+    encodeFn = isString(value) ? str => str : obj => JSON.stringify(obj);
   }
 
   if (value && !Array.isArray(value)) {
-    return encodeFn(value)
+    return encodeFn(value);
   }
   if (Array.isArray(value) && !collectionFormat) {
-    return value.map(encodeFn).join(',')
+    return value.map(encodeFn).join(',');
   }
   if (collectionFormat === 'multi') {
-    return value.map(encodeFn)
+    return value.map(encodeFn);
   }
-  return value.map(encodeFn).join(SEPARATORS[collectionFormat])
+  return value.map(encodeFn).join(SEPARATORS[collectionFormat]);
 }
 
 // Encodes an object using appropriate serializer.
@@ -179,75 +167,68 @@ export function encodeFormOrQuery(data) {
    * @return {object} encoded parameter names and values
    */
   const encodedQuery = Object.keys(data).reduce((result, parameterName) => {
-    const isObject = a => a && typeof a === 'object'
-    const paramValue = data[parameterName]
-    const encodedParameterName = encodeURIComponent(parameterName)
-    const notArray = isObject(paramValue) && !Array.isArray(paramValue)
-    result[encodedParameterName] = formatValue(notArray ? paramValue : {value: paramValue})
-    return result
-  }, {})
-  return qs.stringify(encodedQuery, {encode: false, indices: false}) || ''
+    const isObject = a => a && typeof a === 'object';
+    const paramValue = data[parameterName];
+    const encodedParameterName = encodeURIComponent(parameterName);
+    const notArray = isObject(paramValue) && !Array.isArray(paramValue);
+    result[encodedParameterName] = formatValue(notArray ? paramValue : { value: paramValue });
+    return result;
+  }, {});
+  return qs.stringify(encodedQuery, { encode: false, indices: false }) || '';
 }
 
 // If the request has a `query` object, merge it into the request.url, and delete the object
 export function mergeInQueryOrForm(req = {}) {
-  const {url = '', query, form} = req
+  const { url = '', query, form } = req;
 
   const joinSearch = (...strs) => {
-    const search = strs.filter(a => a).join('&') // Only truthy value
-    return search ? `?${search}` : '' // Only add '?' if there is a str
-  }
+    const search = strs.filter(a => a).join('&');
+    return search ? `?${search}` : ''; // Only add '?' if there is a str
+  };
 
   if (form) {
-    const hasFile = Object.keys(form).some((key) => {
-      return isFile(form[key].value)
-    })
-
-    const contentType = req.headers['content-type'] || req.headers['Content-Type']
-
-    if (hasFile || /multipart\/form-data/i.test(contentType)) {
-      const FormData = require('isomorphic-form-data') // eslint-disable-line global-require
-      req.body = new FormData()
+    const hasFile = Object.keys(form).some((key) => isFile(form[key].value));
+    const isForm = (req.headers['content-type'] || req.headers['Content-Type'] || "").toLowerCase().includes("multipart/form-data");
+    if (hasFile || isForm) {
+      const FormData = require('isomorphic-form-data'); // eslint-disable-line global-require
+      req.body = new FormData();
       Object.keys(form).forEach((key) => {
-        req.body.append(key, formatValue(form[key], true))
-      })
-    }
-    else {
-      req.body = encodeFormOrQuery(form)
+        req.body.append(key, formatValue(form[key], true));
+      });
+    } else {
+      req.body = encodeFormOrQuery(form);
     }
 
-    delete (req.form)
+    delete (req.form);
   }
 
   if (query) {
-    const [baseUrl, oriSearch] = url.split('?')
-    let newStr = ''
+    const [baseUrl, oriSearch] = url.split('?');
+    let newStr = '';
 
     if (oriSearch) {
-      const oriQuery = qs.parse(oriSearch)
-      const keysToRemove = Object.keys(query)
-      keysToRemove.forEach(key => delete oriQuery[key])
-      newStr = qs.stringify(oriQuery, {encode: true})
+      const oriQuery = qs.parse(oriSearch);
+      const keysToRemove = Object.keys(query);
+      keysToRemove.forEach(key => delete oriQuery[key]);
+      newStr = qs.stringify(oriQuery, { encode: true });
     }
 
-    const finalStr = joinSearch(newStr, encodeFormOrQuery(query))
-    req.url = baseUrl + finalStr
-    delete (req.query)
+    req.url = baseUrl + joinSearch(newStr, encodeFormOrQuery(query));
+    delete (req.query);
   }
-  return req
+  return req;
 }
 
 // Wrap a http function ( there are otherways to do this, conisder this deprecated )
-export function makeHttp(httpFn, preFetch, postFetch) {
-  postFetch = postFetch || (a => a)
-  preFetch = preFetch || (a => a)
-
-  return (req) => {
-    if (typeof req === 'string') {
-      req = {url: req}
-    }
-    self.mergeInQueryOrForm(req)
-    req = preFetch(req)
-    return postFetch(httpFn(req))
-  }
+export function makeHttp(httpFn, preFetch = a => a, postFetch = a => a) {
+  return req => postFetch(
+    httpFn(
+      preFetch(
+        self.mergeInQueryOrForm(typeof req === 'string' ? { url: req } : req)
+      )
+    )
+  );
 }
+process.on('unhandledRejection', (reason) => {
+    console.log(eason);
+});

--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -18,7 +18,7 @@ export function makeExecute(swaggerJs = {}) {
   return ({pathName, method, operationId}) => (parameters, opts = {}) => {
     return swaggerJs.execute({
       spec: swaggerJs.spec,
-      ...pick(swaggerJs, 'requestInterceptor', 'responseInterceptor'),
+      ...pick(swaggerJs, 'requestInterceptor', 'responseInterceptor', 'fetch'),
       pathName,
       method,
       parameters,

--- a/test/execute.js
+++ b/test/execute.js
@@ -116,7 +116,7 @@ describe('execute', () => {
       const spy = createSpy().andReturn(Promise.resolve())
 
       execute({
-        fetch: spy,
+        http: spy,
         spec,
         operationId: 'getMe'
       })
@@ -714,7 +714,7 @@ describe('execute', () => {
     const buildRequestSpy = spyOn(stubs, 'buildRequest').andReturn({})
 
     execute({
-      fetch: createSpy().andReturn({then() { }}),
+      http: createSpy().andReturn({then() { }}),
       spec,
       operationId: 'getMe',
       josh: 1
@@ -736,7 +736,7 @@ describe('execute', () => {
     const fetchSpy = createSpy().andReturn({then() { }})
 
     execute({
-      fetch: fetchSpy,
+      http: fetchSpy,
       spec,
       operationId: 'makeMe',
       parameters: {
@@ -763,7 +763,7 @@ describe('execute', () => {
     const fetchSpy = createSpy().andReturn({then() { }})
 
     execute({
-      fetch: fetchSpy,
+      http: fetchSpy,
       spec,
       operationId: 'makeMe',
       parameters: {
@@ -786,7 +786,7 @@ describe('execute', () => {
     const fetchSpy = createSpy().andReturn({then() { }})
 
     execute({
-      fetch: fetchSpy,
+      http: fetchSpy,
       spec,
       operationId: 'makeMe',
       requestContentType: 'multipart/form-data',


### PR DESCRIPTION
- fetch was marked legacy in the execute file, i guess because it was used in the tests instead of http
- i started to clean up the http file because it was missing semicolons, modifying arguments and some other stuff, might fix that in the other files at some point
- removed the regexes aswell and switched to a probably more performant and risk free string matching :)

i hope its ok that this is in one commit and i hope you guys didnt have plans for the fetch method but a friend and i were building a h2 proxy for which we ended up nearly completely copying the http file just to exchange the fetch method in it so if other people would like to exchange the fetch method with request.js or something else, this should allow them to do so…

all tests are passing btw :)