### PR TITLE
Change the regex, increase performance increadibly :D

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -64,7 +64,8 @@ export default function http(url, request = {}) {
   })
 }
 
-const shouldDownloadAsText = (contentType = "") => /json|xml|yaml|text/.test(contentType)
+// exported for testing
+export const shouldDownloadAsText = (contentType = "") => /json|xml|yaml|text/.test(contentType)
 
 // Serialize the response, returns a promise with headers and the body part of the hash
 export function serializeRes(oriRes, url, {loadSpec = false} = {}) {

--- a/src/http.js
+++ b/src/http.js
@@ -64,12 +64,7 @@ export default function http(url, request = {}) {
   })
 }
 
-function shouldDownloadAsText(contentType) {
-  return /json/.test(contentType) ||
-         /xml/.test(contentType) ||
-         /yaml/.test(contentType) ||
-         /text/.test(contentType)
-}
+const shouldDownloadAsText = (contentType = "") => /json|xml|yaml|text/.test(contentType)
 
 // Serialize the response, returns a promise with headers and the body part of the hash
 export function serializeRes(oriRes, url, {loadSpec = false} = {}) {

--- a/test/http.js
+++ b/test/http.js
@@ -1,7 +1,10 @@
 import expect from 'expect'
 import xmock from 'xmock'
 import fetchMock from 'fetch-mock'
-import http, {serializeHeaders, mergeInQueryOrForm, encodeFormOrQuery, serializeRes} from '../src/http'
+import http, {
+  serializeHeaders, mergeInQueryOrForm, encodeFormOrQuery, serializeRes,
+  shouldDownloadAsText
+} from '../src/http'
 
 describe('http', () => {
   let xapp
@@ -301,6 +304,33 @@ describe('http', () => {
         expect(resSerialize.data).toBe(resSerialize.text)
         expect(resSerialize.data).toBe(body)
       }).then(fetchMock.restore)
+    })
+  })
+
+  describe('shouldDownloadAsText', () => {
+    it('should return true for json, xml, yaml, and text types', function() {
+      const types = [
+        "text/x-yaml", "application/xml", "text/xml", "application/json",
+        "text/plain"
+      ]
+
+      types.forEach(v => {
+        expect(`${v} ${shouldDownloadAsText(v)}`).toEqual(v + " true")
+      })
+    })
+
+    it('should return false for other common types', function() {
+      const types = [
+        "application/octet-stream", "application/x-binary"
+      ]
+
+      types.forEach(v => {
+        expect(`${v} ${shouldDownloadAsText(v)}`).toEqual(v + " false")
+      })
+    })
+
+    it('should fail gracefully when called with no parameters', function() {
+      expect(shouldDownloadAsText()).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
first vs last
```
function shouldDownloadAsTextOrig(contentType) {
  return /json/.test(contentType) ||
        /xml/.test(contentType) ||
        /yaml/.test(contentType) ||
        /text/.test(contentType)
}
/*
Orig|json x 11,477,916 ops/sec ±0.75% (91 runs sampled)
Orig|xml x 7,497,474 ops/sec ±0.52% (97 runs sampled)
Orig|yaml x 5,051,156 ops/sec ±0.68% (94 runs sampled)
Orig|text x 4,224,534 ops/sec ±0.39% (96 runs sampled)
*/

function shouldDownloadAsTextOne(contentType = "") {
  return ["json", "xml", "yaml", "text"].some(str => contentType.includes(str))
}
/*
One|json x 6,393,355 ops/sec ±0.62% (94 runs sampled)
One|xml x 4,242,619 ops/sec ±0.89% (94 runs sampled)
One|yaml x 2,880,927 ops/sec ±0.35% (95 runs sampled)
One|text x 2,286,908 ops/sec ±0.61% (93 runs sampled)
*/

function shouldDownloadAsTextTwo(contentType = "") {
    return /json|xml|yaml|text/.test(contentType)
}
/*
Two|json x 19,513,133 ops/sec ±0.29% (92 runs sampled)
Two|xml x 24,767,680 ops/sec ±0.70% (93 runs sampled)
Two|yaml x 24,596,672 ops/sec ±0.31% (94 runs sampled)
Two|text x 24,863,942 ops/sec ±0.68% (88 runs sampled)
*/

const shouldDownloadAsTextThree = (contentType = "") => /json|xml|yaml|text/.test(contentType)
/*
three|json x 20,038,598 ops/sec ±0.31% (93 runs sampled)
three|xml x 24,801,552 ops/sec ±0.68% (92 runs sampled)
three|yaml x 25,187,765 ops/sec ±0.47% (94 runs sampled)
three|text x 25,252,579 ops/sec ±0.67% (96 runs sampled)
*/
```