### PR TITLE
Allow false query parameters

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -148,7 +148,8 @@ function formatValue({value, collectionFormat, allowEmptyValue}, skipEncoding) {
   if (typeof value === 'undefined' && allowEmptyValue) {
     return ''
   }
-  if (isFile(value)) {
+
+  if (isFile(value) || typeof value === 'boolean') {
     return value
   }
 

--- a/test/http.js
+++ b/test/http.js
@@ -208,11 +208,14 @@ describe('http', () => {
           },
           two: {
             value: 2
+          },
+          three: {
+            value: false
           }
         }
       }
 
-      expect(encodeFormOrQuery(req.query)).toEqual('one=1&two=2')
+      expect(encodeFormOrQuery(req.query)).toEqual('one=1&two=2&three=false')
     })
 
     it('should handle arrays', function () {


### PR DESCRIPTION
Currently, when passing a boolean query parameter with a value of `false` to `http`, the following error surfaces:

```
 TypeError: value.map is not a function
      at formatValue (src/http.js:171:16)
      at src/http.js:187:36
      at Array.reduce (native)
      at encodeFormOrQuery (src/http.js:182:42)
      at Context.<anonymous> (test/http.js:218:14)
```

This PR resolves this error by adding a boolean type check in the `formatValue` function.