### PR TITLE
Manually merge arrays inside mergeDeep

### DIFF
--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -44,7 +44,19 @@ function applyPatch(obj, patch, opts) {
   else if (patch.op === 'mergeDeep') {
     const valPatch = _get(patch.path)
     jsonPatch.apply(obj, [valPatch])
+    const origValPatchValue = Object.assign({}, valPatch.value)
     deepExtend(valPatch.value, patch.value)
+
+    // deepExtend doesn't merge arrays, so we will do it manually
+    for ( let prop in patch.value ) {
+      if ( patch.value.hasOwnProperty(prop) ) {
+        const propVal = patch.value[prop]
+        if ( Array.isArray(propVal) ) {
+          let existing = origValPatchValue[prop] || []
+          valPatch.value[prop] = existing.concat( propVal )
+        }
+      }
+    }
   }
   else {
     jsonPatch.apply(obj, [patch])

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -173,6 +173,51 @@ describe('allOf', function () {
       })
     })
   })
+
+  it('merges arrays inside of an `allOf`', function() {
+    return mapSpec({
+      plugins: [plugins.refs, plugins.allOf],
+      showDebug: true,
+      spec: {
+        definitions: {
+          one: {
+            allOf: [
+              {
+                $ref: '#/definitions/two'
+              },
+              {
+                type: 'object',
+                required: ['a', 'b']
+              }
+            ]
+          },
+          two: {
+            allOf: [
+              {
+                type: 'object',
+                required: ['c', 'd']
+              }
+            ]
+          }
+        }
+      }
+    }).then((res) => {
+      expect(res.errors).toEqual([])
+      expect(res.spec).toEqual({
+        definitions: {
+          one: {
+            type: 'object',
+            required: ['c', 'd', 'a', 'b']
+          },
+          two: {
+            type: 'object',
+            required: ['c', 'd']
+          }
+        },
+      })
+    })
+  })
+
   // TODO: this needs to get fixed
   it.skip('should handle case, with an `allOf` referencing an `allOf` ', function () {
     return mapSpec({


### PR DESCRIPTION
Fix and test for swagger-ui #3328 - https://github.com/swagger-api/swagger-ui/issues/3328

Added manual logic to merge arrays after calling deepExtend within `mergeDeep` function.