### PR TITLE
Default to computedPath if schema or host is not set

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -237,7 +237,7 @@ export function baseUrl({spec, scheme, contextUrl = ''}) {
     return res[res.length - 1] === '/' ? res.slice(0, -1) : res
   }
 
-  return ''
+  return computedPath
 }
 
 


### PR DESCRIPTION
Fix for swagger-ui #1091
Default to using a relative basePath if host isn't set