### PR TITLE
Fixes #3376 - Keyword properties fix

### DIFF
--- a/src/specmap/index.js
+++ b/src/specmap/index.js
@@ -94,7 +94,10 @@ class SpecMap {
             }
           }
           else {
-            const parent = path[path.length - 1]
+            const parentIndex = path.length - 1
+            const parent = path[parentIndex]
+            const indexOfFirstProperties = path.indexOf('properties')
+            const isRootProperties = parent === 'properties' && parentIndex === indexOfFirstProperties
 
             for (const key of Object.keys(obj)) {
               const val = obj[key]
@@ -103,7 +106,8 @@ class SpecMap {
               if (lib.isObject(val)) {
                 yield* traverse(val, updatedPath, patch)
               }
-              if (parent !== 'properties' && key === pluginObj.key) {
+
+              if (!isRootProperties && key === pluginObj.key) {
                 yield pluginObj.plugin(val, key, updatedPath, specmap, patch)
               }
             }

--- a/test/specmap/index.js
+++ b/test/specmap/index.js
@@ -728,6 +728,38 @@ describe('specmap', function () {
           })
         })
       })
+
+      it('should merge sub-properties', function () {
+        return mapSpec({
+          plugins: [plugins.refs, plugins.allOf],
+          spec: {
+            properties: {
+              test: {
+                type: 'object',
+                properties: {
+                  color: {
+                    type: 'integer'
+                  }
+                }
+              }
+            }
+          }
+        }).then((res) => {
+          expect(res.errors.length).toEqual(0)
+          expect(res.spec).toEqual({
+            properties: {
+              test: {
+                type: 'object',
+                properties: {
+                  color: {
+                    type: 'integer'
+                  }
+                }
+              }
+            }
+          })
+        })
+      })
     })
 
     describe('context', function () {


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-ui/issues/3376.

Check to make sure properties is the root (first) instance of properties before running plugins.

Added a test to ensure new functionality works.