### PR TITLE
return object if passed to header serializer

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -124,7 +124,7 @@ export function serializeHeaders(headers = {}) {
     return obj
   }
 
-  return obj
+  return headers
 }
 
 function isFile(obj) {


### PR DESCRIPTION
if an object is passed to the serializeHeaders method, return it instead of an empty object, if nothing is passed to the method the default, an empty object is returned