### PR TITLE
Use cross-env to make build scripts Windows-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "deps_check_dir": ".deps_check"
   },
   "scripts": {
-    "build": "NODE_ENV=production webpack -p --config ./webpack.config.js",
-    "build-bundle": "NODE_ENV=production webpack -p --config ./webpack.bundle.config.js",
+    "build": "cross-env NODE_ENV=production webpack -p --config ./webpack.config.js",
+    "build-bundle": "cross-env NODE_ENV=production webpack -p --config ./webpack.bundle.config.js",
     "watch": "webpack --config webpack.config.js --watch --progress",
     "test": "npm run just-test && npm run lint",
-    "just-test": "NODE_ENV=test node ./node_modules/.bin/_mocha --recursive --compilers js:babel-core/register",
+    "just-test": "cross-env NODE_ENV=test node ./node_modules/.bin/_mocha --recursive --compilers js:babel-core/register",
     "test:watch": "npm run test -- -w",
     "lint": "eslint src/ test/",
     "deps-license": "license-checker --production --csv --out $npm_package_config_deps_check_dir/licenses.csv && license-checker --development --csv --out $npm_package_config_deps_check_dir/licenses-dev.csv",
@@ -44,6 +44,7 @@
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-es2015": "^6.22.0",
     "clone": "^2.1.0",
+    "cross-env": "^5.0.5",
     "deepmerge": "^1.3.0",
     "eslint": "^3.18.0",
     "eslint-config-airbnb-base": "^11.1.1",


### PR DESCRIPTION
Currently, `npm run build` fails on Windows - it chokes on `NODE_ENV=production`, because Windows requires the `set` keyword to set environment variables: `set NODE_ENV=production`. See also: https://github.com/swagger-api/swagger-js/issues/1066#issuecomment-304204774.

This PR adds [cross-env](https://www.npmjs.com/package/cross-env) to make environment variable assignment work on both Windows and *nix.