### PR TITLE
Fixes #1129 - allOf fix for $$ref values

### DIFF
--- a/src/specmap/lib/all-of.js
+++ b/src/specmap/lib/all-of.js
@@ -17,7 +17,7 @@ export default {
     const parent = fullPath.slice(0, -1)
     let alreadyAddError = false
 
-    return [specmap.replace(parent, {})].concat(val.map((toMerge, index) => {
+    const allOfPatches = [specmap.replace(parent, {})].concat(val.map((toMerge, index) => {
       if (!specmap.isObject(toMerge)) {
         if (alreadyAddError) {
           return null
@@ -31,5 +31,17 @@ export default {
 
       return specmap.mergeDeep(parent, toMerge)
     }))
+
+    // Find the $$ref value from the patch's copy of the spec
+    // and add it as the last patch for the `allOf` resolution
+    let specObj = patch.value
+    parent.forEach((part) => {
+      specObj = specObj[part]
+    })
+    allOfPatches.push(specmap.mergeDeep(parent, {
+      $$ref: specObj.$$ref
+    }))
+
+    return allOfPatches
   }
 }

--- a/src/specmap/lib/all-of.js
+++ b/src/specmap/lib/all-of.js
@@ -39,9 +39,15 @@ export default {
       specObj = specObj[part]
     })
     if (specObj.$$ref) {
+      // If there was an existing $$ref value, make sure it is applied last so it is preserved
       allOfPatches.push(specmap.mergeDeep(parent, {
         $$ref: specObj.$$ref
       }))
+    }
+    else {
+      // If there was not an existing $$ref value, make sure to remove
+      // any $$ref value that may existing from the result of `allOf` merges
+      allOfPatches.push(specmap.remove([].concat(parent, '$$ref')))
     }
 
     return allOfPatches

--- a/src/specmap/lib/all-of.js
+++ b/src/specmap/lib/all-of.js
@@ -38,9 +38,11 @@ export default {
     parent.forEach((part) => {
       specObj = specObj[part]
     })
-    allOfPatches.push(specmap.mergeDeep(parent, {
-      $$ref: specObj.$$ref
-    }))
+    if (specObj.$$ref) {
+      allOfPatches.push(specmap.mergeDeep(parent, {
+        $$ref: specObj.$$ref
+      }))
+    }
 
     return allOfPatches
   }

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -123,7 +123,6 @@ describe('allOf', function () {
       },
       plugins: [plugins.refs, plugins.allOf]
     }).then((res) => {
-      console.log('res', res.spec.Animal.properties)
       expect(res).toEqual({
         errors: [],
         spec: {

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -336,7 +336,6 @@ describe('allOf', function () {
     })
   })
 
-  // TODO: this needs to get fixed
   it('should handle case, with an `allOf` referencing an `allOf` ', function () {
     return mapSpec({
       plugins: [plugins.refs, plugins.allOf],

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -85,8 +85,9 @@ describe('allOf', function () {
     })
   })
 
-  it.skip('should set $$ref values', function () {
+  it('should set $$ref values', function () {
     return mapSpec({
+      allowMetaPatches: true,
       spec: {
         Pet: {
           type: 'object',

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -337,7 +337,7 @@ describe('allOf', function () {
   })
 
   // TODO: this needs to get fixed
-  it.skip('should handle case, with an `allOf` referencing an `allOf` ', function () {
+  it('should handle case, with an `allOf` referencing an `allOf` ', function () {
     return mapSpec({
       plugins: [plugins.refs, plugins.allOf],
       showDebug: true,

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -54,7 +54,6 @@ describe('allOf', function () {
       expect(res).toEqual({
         errors: [],
         spec: {
-          bar: {baz: 4},
           one: {baz: 4},
           two: 2,
           bar: {baz: 4}

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -61,6 +61,100 @@ describe('allOf', function () {
     })
   })
 
+  it.skip('should set $$ref values', function () {
+    return mapSpec({
+      spec: {
+        Pet: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string'
+            }
+          }
+        },
+        Cat: {
+          allOf: [
+            {$ref: '#/Pet'},
+            {
+              type: 'object',
+              properties: {
+                meow: {
+                  type: 'string'
+                }
+              }
+            }
+          ]
+        },
+        Animal: {
+          type: 'object',
+          properties: {
+            pet: {
+              $ref: '#/Pet'
+            },
+            cat: {
+              $ref: '#/Cat'
+            }
+          }
+        }
+      },
+      plugins: [plugins.refs, plugins.allOf]
+    }).then((res) => {
+      console.log('res', res.spec.Animal.properties)
+      expect(res).toEqual({
+        errors: [],
+        spec: {
+          Pet: {
+            $$ref: '#/Pet',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              }
+            }
+          },
+          Cat: {
+            $$ref: '#/Cat',
+            properties: {
+              meow: {
+                type: 'string'
+              },
+              name: {
+                type: 'string'
+              }
+            },
+            type: 'object'
+          },
+          Animal: {
+            type: 'object',
+            properties: {
+              pet: {
+                $$ref: '#/Pet',
+                properties: {
+                  name: {
+                    type: 'string'
+                  }
+                },
+                type: 'object'
+              },
+              cat: {
+                $$ref: '#/Cat',
+                properties: {
+                  meow: {
+                    type: 'string'
+                  },
+                  name: {
+                    type: 'string'
+                  }
+                },
+                type: 'object'
+              }
+            }
+          }
+        }
+      })
+    })
+  })
+
   it('should return error if allOf is not an array', function () {
     return mapSpec({
       spec: {

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -56,6 +56,7 @@ describe('allOf', function () {
         spec: {
           one: {baz: 4},
           two: 2,
+          bar: {baz: 4}
         }
       })
     })

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -62,6 +62,29 @@ describe('allOf', function () {
     })
   })
 
+  it('should not overwrite properties that are already present', function () {
+    return mapSpec({
+      spec: {
+        original: 'yes',
+        allOf: [
+          {
+            original: 'no',
+            notOriginal: 'yes'
+          }
+        ]
+      },
+      plugins: [plugins.refs, plugins.allOf]
+    }).then((res) => {
+      expect(res).toEqual({
+        errors: [],
+        spec: {
+          original: 'yes',
+          notOriginal: 'yes'
+        }
+      })
+    })
+  })
+
   it.skip('should set $$ref values', function () {
     return mapSpec({
       spec: {


### PR DESCRIPTION
Fixes #1129 

Should also fix the following swagger-ui issues:

https://github.com/swagger-api/swagger-ui/issues/2946
https://github.com/swagger-api/swagger-ui/issues/3490
https://github.com/swagger-api/swagger-ui/issues/3342
https://github.com/swagger-api/swagger-ui/issues/3127
https://github.com/swagger-api/swagger-ui/issues/3093

and possibly others...


Added a patch at the end of the `allOf` plugin to make sure the original values for the definition are merged back into the result of the `allOf`. This includes the `$$ref` value. For definitions that did not originally include `$$ref` values, we make sure the result of `allOf` does not have a `$$ref` value.

I wrote a test for the new functionality, but during test runs (any test, not just mine), the `$$ref` value that is set during the `refs` plugin, is not available on the `patch` object inside the `allOf` plugin. 

Once we get that figured out, then we should be able to remove the `skip` from my new test.

Here's a screenshot showing the fix in action in the UI project:

Before:

<img width="847" alt="screen shot 2017-09-09 at 1 40 55 pm" src="https://user-images.githubusercontent.com/791222/30250516-f950dc5c-960c-11e7-9ca4-ae2d974f063a.png">

After:

<img width="1157" alt="screen shot 2017-09-10 at 9 49 11 am" src="https://user-images.githubusercontent.com/791222/30250546-553ed334-960d-11e7-9835-a568c6ca60c2.png">

