### PR TITLE
Fix empty oAuth2 Bearer token added to req header

### DIFF
--- a/src/execute.js
+++ b/src/execute.js
@@ -419,7 +419,7 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
             result.headers.authorization = `Basic ${value.base64}`
           }
         }
-        else if (type === 'oauth2') {
+        else if (type === 'oauth2' && accessToken) {
           result.headers.authorization = `${tokenType || 'Bearer'} ${accessToken}`
         }
       }

--- a/test/index.js
+++ b/test/index.js
@@ -412,6 +412,47 @@ describe('constructor', () => {
       })
     })
 
+    it('should not add an empty oAuth2 Bearer token header to a request', function () {
+      const spec = {
+        securityDefinitions: {
+          bearer: {
+            description: 'Bearer authorization token',
+            type: 'oauth2',
+            name: 'Authorization',
+            in: 'header'
+          }
+        },
+        security: [{bearer: []}],
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets'
+            }
+          }
+        }
+      }
+
+      const authorizations = {
+        bearer: {
+          token: {
+            access_token: ''
+          }
+        }
+      }
+
+      return Swagger({spec, authorizations}).then((client) => {
+        const http = createSpy()
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {},
+          credentials: 'same-origin',
+          method: 'GET',
+          url: '/pet'
+        })
+      })
+    })
+
     it('should add global securites', function () {
       const spec = {
         securityDefinitions: {


### PR DESCRIPTION
When security definitions are present in the spec and an API call is made without providing an `access_token` value, the resulting auth2 authorization header is invalid: `authorization: Bearer `. 

![](https://cldup.com/jYkUMKwHGb.png)

This PR makes sure an oauth2 authorization header is added only if `access_token` has a value.