### PR TITLE
Fixes #1134 - Merging nested arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "btoa": "1.1.2",
-    "deep-extend": "^0.4.1",
     "fast-json-patch": "~1.1.8",
     "isomorphic-fetch": "2.2.1",
     "isomorphic-form-data": "0.0.1",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,8 +1,18 @@
-import isObject from 'lodash/isObject'
+import {mergeWith, isArray, isObject} from 'lodash'
 
 const toLower = str => String.prototype.toLowerCase.call(str)
 const escapeString = (str) => {
   return str.replace(/[^\w]/gi, '_')
+}
+
+// Deeply merge objects, including merging arrays
+export function mergeDeep(dest, src) {
+  const concatArraysCustomizer = function (objValue, srcValue) {
+    if (isArray(objValue)) {
+      return objValue.concat(srcValue)
+    }
+  }
+  mergeWith(dest, src, concatArraysCustomizer)
 }
 
 // Spec version detection

--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -1,6 +1,6 @@
 import jsonPatch from 'fast-json-patch'
 import regenerator from 'babel-runtime/regenerator'
-import {mergeWith as _mergeWith, isArray as _isArray} from 'lodash'
+import {mergeDeep as mergeDeepHelper} from '../../helpers'
 
 export default {
   add,
@@ -46,12 +46,7 @@ function applyPatch(obj, patch, opts) {
     jsonPatch.apply(obj, [valPatch])
     const origValPatchValue = {...valPatch.value}
 
-    const customizer = function (objValue, srcValue) {
-      if (_isArray(objValue)) {
-        return objValue.concat(srcValue)
-      }
-    }
-    _mergeWith(valPatch.value, patch.value, customizer)
+    mergeDeepHelper(valPatch.value, patch.value)
   }
   else {
     jsonPatch.apply(obj, [patch])

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,47 @@
 import expect from 'expect'
 import {
-  normalizeSwagger, getOperationRaw, idFromPathMethod, pathMethodFromId
+  normalizeSwagger, getOperationRaw, idFromPathMethod, pathMethodFromId, mergeDeep
 } from '../src/helpers'
 
 describe('helpers', function () {
+  describe('mergeDeep', function () {
+    it('should merge objects with nested objects and arrays', function () {
+      // Given
+      const dest = {
+        object: {
+          a: 'b'
+        },
+        array: [1],
+        string: 'test',
+        integer: 1,
+        boolean: true
+      }
+      const src = {
+        object: {
+          c: 'd'
+        },
+        array: [2],
+        string: 'updated strng',
+        integer: 2,
+        boolean: false
+      }
+
+      // When
+      mergeDeep(dest, src)
+
+      expect(dest).toEqual({
+        object: {
+          a: 'b',
+          c: 'd'
+        },
+        array: [1, 2],
+        string: 'updated strng',
+        integer: 2,
+        boolean: false
+      })
+    })
+  })
+
   describe('idFromPathMethod', function () {
     it('should return get_one as an operationId', function () {
       // When

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -305,7 +305,13 @@ describe('allOf', function () {
               },
               {
                 type: 'object',
-                required: ['a', 'b']
+                required: ['a', 'b'],
+                properties: {
+                  letters: {
+                    type: 'string',
+                    enum: ['a', 'b']
+                  }
+                }
               }
             ]
           },
@@ -313,7 +319,13 @@ describe('allOf', function () {
             allOf: [
               {
                 type: 'object',
-                required: ['c', 'd']
+                required: ['c', 'd'],
+                properties: {
+                  letters: {
+                    type: 'string',
+                    enum: ['c', 'd']
+                  }
+                }
               }
             ]
           }
@@ -325,11 +337,23 @@ describe('allOf', function () {
         definitions: {
           one: {
             type: 'object',
-            required: ['c', 'd', 'a', 'b']
+            required: ['c', 'd', 'a', 'b'],
+            properties: {
+              letters: {
+                type: 'string',
+                enum: ['c', 'd', 'a', 'b']
+              }
+            }
           },
           two: {
             type: 'object',
-            required: ['c', 'd']
+            required: ['c', 'd'],
+            properties: {
+              letters: {
+                type: 'string',
+                enum: ['c', 'd']
+              }
+            }
           }
         },
       })


### PR DESCRIPTION
Fixes #1134 

Fixes https://github.com/swagger-api/swagger-ui/issues/3674

Original implementation of merging arrays did not take into account nested arrays. I replaced the `deep-extend` package with lodash's `mergeWith`. 

Updated the existing test for merging arrays to test with `enum` options. Added new test for the new `mergeDeep` function.