### PR TITLE
Temporary fix for console spam

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-runtime": "^6.23.0",
     "btoa": "1.1.2",
     "deep-extend": "^0.4.1",
-    "fast-json-patch": "~1.1.8",
+    "fast-json-patch": "1.1.8",
     "isomorphic-fetch": "2.2.1",
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",


### PR DESCRIPTION
This is a temporary fix to lock the version of json-fast-patch to one which doesn't spam the console.

  - https://github.com/swagger-api/swagger-js/issues/1143