### PR TITLE
Tighten `fetch-mock` version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0",
     "expect": "^1.20.2",
-    "fetch-mock": "^5.9.3",
+    "fetch-mock": "~5.12.0",
     "glob": "^7.1.1",
     "json-loader": "^0.5.4",
     "license-checker": "^8.0.3",


### PR DESCRIPTION
`fetch-mock@5.13.0` is blowing up our tests (25 failing, see https://travis-ci.org/swagger-api/swagger-js/jobs/285076321).

This PR tightens the version constraint on it, in order to avoid the bad version.