### PR TITLE
Refactor `startsWith` usage for IE11 compatibility

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,5 @@
 import isObject from 'lodash/isObject'
+import startsWith from 'lodash/startsWith'
 
 const toLower = str => String.prototype.toLowerCase.call(str)
 const escapeString = (str) => {
@@ -12,7 +13,7 @@ export function isOAS3(spec) {
     return false
   }
 
-  return oasVersion.startsWith('3.0.0')
+  return startsWith(oasVersion, '3')
 }
 
 export function isSwagger2(spec) {
@@ -21,7 +22,7 @@ export function isSwagger2(spec) {
     return false
   }
 
-  return swaggerVersion.startsWith('2')
+  return startsWith(swaggerVersion, '2')
 }
 
 // Strategy for determining operationId

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep'
 import assign from 'lodash/assign'
+import startsWith from 'lodash/startsWith'
 import Url from 'url'
 import Http, {makeHttp, serializeRes, serializeHeaders} from './http'
 import Resolver, {clearCache} from './resolver'
@@ -82,7 +83,7 @@ Swagger.prototype.applyDefaults = function () {
   const spec = this.spec
   const specUrl = this.url
   // TODO: OAS3: support servers here
-  if (specUrl && specUrl.startsWith('http')) {
+  if (specUrl && startsWith(specUrl, 'http')) {
     const parsed = Url.parse(specUrl)
     if (!spec.host) {
       spec.host = parsed.host


### PR DESCRIPTION
Fixes #1152.

This PR:
- migrates `String().startsWith` ES6 method usage to lodash's `startsWith` function
- loosens `isOAS3` helper to match `openapi: 3*` instead of `3.0.0*`