### PR TITLE
Fixes #1155

### DIFF
--- a/src/execute/swagger2/build-request.js
+++ b/src/execute/swagger2/build-request.js
@@ -84,7 +84,7 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'oauth2' && accessToken) {
-          tokenType = (!tokenType || tokenType === 'bearer') ? 'Bearer' : tokenType
+          tokenType = (!tokenType || tokenType.toLowerCase() === 'bearer') ? 'Bearer' : tokenType
           result.headers.authorization = `${tokenType} ${accessToken}`
         }
       }

--- a/src/execute/swagger2/build-request.js
+++ b/src/execute/swagger2/build-request.js
@@ -66,7 +66,7 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
       const schema = securityDef[key]
       const {type} = schema
       const accessToken = token && token.access_token
-      const tokenType = token && token.token_type
+      let tokenType = token && token.token_type
 
       if (auth) {
         if (type === 'apiKey') {
@@ -84,7 +84,8 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'oauth2' && accessToken) {
-          result.headers.authorization = `${tokenType || 'Bearer'} ${accessToken}`
+          tokenType = (!tokenType || tokenType === 'bearer') ? 'Bearer' : tokenType
+          result.headers.authorization = `${tokenType} ${accessToken}`
         }
       }
     }

--- a/test/index-authorizations.js
+++ b/test/index-authorizations.js
@@ -175,6 +175,47 @@ describe('(instance) #execute', function () {
     })
   })
 
+  it('should uppercase the `bearer` token_type', function () {
+    const spec = {
+      securityDefinitions: {
+        testBearer: {
+          type: 'oauth2',
+        }
+      },
+      paths: {
+        '/pet': {
+          get: {
+            operationId: 'getPets',
+            security: [{testBearer: []}]
+          }
+        }
+      }
+    }
+
+    const authorizations = {
+      testBearer: {
+        token: {
+          token_type: 'bearer',
+          access_token: 'one two'
+        }
+      }
+    }
+
+    return Swagger({spec, authorizations}).then((client) => {
+      const http = createSpy()
+      client.execute({http, operationId: 'getPets'})
+      expect(http.calls.length).toEqual(1)
+      expect(http.calls[0].arguments[0]).toEqual({
+        credentials: 'same-origin',
+        headers: {
+          authorization: 'Bearer one two'
+        },
+        method: 'GET',
+        url: '/pet'
+      })
+    })
+  })
+
   it('should add global securites', function () {
     const spec = {
       securityDefinitions: {

--- a/test/index-authorizations.js
+++ b/test/index-authorizations.js
@@ -175,7 +175,7 @@ describe('(instance) #execute', function () {
     })
   })
 
-  it('should uppercase the `bearer` token_type', function () {
+  it('should replace any occurrence of `bearer` with `Bearer`', function () {
     const spec = {
       securityDefinitions: {
         testBearer: {
@@ -195,7 +195,7 @@ describe('(instance) #execute', function () {
     const authorizations = {
       testBearer: {
         token: {
-          token_type: 'bearer',
+          token_type: 'BeArEr',
           access_token: 'one two'
         }
       }


### PR DESCRIPTION
Fixes #1155 

Pass 'Bearer' if the token_type property equals 'bearer' or is falsy.

Fixes original issue found in UI: https://github.com/swagger-api/swagger-ui/issues/3594