### PR TITLE
OAS 3.0 Authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "btoa": "1.1.2",
+    "cookie": "^0.3.1",
     "deep-extend": "^0.4.1",
     "fast-json-patch": "1.1.8",
     "isomorphic-fetch": "2.2.1",
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",
-    "lightcookie": "^1.0.24",
     "lodash": "4.16.2",
     "qs": "^6.3.0",
     "url": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "isomorphic-fetch": "2.2.1",
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",
+    "lightcookie": "^1.0.24",
     "lodash": "4.16.2",
     "qs": "^6.3.0",
     "url": "^0.11.0"

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -4,7 +4,7 @@ import isPlainObject from 'lodash/isPlainObject'
 import isArray from 'lodash/isArray'
 import btoa from 'btoa'
 import url from 'url'
-import {serialize as serializeCookie} from 'lightcookie'
+import cookie from 'cookie'
 import http, {mergeInQueryOrForm} from '../http'
 import createError from '../specmap/lib/create-error'
 
@@ -209,7 +209,12 @@ export function buildRequest(options) {
   // If the cookie convenience object exists in our request,
   // serialize its content and then delete the cookie object.
   if (req.cookies && Object.keys(req.cookies).length) {
-    const cookieString = serializeCookie(req.cookies)
+    const cookieString = Object.keys(req.cookies).reduce((prev, cookieName) => {
+      const cookieValue = req.cookies[cookieName]
+      const prefix = prev ? '&' : ''
+      const stringified = cookie.serialize(cookieName, cookieValue)
+      return prev + prefix + stringified
+    }, '')
     req.headers.Cookie = cookieString
   }
 

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -126,6 +126,11 @@ export function buildRequest(options) {
 
   // Mostly for testing
   if (!operationId) {
+    // Not removing req.cookies causes testing issues and would
+    // change our interface, so we're always sure to remove it.
+    // See the same statement lower down in this function for
+    // more context.
+    delete req.cookies
     return req
   }
 

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -109,6 +109,9 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           if (schema.in === 'header') {
             result.headers[schema.name] = value
           }
+          if (schema.in === 'cookie') {
+            result.cookies[schema.name] = value
+          }
         }
         else if (type === 'http') {
           if (schema.scheme === 'basic') {

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -76,8 +76,8 @@ export default function (options, req) {
 // Adapted from the Swagger2 implementation
 export function applySecurities({request, securities = {}, operation = {}, spec}) {
   const result = assign({}, request)
-  const {authorized = {}, specSecurity = []} = securities
-  const security = operation.security || specSecurity
+  const {authorized = {}} = securities
+  const security = operation.security || spec.security || []
   const isAuthorized = authorized && !!Object.keys(authorized).length
   const securityDef = get(spec, ['components', 'securitySchemes']) || {}
 

--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -91,8 +91,19 @@ function query({req, value, parameter}) {
   }
 }
 
+const PARAMETER_HEADER_BLACKLIST = [
+  'accept',
+  'authorization',
+  'content-type'
+]
+
 function header({req, parameter, value}) {
   req.headers = req.headers || {}
+
+  if (PARAMETER_HEADER_BLACKLIST.indexOf(parameter.name.toLowerCase()) > -1) {
+    return
+  }
+
   if (typeof value !== 'undefined') {
     req.headers[parameter.name] = stylize({
       key: parameter.name,

--- a/src/execute/swagger2/build-request.js
+++ b/src/execute/swagger2/build-request.js
@@ -3,7 +3,7 @@
 
 import btoa from 'btoa'
 import assign from 'lodash/assign'
-import http, {mergeInQueryOrForm} from '../../http'
+import http from '../../http'
 
 
 export default function (options, req) {

--- a/test/http.js
+++ b/test/http.js
@@ -252,7 +252,7 @@ describe('http', () => {
       return http('http://example.com', req).then((response) => {
         expect(response.url).toEqual('http://example.com?anotherOne=one,two&evenMore=hi&bar=1%202%203')
         expect(response.status).toEqual(200)
-      }).finally(fetchMock.restore)
+      }).then(fetchMock.restore)
     })
   })
 
@@ -268,7 +268,7 @@ describe('http', () => {
         return serializeRes(_res, 'https://swagger.io')
       }).then((resSerialize) => {
         expect(resSerialize.headers).toEqual({authorization: ['Basic hoop-la', 'Advanced hoop-la']})
-      }).finally(fetchMock.restore)
+      }).then(fetchMock.restore)
     })
 
     it('should set .text and .data to body Blob or Buffer for binary response', function () {
@@ -290,7 +290,7 @@ describe('http', () => {
           expect(resSerialize.data).toBeA(Buffer)
           expect(resSerialize.data).toEqual(new Buffer(body))
         }
-      }).finally(fetchMock.restore)
+      }).then(fetchMock.restore)
     })
 
     it('should set .text and .data to body string for text response', function () {
@@ -306,7 +306,7 @@ describe('http', () => {
       }).then((resSerialize) => {
         expect(resSerialize.data).toBe(resSerialize.text)
         expect(resSerialize.data).toBe(body)
-      }).finally(fetchMock.restore)
+      }).then(fetchMock.restore)
     })
   })
 

--- a/test/http.js
+++ b/test/http.js
@@ -252,7 +252,7 @@ describe('http', () => {
       return http('http://example.com', req).then((response) => {
         expect(response.url).toEqual('http://example.com?anotherOne=one,two&evenMore=hi&bar=1%202%203')
         expect(response.status).toEqual(200)
-      }).then(fetchMock.restore)
+      }).finally(fetchMock.restore)
     })
   })
 
@@ -268,7 +268,7 @@ describe('http', () => {
         return serializeRes(_res, 'https://swagger.io')
       }).then((resSerialize) => {
         expect(resSerialize.headers).toEqual({authorization: ['Basic hoop-la', 'Advanced hoop-la']})
-      }).then(fetchMock.restore)
+      }).finally(fetchMock.restore)
     })
 
     it('should set .text and .data to body Blob or Buffer for binary response', function () {
@@ -290,7 +290,7 @@ describe('http', () => {
           expect(resSerialize.data).toBeA(Buffer)
           expect(resSerialize.data).toEqual(new Buffer(body))
         }
-      }).then(fetchMock.restore)
+      }).finally(fetchMock.restore)
     })
 
     it('should set .text and .data to body string for text response', function () {
@@ -306,7 +306,7 @@ describe('http', () => {
       }).then((resSerialize) => {
         expect(resSerialize.data).toBe(resSerialize.text)
         expect(resSerialize.data).toBe(body)
-      }).then(fetchMock.restore)
+      }).finally(fetchMock.restore)
     })
   })
 

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -19,7 +19,7 @@ import {execute, buildRequest, baseUrl, applySecurities, self as stubs} from '..
 // - [ ] HTTP Bearer with credentials in constructor
 // - [ ] HTTP Bearer with credentials through buildRequest/execute
 
-describe.only('Authorization - OpenAPI Specification 3.0', function () {
+describe('Authorization - OpenAPI Specification 3.0', function () {
   it('should ignore a header parameter named `Authorization`', () => {
     const spec = {
       openapi: '3.0.0',

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -9,15 +9,6 @@ import {execute, buildRequest, baseUrl, applySecurities, self as stubs} from '..
 
 
 // OAS 3.0 Authorization
-//
-// Testing TODO:
-// - [ ] Ignore `Authorization` header parameters
-// - [ ] OAuth2 with credentials in constructor
-// - [ ] OAuth2 with credentials through buildRequest/execute
-// - [ ] HTTP Basic with credentials in constructor
-// - [ ] HTTP Basic with credentials through buildRequest/execute
-// - [ ] HTTP Bearer with credentials in constructor
-// - [ ] HTTP Bearer with credentials through buildRequest/execute
 
 describe('Authorization - OpenAPI Specification 3.0', function () {
   it('should ignore a header parameter named `Authorization`', () => {
@@ -435,119 +426,163 @@ describe('Authorization - OpenAPI Specification 3.0', function () {
     })
   })
 
-  describe.skip('OAuth2', () => {
-    describe('implicit', () => {
-      it('should build a request with constructor credentials', () => {
-        const spec = {
-          openapi: '3.0.0',
-          paths: {
-            '/': {
-              get: {
-                operationId: 'myOperation',
-                parameters: [
-                  {
-                    name: 'Authorization',
-                    in: 'header'
+  describe('OAuth2', () => {
+    it('should build a request with an operation security', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myOAuth2Implicit: {
+              type: 'oauth2',
+              flows: {
+                implicit: {
+                  authorizationUrl: 'http://google.com/',
+                  scopes: {
+                    myScope: 'blah blah blah'
                   }
-                ]
+                }
+              }
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation',
+              security: [
+                {myOAuth2Implicit: []}
+              ]
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myOAuth2Implicit: {
+              token: {
+                access_token: 'myTokenValue'
               }
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'myOperation',
-          parameters: {
-            Authorization: 'myAuthValue'
-          }
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: '/',
-          credentials: 'same-origin',
-          headers: {},
-        })
       })
-      it('should build a request with buildRequest credentials', () => {
-        const spec = {
-          openapi: '3.0.0',
-          paths: {
-            '/': {
-              get: {
-                operationId: 'myOperation',
-                parameters: [
-                  {
-                    name: 'Authorization',
-                    in: 'header'
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {
+          Authorization: 'Bearer myTokenValue'
+        },
+      })
+    })
+    it('should build a request with a global security', () => {
+      const spec = {
+        openapi: '3.0.0',
+        security: [
+          {myOAuth2Implicit: []}
+        ],
+        components: {
+          securitySchemes: {
+            myOAuth2Implicit: {
+              type: 'oauth2',
+              flows: {
+                implicit: {
+                  authorizationUrl: 'http://google.com/',
+                  scopes: {
+                    myScope: 'blah blah blah'
                   }
-                ]
+                }
+              }
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation'
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myOAuth2Implicit: {
+              token: {
+                access_token: 'myTokenValue'
               }
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'myOperation',
-          parameters: {
-            Authorization: 'myAuthValue'
-          }
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: '/',
-          credentials: 'same-origin',
-          headers: {},
-        })
       })
-      it('should set buildRequest credentials over constructor', () => {
-        const spec = {
-          openapi: '3.0.0',
-          paths: {
-            '/': {
-              get: {
-                operationId: 'myOperation',
-                parameters: [
-                  {
-                    name: 'Authorization',
-                    in: 'header'
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {
+          Authorization: 'Bearer myTokenValue'
+        },
+      })
+    })
+    it('should build a request without authorization when spec does not require it', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myOAuth2Implicit: {
+              type: 'oauth2',
+              flows: {
+                implicit: {
+                  authorizationUrl: 'http://google.com/',
+                  scopes: {
+                    myScope: 'blah blah blah'
                   }
-                ]
+                }
+              }
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation'
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myOAuth2Implicit: {
+              token: {
+                access_token: 'myTokenValue'
               }
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'myOperation',
-          parameters: {
-            Authorization: 'myAuthValue'
-          }
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: '/',
-          credentials: 'same-origin',
-          headers: {},
-        })
       })
-    })
-    describe('password', () => {
 
-    })
-    describe('application', () => {
-
-    })
-    describe('access code', () => {
-
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {},
+      })
     })
   })
 })

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -1,0 +1,172 @@
+import expect, {createSpy, spyOn} from 'expect'
+import xmock from 'xmock'
+import path from 'path'
+import fs from 'fs'
+import jsYaml from 'js-yaml'
+
+import {execute, buildRequest, baseUrl, applySecurities, self as stubs} from '../../../src/execute'
+
+
+// OAS 3.0 Authorization
+//
+// Testing TODO:
+// - [ ] Ignore `Authorization` header parameters
+// - [ ] OAuth2 with credentials in constructor
+// - [ ] OAuth2 with credentials through buildRequest/execute
+// - [ ] HTTP Basic with credentials in constructor
+// - [ ] HTTP Basic with credentials through buildRequest/execute
+// - [ ] HTTP Bearer with credentials in constructor
+// - [ ] HTTP Bearer with credentials through buildRequest/execute
+
+describe.only('Authorization - OpenAPI Specification 3.0', function () {
+  it('should ignore a header parameter named `Authorization`', () => {
+    const spec = {
+      openapi: '3.0.0',
+      paths: {
+        '/': {
+          get: {
+            operationId: 'myOperation',
+            parameters: [
+              {
+                name: 'Authorization',
+                in: 'header'
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    // when
+    const req = buildRequest({
+      spec,
+      operationId: 'myOperation',
+      parameters: {
+        Authorization: 'myAuthValue'
+      }
+    })
+
+    expect(req).toEqual({
+      method: 'GET',
+      url: '/',
+      credentials: 'same-origin',
+      headers: {},
+    })
+  })
+
+  describe('OAuth2', () => {
+    describe('implicit', () => {
+      it('should build a request with constructor credentials', () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                parameters: [
+                  {
+                    name: 'Authorization',
+                    in: 'header'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          parameters: {
+            Authorization: 'myAuthValue'
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+      it('should build a request with buildRequest credentials', () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                parameters: [
+                  {
+                    name: 'Authorization',
+                    in: 'header'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          parameters: {
+            Authorization: 'myAuthValue'
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+      it('should set buildRequest credentials over constructor', () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                parameters: [
+                  {
+                    name: 'Authorization',
+                    in: 'header'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          parameters: {
+            Authorization: 'myAuthValue'
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+    })
+    describe('password', () => {
+
+    })
+    describe('application', () => {
+
+    })
+    describe('access code', () => {
+
+    })
+  })
+})

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -2,6 +2,7 @@ import expect, {createSpy, spyOn} from 'expect'
 import xmock from 'xmock'
 import path from 'path'
 import fs from 'fs'
+import btoa from 'btoa'
 import jsYaml from 'js-yaml'
 
 import {execute, buildRequest, baseUrl, applySecurities, self as stubs} from '../../../src/execute'
@@ -46,6 +47,7 @@ describe.only('Authorization - OpenAPI Specification 3.0', function () {
       }
     })
 
+    // then
     expect(req).toEqual({
       method: 'GET',
       url: '/',
@@ -54,7 +56,386 @@ describe.only('Authorization - OpenAPI Specification 3.0', function () {
     })
   })
 
-  describe('OAuth2', () => {
+  describe('HTTP', () => {
+    describe('Basic', () => {
+      it('should encode credentials into the Authorization header', () => {
+        const spec = {
+          openapi: '3.0.0',
+          components: {
+            securitySchemes: {
+              myBasicAuth: {
+                type: 'http',
+                in: 'header',
+                scheme: 'basic'
+              }
+            }
+          },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                security: [{
+                  myBasicAuth: []
+                }],
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          securities: {
+            authorized: {
+              myBasicAuth: {
+                username: 'somebody',
+                password: 'goodpass'
+              }
+            }
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {
+            Authorization: `Basic ${btoa('somebody:goodpass')}`
+          },
+        })
+      })
+      it('should not add credentials to operations without the security requirement', () => {
+        const spec = {
+          openapi: '3.0.0',
+          components: {
+            securitySchemes: {
+              myBasicAuth: {
+                type: 'http',
+                in: 'header',
+                scheme: 'basic'
+              }
+            }
+          },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation'
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          securities: {
+            authorized: {
+              myBasicAuth: {
+                username: 'somebody',
+                password: 'goodpass'
+              }
+            }
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+    })
+    describe('Bearer', () => {
+      it('should add token to the Authorization header', () => {
+        const spec = {
+          openapi: '3.0.0',
+          components: {
+            securitySchemes: {
+              myBearerAuth: {
+                type: 'http',
+                in: 'header',
+                scheme: 'bearer'
+              }
+            }
+          },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                security: [{
+                  myBearerAuth: []
+                }]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          securities: {
+            authorized: {
+              myBearerAuth: {
+                value: 'Asdf1234'
+              }
+            }
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {
+            Authorization: 'Bearer Asdf1234'
+          },
+        })
+      })
+      it('should not add credentials to operations without the security requirement', () => {
+        const spec = {
+          openapi: '3.0.0',
+          components: {
+            securitySchemes: {
+              myBearerAuth: {
+                type: 'http',
+                in: 'header',
+                scheme: 'bearer'
+              }
+            }
+          },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          securities: {
+            authorized: {
+              myBearerAuth: {
+                value: 'Asdf1234'
+              }
+            }
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+    })
+  })
+
+  describe('apiKey', () => {
+    it('should add apiKey credentials as a header', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myApiKey: {
+              type: 'apiKey',
+              name: 'MyApiKeyHeader',
+              in: 'header'
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation',
+              security: [{
+                myApiKey: []
+              }]
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myApiKey: {
+              value: '===MyToken==='
+            }
+          }
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {
+          MyApiKeyHeader: '===MyToken==='
+        },
+      })
+    })
+    it('should add apiKey credentials as a query param', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myApiKey: {
+              type: 'apiKey',
+              name: 'myQueryParam',
+              in: 'query'
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation',
+              security: [{
+                myApiKey: []
+              }]
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myApiKey: {
+              value: 'myQueryValue'
+            }
+          }
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/?myQueryParam=myQueryValue',
+        credentials: 'same-origin',
+        headers: {}
+      })
+    })
+    it('should add apiKey credentials as a cookie', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myApiKey: {
+              type: 'apiKey',
+              name: 'MyApiKeyCookie',
+              in: 'cookie'
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation',
+              security: [{
+                myApiKey: []
+              }]
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myApiKey: {
+              value: 'MyToken'
+            }
+          }
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {
+          Cookie: 'MyApiKeyCookie=MyToken'
+        },
+      })
+    })
+    it('should not add credentials if operation does not call for security', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myApiKeyCookie: {
+              type: 'apiKey',
+              name: 'MyApiKeyCookie',
+              in: 'cookie'
+            },
+            MyApiKeyHeader: {
+              type: 'apiKey',
+              name: 'MyApiKeyHeader',
+              in: 'header'
+            },
+            myApiKeyQuery: {
+              type: 'apiKey',
+              name: 'myApiKeyQuery',
+              in: 'query'
+            }
+          }
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation'
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myApiKeyQuery: {
+              value: 'test'
+            },
+            MyApiKeyHeader: {
+              value: 'test'
+            },
+            myApiKeyCookie: {
+              value: 'test'
+            },
+          }
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {},
+      })
+    })
+  })
+
+  describe.skip('OAuth2', () => {
     describe('implicit', () => {
       it('should build a request with constructor credentials', () => {
         const spec = {


### PR DESCRIPTION
This PR adds support for the following types of OpenAPI 3.0 security schemes:
- HTTP Basic
- HTTP Bearer
- OAuth2 Authorization Code
- OAuth2 Implicit
- OAuth2 Password
- OAuth2 Multiple Flows
- apiKey Header
- apiKey Query

There's a new `req.cookies` convenience key in `buildRequest`, but for now it's only useful in Node environments. Browsers do not allow arbitrary control of the `Cookie` header (see #1163).