### PR TITLE
OAS3 baseUrl TypeError

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -219,7 +219,7 @@ function oas3BaseUrl({spec, server, contextUrl, serverVariables = {}}) {
   let selectedServerUrl = ''
   let selectedServerObj = null
 
-  if (server) {
+  if (server && servers) {
     const serverUrls = servers.map(srv => srv.url)
 
     if (serverUrls.indexOf(server) > -1) {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -484,5 +484,30 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
 
       expect(res).toEqual('https://petstore.com')
     })
+    it('should fall back to contextUrls if no servers are provided', function () {
+      const spec = {
+        openapi: '3.0.0'
+      }
+
+      const res = baseUrl({
+        spec,
+        server: 'http://some-invalid-server.com/',
+        contextUrl: 'http://google.com/'
+      })
+
+      expect(res).toEqual('http://google.com')
+    })
+    it('should return an empty string if no servers or contextUrl are provided', function () {
+      const spec = {
+        openapi: '3.0.0'
+      }
+
+      const res = baseUrl({
+        spec,
+        server: 'http://some-invalid-server.com/'
+      })
+
+      expect(res).toEqual('')
+    })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-ui/issues/3791.

This is an edge case that doesn't bubble up for every OAS 3.0 definition that lacks a `servers` definition. A request that has a `server` provided, but no `servers`, were causing this.