### PR TITLE
Interceptors for $ref download

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,9 @@ Swagger.prototype = {
     return Swagger.resolve({
       spec: this.spec,
       url: this.url,
-      allowMetaPatches: this.allowMetaPatches
+      allowMetaPatches: this.allowMetaPatches,
+      requestInterceptor: this.requestInterceptor || null,
+      responseInterceptor: this.responseInterceptor || null
     }).then((obj) => {
       this.originalSpec = this.spec
       this.spec = obj.spec

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -2,11 +2,14 @@ import Http from './http'
 import mapSpec, {plugins} from './specmap'
 import {normalizeSwagger} from './helpers'
 
-export function makeFetchJSON(http) {
+export function makeFetchJSON(http, opts = {}) {
+  const { requestInterceptor, responseInterceptor } = opts
   return (docPath) => {
     return http({
       url: docPath,
       loadSpec: true,
+      requestInterceptor,
+      responseInterceptor,
       headers: {
         Accept: 'application/json'
       },
@@ -23,10 +26,17 @@ export function clearCache() {
   plugins.refs.clearCache()
 }
 
-export default function resolve({
-  http, fetch, spec, url, baseDoc, mode, allowMetaPatches = true,
-  modelPropertyMacro, parameterMacro
-}) {
+export default function resolve(obj) {
+  const {
+    fetch, spec, url, mode, allowMetaPatches = true,
+    modelPropertyMacro, parameterMacro, requestInterceptor,
+    responseInterceptor
+  } = obj
+
+  let {http, baseDoc} = obj
+
+  // console.log(obj)
+
   // @TODO Swagger-UI uses baseDoc instead of url, this is to allow both
   // need to fix and pick one.
   baseDoc = baseDoc || url
@@ -36,7 +46,7 @@ export default function resolve({
   http = fetch || http || Http
 
   if (!spec) {
-    return makeFetchJSON(http)(baseDoc).then(doResolve)
+    return makeFetchJSON(http, {requestInterceptor, responseInterceptor})(baseDoc).then(doResolve)
   }
 
   return doResolve(spec)

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -3,7 +3,7 @@ import mapSpec, {plugins} from './specmap'
 import {normalizeSwagger} from './helpers'
 
 export function makeFetchJSON(http, opts = {}) {
-  const { requestInterceptor, responseInterceptor } = opts
+  const {requestInterceptor, responseInterceptor} = opts
   return (docPath) => {
     return http({
       url: docPath,
@@ -57,7 +57,7 @@ export default function resolve(obj) {
     }
 
     // Build a json-fetcher ( ie: give it a URL and get json out )
-    plugins.refs.fetchJSON = makeFetchJSON(http)
+    plugins.refs.fetchJSON = makeFetchJSON(http, {requestInterceptor, responseInterceptor})
 
     const plugs = [plugins.refs]
 

--- a/test/index.js
+++ b/test/index.js
@@ -492,19 +492,28 @@ describe('constructor', () => {
     })
   })
 
-  describe('interceptor', function () {
+  describe.only('interceptor', function () {
     beforeEach(() => {
       const xapp = xmock()
       xapp
         .get('http://petstore.swagger.io/v2/swagger.json', () => require('./data/petstore.json'))
         .get('http://petstore.swagger.io/v2/pet/3', () => ({id: 3}))
         .get('http://petstore.swagger.io/v2/pet/4', () => ({id: 4}))
+        .get('http://petstore.swagger.io/v2/ref.json', () => ({b: 2}))
+        .get('http://petstore.swagger.io/v2/base.json', () => (
+          {
+            $ref: 'http://petstore.swagger.io/v2/ref.json#b'
+          }
+        ))
     })
 
     it('should support request interceptor', function (cb) {
       new Swagger({
         url: 'http://petstore.swagger.io/v2/swagger.json',
         requestInterceptor: (req) => {
+          if (req.loadSpec) {
+            return req
+          }
           req.url = 'http://petstore.swagger.io/v2/pet/4'
         }
       }).then((client) => {
@@ -527,6 +536,28 @@ describe('constructor', () => {
           cb()
         })
       }, cb)
+    })
+
+    it('should support request interceptor when fetching a spec and remote ref', function (cb) {
+      const spy = createSpy().andCall(a => a)
+      new Swagger({
+        url: 'http://petstore.swagger.io/v2/base.json',
+        requestInterceptor: spy
+      }).then((client) => {
+        expect(spy.calls.length).toEqual(2)
+        cb()
+      }).catch(cb)
+    })
+
+    it('should support response interceptor when fetching a spec and remote ref', function (cb) {
+      const spy = createSpy().andCall(a => a)
+      new Swagger({
+        url: 'http://petstore.swagger.io/v2/base.json',
+        responseInterceptor: spy
+      }).then((client) => {
+        expect(spy.calls.length).toEqual(2)
+        cb()
+      }).catch(cb)
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -551,7 +551,7 @@ describe('constructor', () => {
     })
 
     it('should support response interceptor when fetching a spec and remote ref', function (cb) {
-      const spy = createSpy().andCall(a => {
+      const spy = createSpy().andCall((a) => {
         return a
       })
 

--- a/test/index.js
+++ b/test/index.js
@@ -494,6 +494,7 @@ describe('constructor', () => {
 
   describe('interceptor', function () {
     beforeEach(() => {
+      Swagger.clearCache()
       const xapp = xmock()
       xapp
         .get('http://petstore.swagger.io/v2/swagger.json', () => require('./data/petstore.json'))
@@ -553,6 +554,7 @@ describe('constructor', () => {
       const spy = createSpy().andCall(a => {
         return a
       })
+
       new Swagger({
         url: 'http://petstore.swagger.io/v2/base.json',
         responseInterceptor: spy

--- a/test/index.js
+++ b/test/index.js
@@ -492,7 +492,7 @@ describe('constructor', () => {
     })
   })
 
-  describe.only('interceptor', function () {
+  describe('interceptor', function () {
     beforeEach(() => {
       const xapp = xmock()
       xapp
@@ -550,12 +550,28 @@ describe('constructor', () => {
     })
 
     it('should support response interceptor when fetching a spec and remote ref', function (cb) {
-      const spy = createSpy().andCall(a => a)
+      const spy = createSpy().andCall(a => {
+        return a
+      })
       new Swagger({
         url: 'http://petstore.swagger.io/v2/base.json',
         responseInterceptor: spy
       }).then((client) => {
         expect(spy.calls.length).toEqual(2)
+        cb()
+      }).catch(cb)
+    })
+
+    it('should support request and response interceptor when fetching a spec and remote ref', function (cb) {
+      const reqSpy = createSpy().andCall(a => a)
+      const resSpy = createSpy().andCall(a => a)
+      new Swagger({
+        url: 'http://petstore.swagger.io/v2/base.json',
+        responseInterceptor: reqSpy,
+        requestInterceptor: resSpy
+      }).then((client) => {
+        expect(reqSpy.calls.length).toEqual(2)
+        expect(resSpy.calls.length).toEqual(2)
         cb()
       }).catch(cb)
     })


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-ui/issues/3763.

This PR:
- Adds interceptors to Swagger-Client spec downloads
  - Note: Swagger-UI already had this, since it defines its own spec download function, then gives the resulting object to Swagger-Client.
- Adds interceptors to special $ref fetches
  - Note: the $ref docCache is alive and well, so `1 ref !== 1 request`.
- Sets the `req.loadSpec` flag on spec and ref requests
- Adds tests for the above functionality