### PR TITLE
Loosen fetch-mock version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-airbnb-base": "^11.1.1",
     "eslint-plugin-import": "^2.2.0",
     "expect": "^1.20.2",
-    "fetch-mock": "~5.12.0",
+    "fetch-mock": "^5.12.0",
     "glob": "^7.1.1",
     "json-loader": "^0.5.4",
     "license-checker": "^8.0.3",


### PR DESCRIPTION
Per the conversation in #1148, `fetch-mock` no longer needs to be constrained to `5.12`.