### PR TITLE
Generate relative base url if we can't make an absolute one

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -286,15 +286,18 @@ function buildOas3UrlWithContext(ourUrl = '', contextUrl = '') {
   const computedScheme = stripNonAlpha(parsedUrl.protocol) || stripNonAlpha(parsedContextUrl.protocol) || ''
   const computedHost = parsedUrl.host || parsedContextUrl.host
   const computedPath = parsedUrl.pathname || ''
+  let res
 
   if (computedScheme && computedHost) {
-    const res = `${computedScheme}://${computedHost + computedPath}`
+    res = `${computedScheme}://${computedHost + computedPath}`
 
     // If last character is '/', trim it off
-    return res[res.length - 1] === '/' ? res.slice(0, -1) : res
+  }
+  else {
+    res = computedPath
   }
 
-  return ''
+  return res[res.length - 1] === '/' ? res.slice(0, -1) : res
 }
 
 function getVariableTemplateNames(str) {

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -317,13 +317,17 @@ function swagger2BaseUrl({spec, scheme, contextUrl = ''}) {
   const computedScheme = scheme || firstSchemeInSpec || stripNonAlpha(parsedContextUrl.protocol) || 'http'
   const computedHost = spec.host || parsedContextUrl.host || ''
   const computedPath = spec.basePath || ''
+  let res
 
   if (computedScheme && computedHost) {
-    const res = `${computedScheme}://${computedHost + computedPath}`
-
-    // If last character is '/', trim it off
-    return res[res.length - 1] === '/' ? res.slice(0, -1) : res
+    // we have what we need for an absolute URL
+    res = `${computedScheme}://${computedHost + computedPath}`
+  }
+  else {
+    // if not, a relative URL will have to do
+    res = computedPath
   }
 
-  return ''
+  // If last character is '/', trim it off
+  return res[res.length - 1] === '/' ? res.slice(0, -1) : res
 }

--- a/test/execute/baseurl.js
+++ b/test/execute/baseurl.js
@@ -129,4 +129,15 @@ describe('baseUrl', () => {
 
     expect(res).toEqual('https://example.com:9090')
   })
+
+  it('should include a basePath when no contextUrl is available', () => {
+    const res = baseUrl({
+      spec: {
+        title: 'a spec',
+        basePath: '/mybase'
+      }
+    })
+
+    expect(res).toEqual('/mybase')
+  })
 })

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -497,6 +497,23 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
 
       expect(res).toEqual('http://google.com')
     })
+    it('should create a relative url based on a relative server if no contextUrl is available', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: '/mypath'
+          }
+        ]
+      }
+
+      const res = baseUrl({
+        spec,
+        server: '/mypath'
+      })
+
+      expect(res).toEqual('/mypath')
+    })
     it('should return an empty string if no servers or contextUrl are provided', function () {
       const spec = {
         openapi: '3.0.0'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR modifies the Swagger 2.0 and OpenAPI 3.0 base url constructors to _not_ bail out if they cannot compute a scheme and host for the request.

@garywong89 brought this to my attention.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Without this PR, Swagger-Client will still generate a relative URL based on the path of the operation being executed, but won't attach a Swagger 2.0 basePath, or an OpenAPI 3.0 relative server path.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In order to solve this, I wrote failing tests for the Swagger 2.0 and OpenAPI 3.0 baseUrl constructors.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.