### PR TITLE
loosen lodash version constraint to major version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "isomorphic-fetch": "2.2.1",
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",
-    "lodash": "4.16.2",
+    "lodash": "^4.16.2",
     "qs": "^6.3.0",
     "url": "^0.11.0"
   }


### PR DESCRIPTION
### Description
This allows the package to use the compatible range of lodash versions

### Motivation and Context
Part of #1165, allows to reduce the bundle size when swagger-client is used as a part of bigger application

### How Has This Been Tested?
I ran `yarn install` and it worked

### Types of changes
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
