### PR TITLE
add `npm run build-dev` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ npm run test         # run test
 npm run test:watch   # run test with change watching
 npm run lint         # run lint
 npm run build        # package to release
+npm run build-dev    # package with non-minified dist/index.js (for debugging)
 npm run build-bundle # build browser version available at .../browser
 ```
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack -p --config ./webpack.config.js",
+    "build-dev": "cross-env NODE_ENV=development webpack --config ./webpack.config.js",
     "build-bundle": "cross-env NODE_ENV=production webpack -p --config ./webpack.bundle.config.js",
     "watch": "webpack --config webpack.config.js --watch --progress",
     "test": "npm run just-test && npm run lint",


### PR DESCRIPTION
* `npm run build-dev` will create a non-minified `dist/index.js`
* This makes debugging possible and stack traces nicer
* Also, docs.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
* Added a script in `package.json`
* updated `README.md`

### Motivation and Context

* This issue was found when trying to debug https://github.com/swagger-api/swagger-js/issues/1171
* there was no way to easily create a `dist/index.js` for debugging.

### How Has This Been Tested?
* Run from the command line and tested with my app

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] No code changes (changes to documentation, CI, metadata, etc)  _only changes build script_
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Special thanks: https://stackoverflow.com/a/43308463/185799