### PR TITLE
only use YAML parser for YAML responses

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -67,6 +67,13 @@ export default function http(url, request = {}) {
 // exported for testing
 export const shouldDownloadAsText = (contentType = '') => /json|xml|yaml|text/.test(contentType)
 
+function parseBody(body) {
+  if (/^\s*\{/.test(body)) {
+    return JSON.parse(body)
+  }
+  return jsYaml.safeLoad(body)
+}
+
 // Serialize the response, returns a promise with headers and the body part of the hash
 export function serializeRes(oriRes, url, {loadSpec = false} = {}) {
   const res = {
@@ -88,8 +95,7 @@ export function serializeRes(oriRes, url, {loadSpec = false} = {}) {
 
     if (useText) {
       try {
-        // Optimistically try to convert all bodies
-        const obj = jsYaml.safeLoad(body)
+        const obj = parseBody(body)
         res.body = obj
         res.obj = obj
       }


### PR DESCRIPTION
### Description
Check the content-type of response and use appropriate parser: `js-yaml`, json, or no parser.

### Motivation and Context
As described in #1165 even if one doesn’t use YAML at all, providing the spec via JSON object and using JSON to talk to backend, the swagger-client still uses `js-yaml` to parse responses. The downside to that approach is that one cannot forcefully remove `js-yaml` from Webpack bundle. 

If someone however have been using invalid JSON in the responses, this change will break things. Apparently the JSON parser of `js-yaml` is quite relaxed and handles even invalid JSON like this `{"123": NULL}`. It is your call whether to treat this as a breaking change or not.

### How Has This Been Tested?
`npm test` has passed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
