### PR TITLE
Enable submitting cookies in CORS requests

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -120,10 +120,13 @@ export function buildRequest(options) {
     }
   }
 
+  // Set credentials with 'http.withCredentials' value
+  const credentials = (http.withCredentials) ? 'include' : 'same-origin'
+
   // Base Template
   let req = {
     url: '',
-    credentials: 'same-origin',
+    credentials,
     headers: {
       // This breaks CORSs... removing this line... probably breaks oAuth. Need to address that
       // This also breaks tests

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -5,7 +5,7 @@ import isArray from 'lodash/isArray'
 import btoa from 'btoa'
 import url from 'url'
 import cookie from 'cookie'
-import http, {mergeInQueryOrForm} from '../http'
+import stockHttp, {mergeInQueryOrForm} from '../http'
 import createError from '../specmap/lib/create-error'
 
 import SWAGGER2_PARAMETER_BUILDERS from './swagger2/parameter-builders'
@@ -70,20 +70,20 @@ export function execute({
   ...extras
 }) {
   // Provide default fetch implementation
-  userHttp = userHttp || fetch || http // Default to _our_ http
+  const http = userHttp || fetch || stockHttp // Default to _our_ http
 
   if (pathName && method && !operationId) {
     operationId = legacyIdFromPathMethod(pathName, method)
   }
 
-  const request = self.buildRequest({spec, operationId, parameters, securities, ...extras})
+  const request = self.buildRequest({spec, operationId, parameters, securities, http, ...extras})
 
   if (request.body && (isPlainObject(request.body) || isArray(request.body))) {
     request.body = JSON.stringify(request.body)
   }
 
   // Build request and execute it
-  return userHttp(request)
+  return http(request)
 }
 
 // Build a request, which can be handled by the `http.js` implementation.
@@ -101,7 +101,8 @@ export function buildRequest(options) {
     userFetch,
     requestBody,
     server,
-    serverVariables
+    serverVariables,
+    http
   } = options
 
   let {
@@ -121,17 +122,13 @@ export function buildRequest(options) {
   }
 
   // Set credentials with 'http.withCredentials' value
-  const credentials = (http.withCredentials) ? 'include' : 'same-origin'
+  const credentials = (http && http.withCredentials) ? 'include' : 'same-origin'
 
   // Base Template
   let req = {
     url: '',
     credentials,
-    headers: {
-      // This breaks CORSs... removing this line... probably breaks oAuth. Need to address that
-      // This also breaks tests
-      // 'access-control-allow-origin': '*'
-    },
+    headers: {},
     cookies: {}
   }
 

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -4,6 +4,8 @@ import {normalizeSwagger} from './helpers'
 
 export function makeFetchJSON(http, opts = {}) {
   const {requestInterceptor, responseInterceptor} = opts
+  // Set credentials with 'http.withCredentials' value
+  const credentials = (http.withCredentials) ? 'include' : 'same-origin'
   return (docPath) => {
     return http({
       url: docPath,
@@ -13,7 +15,7 @@ export function makeFetchJSON(http, opts = {}) {
       headers: {
         Accept: 'application/json'
       },
-      credentials: 'same-origin' // same-origin to send cookies and auth headers
+      credentials
     })
     .then((res) => {
       return res.body

--- a/test/index.js
+++ b/test/index.js
@@ -259,6 +259,30 @@ describe('constructor', () => {
       })
     })
 
+    it('should respect the `withCredentials` flag on the http agent', function () {
+      const spec = {
+        paths: {
+          '/pet': {
+            get: {
+              operationId: 'getPets'
+            }
+          }
+        }
+      }
+      return Swagger({spec}).then((client) => {
+        const http = createSpy()
+        http.withCredentials = true
+        client.execute({http, operationId: 'getPets'})
+        expect(http.calls.length).toEqual(1)
+        expect(http.calls[0].arguments[0]).toEqual({
+          headers: {},
+          method: 'GET',
+          credentials: 'include',
+          url: '/pet'
+        })
+      })
+    })
+
     it('should add basic auth to a request', function () {
       const spec = {
         securityDefinitions: {


### PR DESCRIPTION
### Changes
- Change the value of `credentials` according to the value of `http.withCredentials` as in the `README.md`.

### Description
- Change the value of `credentials` if `http.withCredentials` value is `true`.

### Motivation and Context
- The issue is `credentials` is always 'same-origin' to fetch request.
- Cookies are not stored nor submitted across different origins.
- Fixes https://github.com/swagger-api/swagger-js/issues/1186

### How Has This Been Tested?
 - Tested with two origins.
 - UI running on `localhost:9292` sends requests to the server on `localhost:9293`.

### Screenshots (if appropriate):
- Video on testing the fix: [Testing swagger-js submitting cookies within two origins.](https://youtu.be/lXu1MR_Z730)
- Set cookies
  ![setcookie-header](https://user-images.githubusercontent.com/23183042/33251965-f549de56-d360-11e7-94c2-aa65a41d3027.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
