### PR TITLE
Add lookaside to `traverse` - Limits DFS revisit

### DIFF
--- a/src/specmap/index.js
+++ b/src/specmap/index.js
@@ -117,8 +117,8 @@ class SpecMap {
                   if (specmap.allowMetaPatches && objRef) {
                     traversedRefs[objRef] = true
                   }
-                yield* traverse(val, updatedPath, patch)
-              }
+                  yield* traverse(val, updatedPath, patch)
+                }
               }
 
               if (!isRootProperties && key === pluginObj.key) {

--- a/src/specmap/index.js
+++ b/src/specmap/index.js
@@ -83,6 +83,8 @@ class SpecMap {
     // We might consider making this (traversing & application) configurable later.
     function createKeyBasedPlugin(pluginObj) {
       return function* (patches, specmap) {
+        const traversedRefs = {}
+
         for (const patch of patches.filter(lib.isAdditiveMutation)) {
           yield* traverse(patch.value, patch.path, patch)
         }
@@ -102,9 +104,21 @@ class SpecMap {
             for (const key of Object.keys(obj)) {
               const val = obj[key]
               const updatedPath = path.concat(key)
+              const isObj = lib.isObject(val)
 
-              if (lib.isObject(val)) {
+              // If the object has a meta '$$ref' - and store this $$ref
+              // in a lookaside to prevent future traversals of this $ref's tree.
+              const objRef = obj.$$ref
+              const traversed = specmap.allowMetaPatches && traversedRefs[obj.$$ref]
+
+              if (!traversed) {
+                if (isObj) {
+                  // Only store the ref if it exists
+                  if (specmap.allowMetaPatches && objRef) {
+                    traversedRefs[objRef] = true
+                  }
                 yield* traverse(val, updatedPath, patch)
+              }
               }
 
               if (!isRootProperties && key === pluginObj.key) {


### PR DESCRIPTION
### Description
See #1150. Adds a 'per-patch' lookaside to the `traverse` method within `createKeyBasedPlugin`.

### Motivation and Context
Previously, a `$ref` would be traversed multiple times during spec resolution. This change allows `$ref`s to be resolved once and prevents future unnecessary revisits.

Fixes #1150 - but still some questions about handling `allOf` resolution that may be handled in another PR.

### How Has This Been Tested?
All tests appear to pass - unsure if additional tests are required or need to be added for this change.

Existing code. Small spec (~5k lines formatted JSON). Average Resolution of ~1100ms.
![image](https://user-images.githubusercontent.com/1234523/33392940-2a2088e8-d503-11e7-92cb-3c51261d0ae1.png)

With change. Average Resolution of ~250ms.
![image](https://user-images.githubusercontent.com/1234523/33393056-7dea2f42-d503-11e7-8708-293732fdc808.png)

Existing code. Large spec (~141k lines formatted JSON). **NOTE: `allOf` plugin disabled for the below tests - only running `$ref` plugin.**
**????** I couldn't actually get this to complete in any reasonable time. 😄 

With change. Average Resolution of ~5200ms.
![image](https://user-images.githubusercontent.com/1234523/33393313-6ce28748-d504-11e7-8b45-f04c23974b6a.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
