### PR TITLE
OAS3: Path & Operation Servers

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -240,8 +240,11 @@ export function baseUrl(obj) {
   return specIsOAS3 ? oas3BaseUrl(obj) : swagger2BaseUrl(obj)
 }
 
-function oas3BaseUrl({spec, server, contextUrl, serverVariables = {}}) {
-  const servers = spec.servers
+function oas3BaseUrl({spec, pathName, method, server, contextUrl, serverVariables = {}}) {
+  const servers =
+    getIn(spec, ['paths', pathName, method, 'servers']) ||
+    getIn(spec, ['paths', pathName, 'servers']) ||
+    getIn(spec, ['servers'])
 
   let selectedServerUrl = ''
   let selectedServerObj = null

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -243,7 +243,6 @@ export function baseUrl(obj) {
 }
 
 function oas3BaseUrl({spec, pathName, method, server, contextUrl, serverVariables = {}}) {
-  debugger
   const servers =
     getIn(spec, ['paths', pathName, (method || '').toLowerCase(), 'servers']) ||
     getIn(spec, ['paths', pathName, 'servers']) ||

--- a/test.js
+++ b/test.js
@@ -1,9 +1,0 @@
-const fs = require("fs")
-const Swagger = require("./dist")
-
-const spec = JSON.parse(fs.readFileSync(__dirname + "/api-docs.json"))
-
-Swagger({ spec }).then((client) => {
-  console.log(client)
-  process.exit(0)
-})

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+const fs = require("fs")
+const Swagger = require("./dist")
+
+const spec = JSON.parse(fs.readFileSync(__dirname + "/api-docs.json"))
+
+Swagger({ spec }).then((client) => {
+  console.log(client)
+  process.exit(0)
+})

--- a/test/execute/main.js
+++ b/test/execute/main.js
@@ -37,37 +37,27 @@ describe('execute', () => {
       })
     })
 
-    it('should include host + http + baseUrl', function () {
-      // Given
-      const spec = {
-        host: 'swagger.io',
-        basePath: '/v1',
-      }
-
-      // When
-      const req = buildRequest({spec})
-
-      // Then
-      expect(req).toEqual({
-        url: 'http://swagger.io/v1',
-        credentials: 'same-origin',
-        headers: { }
-      })
-    })
-
     it('should include host + port', function () {
       // Given
       const spec = {
         host: 'foo.com:8081',
         basePath: '/v1',
+        paths: {
+          '/': {
+            get: {
+              operationId: 'foo'
+            }
+          }
+        }
       }
 
       // When
-      const req = buildRequest({spec})
+      const req = buildRequest({spec, operationId: 'foo'})
 
       // Then
       expect(req).toEqual({
-        url: 'http://foo.com:8081/v1',
+        url: 'http://foo.com:8081/v1/',
+        method: 'GET',
         credentials: 'same-origin',
         headers: { }
       })

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -504,7 +504,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
         spec,
         server: 'https://petstore-operation.net/{path}',
         pathName: '/',
-        method: 'get'
+        method: 'GET'
       })
 
       const resWithVariables = baseUrl({
@@ -514,7 +514,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           path: 'fizzbuzz'
         },
         pathName: '/',
-        method: 'get'
+        method: 'GET'
       })
 
       expect(res).toEqual('https://petstore-operation.net/foobar')
@@ -553,7 +553,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
         spec,
         server: 'https://petstore-path.net/{path}',
         pathName: '/',
-        method: 'get'
+        method: 'GET'
       })
 
       const resWithVariables = baseUrl({
@@ -563,7 +563,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           path: 'fizzbuzz'
         },
         pathName: '/',
-        method: 'get'
+        method: 'GET'
       })
 
       expect(res).toEqual('https://petstore-path.net/foobar')

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -471,6 +471,104 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
 
       expect(res).toEqual('https://petstore.net')
     })
+    it('should use an explicitly chosen server at the operation level', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'https://petstore.com'
+          },
+          {
+            url: 'https://petstore.net'
+          }
+        ],
+        paths: {
+          '/': {
+            get: {
+              servers: [
+                {
+                  url: 'https://petstore-operation.net/{path}',
+                  variables: {
+                    path: {
+                      default: 'foobar'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      const res = baseUrl({
+        spec,
+        server: 'https://petstore-operation.net/{path}',
+        pathName: '/',
+        method: 'get'
+      })
+
+      const resWithVariables = baseUrl({
+        spec,
+        server: 'https://petstore-operation.net/{path}',
+        serverVariables: {
+          path: 'fizzbuzz'
+        },
+        pathName: '/',
+        method: 'get'
+      })
+
+      expect(res).toEqual('https://petstore-operation.net/foobar')
+      expect(resWithVariables).toEqual('https://petstore-operation.net/fizzbuzz')
+    })
+
+    it('should use an explicitly chosen server at the path level', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'https://petstore.com'
+          },
+          {
+            url: 'https://petstore.net'
+          }
+        ],
+        paths: {
+          '/': {
+            servers: [
+              {
+                url: 'https://petstore-path.net/{asdf}',
+                variables: {
+                  asdf: {
+                    default: 'foobar'
+                  }
+                }
+              }
+            ],
+            get: {}
+          }
+        }
+      }
+
+      const res = baseUrl({
+        spec,
+        server: 'https://petstore-path.net/{asdf}',
+        pathName: '/',
+        method: 'get'
+      })
+
+      const resWithVariables = baseUrl({
+        spec,
+        server: 'https://petstore-path.net/{asdf}',
+        serverVariables: {
+          path: 'fizzbuzz'
+        },
+        pathName: '/',
+        method: 'get'
+      })
+
+      expect(res).toEqual('https://petstore-path.net/foobar')
+      expect(resWithVariables).toEqual('https://petstore-path.net/fizzbuzz')
+    })
     it('should not use an explicitly chosen server that is not present in the spec', function () {
       const spec = {
         openapi: '3.0.0',

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -536,9 +536,9 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           '/': {
             servers: [
               {
-                url: 'https://petstore-path.net/{asdf}',
+                url: 'https://petstore-path.net/{path}',
                 variables: {
-                  asdf: {
+                  path: {
                     default: 'foobar'
                   }
                 }
@@ -551,14 +551,14 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
 
       const res = baseUrl({
         spec,
-        server: 'https://petstore-path.net/{asdf}',
+        server: 'https://petstore-path.net/{path}',
         pathName: '/',
         method: 'get'
       })
 
       const resWithVariables = baseUrl({
         spec,
-        server: 'https://petstore-path.net/{asdf}',
+        server: 'https://petstore-path.net/{path}',
         serverVariables: {
           path: 'fizzbuzz'
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Adds support for operation and path-level `servers`.

Users will be able to provide path and operation `serverVariables` at request-time and they will be matched to the first `servers` definition that is found. Precedence is as follows: `operation > path > global`.

Users will still need to provide a `server` string found in a server definition that is matched to the operation, i.e. operations with `servers` in themselves or their path cannot try to use a global `server` definition.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Prerequisite for solving https://github.com/swagger-api/swagger-ui/issues/3820; companion to https://github.com/swagger-api/swagger-ui/pull/3972.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I added some unit tests to cover the new functionality.
- I manually tested this within the UI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.