### PR TITLE
fix(test): Fix test issues on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-bundle": "cross-env NODE_ENV=production webpack -p --config ./webpack.bundle.config.js",
     "watch": "webpack --config webpack.config.js --watch --progress",
     "test": "npm run just-test && npm run lint",
-    "just-test": "cross-env NODE_ENV=test node ./node_modules/.bin/_mocha --recursive --compilers js:babel-core/register",
+    "just-test": "cross-env NODE_ENV=test node ./node_modules/mocha/bin/_mocha --recursive --compilers js:babel-core/register",
     "test:watch": "npm run test -- -w",
     "lint": "eslint src/ test/",
     "deps-license": "license-checker --production --csv --out $npm_package_config_deps_check_dir/licenses.csv && license-checker --development --csv --out $npm_package_config_deps_check_dir/licenses-dev.csv",

--- a/test/specmap/refs.js
+++ b/test/specmap/refs.js
@@ -288,8 +288,8 @@ describe('refs', function () {
       const cases = caseFiles
         .sort((f1, f2) => {
           // Sorts by group ('internal', 'external') before test case number
-          const group1 = f1.substring(dir.length).split(path.sep)[1]
-          const group2 = f2.substring(dir.length).split(path.sep)[1]
+          const group1 = f1.replace(/\//g, path.sep).substring(dir.length).split(path.sep)[1]
+          const group2 = f2.replace(/\//g, path.sep).substring(dir.length).split(path.sep)[1]
           const no1 = Number(path.basename(f1).split('.')[0])
           const no2 = Number(path.basename(f2).split('.')[0])
           return group1.localeCompare(group2) || (no1 - no2)


### PR DESCRIPTION
Allows unit test execution in Windows. 

### Description
There is a [mocha bug](https://github.com/gotwarlost/istanbul/issues/677) that keeps tests from running in Windows. The change in the package.json is to resolve this.

Also - node-glob always provides a single slash path - ignoring the value of the path.sep. This replaces that value with the value of path.sep. This changes all forward slashes in these tests to be whatever path.sep is - which should allow execution and proper paths on any platform.

### Motivation and Context
Fixes tests. Previously I ran tests with WSL (Windows Subsystem for Linux) - but got tired of dealing with it 😆 

### How Has This Been Tested?
All tests run / pass

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
