### PR TITLE
Ignore Swagger/OpenAPI freely-named key paths in $ref/allOf plugins

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "no-underscore-dangle": 0,
     "no-unused-expressions": [2, {"allowShortCircuit": true}],
     "object-curly-spacing": [2, "never"],
+    "import/prefer-default-export": 1,
     "import/no-extraneous-dependencies": ["error", {"devDependencies": ["!test/**/*.js"]}]
   }
 }

--- a/src/specmap/helpers.js
+++ b/src/specmap/helpers.js
@@ -1,0 +1,13 @@
+export const freelyNamedKeyParents = [
+  // Swagger 2.0
+  'definitions',
+  'parameters',
+  'responses',
+  'securityDefinitions',
+
+  // OpenAPI 3.0
+  'components/schemas',
+  'components/responses',
+  'components/parameters',
+  'components/securitySchemes',
+]

--- a/src/specmap/lib/all-of.js
+++ b/src/specmap/lib/all-of.js
@@ -1,3 +1,5 @@
+import {freelyNamedKeyParents} from '../helpers'
+
 export default {
   key: 'allOf',
   plugin: (val, key, fullPath, specmap, patch) => {
@@ -8,13 +10,20 @@ export default {
       return
     }
 
+    const parent = fullPath.slice(0, -1)
+    const parentStr = parent.join('/')
+
+    if (freelyNamedKeyParents.indexOf(parentStr) > -1) {
+      return
+    }
+
     if (!Array.isArray(val)) {
       const err = new TypeError('allOf must be an array')
       err.fullPath = fullPath // This is an array
       return err
     }
 
-    const parent = fullPath.slice(0, -1)
+
     let alreadyAddError = false
 
     // Find the original definition from the `patch.value` object

--- a/src/specmap/lib/refs.js
+++ b/src/specmap/lib/refs.js
@@ -2,6 +2,7 @@ import {fetch} from 'cross-fetch'
 import url from 'url'
 import lib from '../lib'
 import createError from '../lib/create-error'
+import {freelyNamedKeyParents} from '../helpers'
 
 const ABSOLUTE_URL_REGEXP = new RegExp('^([a-z]+://|//)', 'i')
 
@@ -41,7 +42,12 @@ const plugin = {
   key: '$ref',
   plugin: (ref, key, fullPath, specmap) => {
     const parent = fullPath.slice(0, -1)
+    const parentStr = parent.join('/')
     const baseDoc = specmap.getContext(fullPath).baseDoc
+
+    if (freelyNamedKeyParents.indexOf(parentStr) > -1) {
+      return
+    }
 
     if (typeof ref !== 'string') {
       return new JSONRefError('$ref: must be a string (JSON-Ref)', {

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -192,6 +192,39 @@ describe('allOf', function () {
     })
   })
 
+  it('should ignore "allOf" in freely named Swagger key positions', function () {
+    const spec = {
+      parameters: {
+        allOf: {
+          a: 123
+        }
+      },
+      responses: {
+        allOf: {
+          a: 123
+        }
+      },
+      definitions: {
+        allOf: {
+          a: 123
+        }
+      },
+      securityDefinitions: {
+        allOf: {
+          a: 123
+        }
+      },
+    }
+
+    return mapSpec({
+      spec,
+      plugins: [plugins.allOf]
+    }).then((res) => {
+      expect(res.errors).toEqual([])
+      expect(res.spec).toEqual(spec)
+    })
+  })
+
   it('should throw error if allOf has a non-object item', function () {
     return mapSpec({
       spec: {

--- a/test/specmap/refs.js
+++ b/test/specmap/refs.js
@@ -363,6 +363,43 @@ describe('refs', function () {
       })
     })
 
+    it('should ignore $refs in freely named Swagger positions', function () {
+      return mapSpec({
+        spec: {
+          a: 1234,
+          parameters: {
+            $ref: '#/a'
+          },
+          responses: {
+            $ref: '#/a'
+          },
+          definitions: {
+            $ref: '#/a'
+          },
+          securityDefinitions: {
+            $ref: '#/a'
+          }
+        },
+        plugins: [refs],
+      }).then((res) => {
+        expect(res.spec).toEqual({
+          a: 1234,
+          parameters: {
+            $ref: '#/a'
+          },
+          responses: {
+            $ref: '#/a'
+          },
+          definitions: {
+            $ref: '#/a'
+          },
+          securityDefinitions: {
+            $ref: '#/a'
+          }
+        })
+      })
+    })
+
     it('should include fullPath in invalid $ref type', function () {
       return mapSpec({
         spec: {one: {$ref: 1}},


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-editor/issues/1343.