### PR TITLE
Fixing support for matrix parameters when not present in the path definition

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -10,14 +10,19 @@ export default {
 function path({req, value, parameter}) {
   const {name, style, explode} = parameter
   const styledValue = stylize({
-    key: parameter.name,
+    key: name,
     value,
     style: style || 'simple',
-    explode: explode || false,
-    escape: false,
+    explode: typeof explode === 'undefined' ? false : explode,
+    escape: style === 'matrix'
   })
 
-  req.url = req.url.replace(`{${name}}`, styledValue)
+  if (style === 'matrix' && req.url.indexOf(`{${name}}`) === -1) {
+    req.url = req.url.concat(styledValue)
+  }
+  else {
+    req.url = req.url.replace(`{${name}}`, styledValue)
+  }
 }
 
 function query({req, value, parameter}) {

--- a/test/oas3/execute/style-explode/path.js
+++ b/test/oas3/execute/style-explode/path.js
@@ -824,5 +824,43 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', func
         headers: {},
       })
     })
+
+    it('should build a path parameter in a matrix/no-explode format when not present in the path definition', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        paths: {
+          '/path/': {
+            get: {
+              operationId: 'myOperation',
+              parameters: [
+                {
+                  name: 'type',
+                  in: 'path',
+                  style: 'matrix',
+                  explode: false
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        parameters: {
+          type: 'PullTask'
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/path/;type=PullTask',
+        credentials: 'same-origin',
+        headers: {},
+      })
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
While already part of the OpanApi Spec 3.0, Matrix parameters are currently ignored by swagger-js and, by consequence, by swagger-ui.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
