### PR TITLE
fix(oas3-encoding): encode form-urlencoded array values as comma-separated values by default

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -50,8 +50,22 @@ export default function (options, req) {
             req.form = {}
             Object.keys(requestBody).forEach((k) => {
               const val = requestBody[k]
+              let newVal
+
+              if (typeof val === 'object') {
+                if (Array.isArray(val)) {
+                  newVal = val.toString()
+                }
+                else {
+                  newVal = JSON.stringify(val)
+                }
+              }
+              else {
+                newVal = val
+              }
+
               req.form[k] = {
-                value: typeof val === 'object' ? JSON.stringify(val) : val
+                value: newVal
               }
             })
           }

--- a/test/bugs/ui-4071.js
+++ b/test/bugs/ui-4071.js
@@ -1,0 +1,73 @@
+// https://github.com/swagger-api/swagger-ui/issues/4071
+
+import expect, {createSpy, spyOn} from 'expect'
+import {execute, buildRequest, baseUrl, self as stubs} from '../../src/execute'
+
+const spec = {
+  openapi: '3.0.0',
+  servers: [
+    {
+      url: 'https://workbcjobs.api.gov.bc.ca/v1'
+    }
+  ],
+  paths: {
+    '/jobs': {
+      post: {
+        operationId: 'postJobs',
+        description: 'The job feed endpoint returns an array of job records that satisfy the supplied criteria.',
+        responses: {
+          default: {
+            description: 'Unexpected error'
+          }
+        },
+        requestBody: {
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  industries: {
+                    type: 'array',
+                    items: {
+                      type: 'integer'
+                    }
+                  }
+                }
+              },
+              encoding: {
+                industries: {
+                  style: 'form'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+
+it('should generate a request with application/x-www-form-urlencoded', function () {
+  const req = buildRequest({
+    spec,
+    requestContentType: 'application/x-www-form-urlencoded',
+    operationId: 'postJobs',
+    requestBody: {
+      industries: [
+        1,
+        16
+      ]
+    }
+  })
+
+  expect(req).toEqual({
+    url: 'https://workbcjobs.api.gov.bc.ca/v1/jobs',
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'industries=1%2C16'
+  })
+})


### PR DESCRIPTION
Addresses https://github.com/swagger-api/swagger-ui/issues/4071.