### PR TITLE
Remove the unnecessary loop of all operations when new one added

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -146,22 +146,21 @@ export function normalizeSwagger(parsedSpec) {
           map[oid] = [operation]
         }
 
-        Object.keys(map).forEach((op) => {
-          if (map[op].length > 1) {
-            map[op].forEach((o, i) => {
-              o.__originalOperationId = o.__originalOperationId || o.operationId
-              o.operationId = `${op}${i + 1}`
-            })
-          }
-          else if (typeof operation.operationId !== 'undefined') {
-            // Ensure we always add the normalized operation ID if one already exists
-            // ( potentially different, given that we normalize our IDs)
-            // ... _back_ to the spec. Otherwise, they might not line up
-            const obj = map[op][0]
-            obj.__originalOperationId = obj.__originalOperationId || operation.operationId
-            obj.operationId = op
-          }
-        })
+        const opList = map[oid]
+        if (opList.length > 1) {
+          opList.forEach((o, i) => {
+            o.__originalOperationId = o.__originalOperationId || o.operationId
+            o.operationId = `${oid}${i + 1}`
+          })
+        }
+        else if (typeof operation.operationId !== 'undefined') {
+          // Ensure we always add the normalized operation ID if one already exists
+          // ( potentially different, given that we normalize our IDs)
+          // ... _back_ to the spec. Otherwise, they might not line up
+          const obj = opList[0]
+          obj.__originalOperationId = obj.__originalOperationId || operation.operationId
+          obj.operationId = oid
+        }
       }
 
       if (method !== 'parameters') {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -277,6 +277,30 @@ describe('helpers', function () {
         expect(originalId).toEqual('something with spaces')
       })
 
+      it('should not set __originalOperationId when operationId is not defined', function () {
+        // Given
+        const spec = {spec: {
+          paths: {
+            '/foo': {
+              get: {
+              },
+              post: {
+                operationId: 'myId2'
+              }
+            },
+          }
+        }}
+
+        // When
+        const normalizedSpec = normalizeSwagger(spec)
+        const fooGet = normalizedSpec.spec.paths['/foo'].get
+        const fooPost = normalizedSpec.spec.paths['/foo'].post
+
+        // Then
+        expect(fooPost.__originalOperationId).toEqual('myId2')
+        expect(fooGet.__originalOperationId).toEqual(undefined)
+      })
+
       it('should create unique operationIds when explicit operationIds are effectively the same due to whitespace', function () {
         const spec = {spec: {
           paths: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The previous code was looping through all known operations and update their __originalOperationId and operationId, after each one operation is added to the known list.

This is not only inefficient, but introduces a bug at the following line

```
obj.__originalOperationId = obj.__originalOperationId || operation.operationId
```

Where `operation` is the one that just got added and `obj` is the current operation in the loop.

This means for the following spec:

```
        const spec = {spec: {
          paths: {
            '/foo': {
              get: {
              },
              post: {
                operationId: 'myId2'
              }
            },
          }
        }}
```

When operationId is not defined for the `get` operation, the __originalOperationId incorrectly gets set to 'myId2' when the post operation got added to the list.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #1221 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added extra unit test to cover the above scenario

### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
