### PR TITLE
fix(resolver): accept yaml when fetching documents

### DIFF
--- a/src/specmap/lib/refs.js
+++ b/src/specmap/lib/refs.js
@@ -254,7 +254,7 @@ function getDoc(docPath) {
  * @api public
  */
 function fetchJSON(docPath) {
-  return fetch(docPath, {headers: {Accept: 'application/json'}, loadSpec: true}).then(res => res.json())
+  return fetch(docPath, {headers: {Accept: 'application/json, application/yaml'}, loadSpec: true}).then(res => res.json())
 }
 
 /**


### PR DESCRIPTION
addresses https://github.com/swagger-api/swagger-ui/issues/4070