### PR TITLE
fix bind error to enable submitting cookies in CORS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,12 @@ If you need activate CORS requests, just enable it by `withCredentials` property
 <head>
 <script src='browser/swagger-client.js' type='text/javascript'></script>
 <script>
+
 var specUrl = 'http://petstore.swagger.io/v2/swagger.json'; // data urls are OK too 'data:application/json;base64,abc...'
+SwaggerClient.http.withCredentials = true; // this activates CORS, if necessary
+
 var swaggerClient = new SwaggerClient(specUrl)
-      .then(function (swaggerClient) {                                            
-          swaggerClient.http.withCredentials = true; // this activates CORS, if necessary
-                   
+      .then(function (swaggerClient) {
           return swaggerClient.apis.pet.addPet({id: 1, name: "bobby"}); // chaining promises
       }, function (reason) {
          console.error("failed to load the spec" + reason);

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ Swagger.prototype = {
 
     return Swagger.execute({
       spec: this.spec,
-      http: this.http.bind(this),
+      http: this.http,
       securities: {authorized: this.authorizations},
       ...argHash
     })


### PR DESCRIPTION
- Removed `this.http.bind` statement
- Documentation is updated.

### Description
- The statement will not assign the `withCredentials` value of `http` function to the new `http` variable.
- Below is the test run in console.
```js
>  this.http
<- ƒ http(url) {
     var request = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};

     if ((typeof url === 'undefined' ? 'undefined' : (0, _typeof3.default)(url)) === 'object') {
     …
>  this.http.withCredentials
<- true
>  var bindedHttp = this.http.bind(this);
<- undefined
>  bindedHttp.withCredentials
<- undefined
```
- No method consumes `this.'any_property'` in the http (i.e.src/http.js) method. No use of binding.


### Motivation and Context
- fixed https://github.com/swagger-api/swagger-js/issues/1186



### How Has This Been Tested?
 - Tested with two origins.
 - UI running on `localhost:9292` sends requests to the server on `localhost:9293`.



### Screenshots (if appropriate):
- Please refer the console area
![bind_error](https://user-images.githubusercontent.com/23183042/35572074-d2daa15e-05f9-11e8-9297-e31385059ab3.png)



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
