### PR TITLE
fix(resolver): don't attach $$ref meta patches to $ref origin locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cross-fetch": "0.0.8",
     "deep-extend": "^0.4.1",
     "encode-3986": "^1.0.0",
-    "fast-json-patch": "1.1.8",
+    "fast-json-patch": "^1.2.2",
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",
     "lodash": "^4.16.2",

--- a/src/specmap/index.js
+++ b/src/specmap/index.js
@@ -212,8 +212,11 @@ class SpecMap {
   }
 
   updateMutations(patch) {
-    if (lib.applyPatch(this.state, patch, {allowMetaPatches: this.allowMetaPatches})) {
+    const result = lib.applyPatch(this.state, patch, {allowMetaPatches: this.allowMetaPatches})
+    console.log('SPECMAP RESULT', result)
+    if (result) {
       this.mutations.push(patch)
+      this.state = result
     }
   }
 

--- a/src/specmap/index.js
+++ b/src/specmap/index.js
@@ -213,7 +213,6 @@ class SpecMap {
 
   updateMutations(patch) {
     const result = lib.applyPatch(this.state, patch, {allowMetaPatches: this.allowMetaPatches})
-    console.log('SPECMAP RESULT', result)
     if (result) {
       this.mutations.push(patch)
       this.state = result

--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -30,15 +30,11 @@ export default {
 }
 
 function applyPatch(obj, patch, opts) {
-  console.log('original obj', obj, "\n\n")
-
   opts = opts || {}
 
   patch = Object.assign({}, patch, {
     path: patch.path && normalizeJSONPath(patch.path)
   })
-
-  console.log('patch', patch, "\n\n")
 
   if (patch.op === 'merge') {
     const newValue = getInByJsonPath(obj, patch.path)
@@ -77,9 +73,9 @@ function applyPatch(obj, patch, opts) {
         return arr
       }, [])
 
-      console.log('segmented patches', patches, "\n\n")
-      jsonPatch.applyPatch(obj, patches)
-  } else if(patch.op === 'replace' && patch.path === '') {
+    jsonPatch.applyPatch(obj, patches)
+  }
+  else if (patch.op === 'replace' && patch.path === '') {
     let value = patch.value
 
     if (opts.allowMetaPatches && patch.meta && isAdditiveMutation(patch) &&
@@ -87,7 +83,8 @@ function applyPatch(obj, patch, opts) {
       value = Object.assign({}, value, patch.meta)
     }
     obj = value
-  } else {
+  }
+  else {
     jsonPatch.applyPatch(obj, [patch])
 
     // Attach metadata to the resulting value.
@@ -98,8 +95,6 @@ function applyPatch(obj, patch, opts) {
       jsonPatch.applyPatch(obj, [replace(patch.path, newValue)])
     }
   }
-
-  console.log('final obj', obj, "\n\n")
 
   return obj
 }
@@ -335,12 +330,11 @@ function isPatch(patch) {
 }
 
 function getInByJsonPath(obj, jsonPath) {
-  console.log('getInByJsonPath', jsonPath)
   try {
     return jsonPatch.getValueByPointer(obj, jsonPath)
   }
   catch (e) {
-    console.error(e)
+    console.error(e) // eslint-disable-line no-console
     return {}
   }
 }

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -447,7 +447,6 @@ describe('resolver', () => {
           },
           definitions: {
             Category: {
-              $$ref: '#/definitions/Category', // FIXME: benign, but this should not be present
               type: 'object',
               properties: {
                 id: {
@@ -460,14 +459,13 @@ describe('resolver', () => {
               }
             },
             Pet: {
-              $$ref: '#/definitions/Pet',
               type: 'object',
               required: [
                 'category'
               ],
               properties: {
                 category: {
-                  $$ref: '#/definitions/Category', // FIXME: benign, but this should not be present
+                  $$ref: '#/definitions/Category',
                   type: 'object',
                   properties: {
                     id: {

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -128,7 +128,6 @@ describe('allOf', function () {
         errors: [],
         spec: {
           Pet: {
-            $$ref: '#/Pet',
             type: 'object',
             properties: {
               name: {
@@ -137,7 +136,6 @@ describe('allOf', function () {
             }
           },
           Cat: {
-            $$ref: '#/Cat',
             properties: {
               meow: {
                 type: 'string'

--- a/test/specmap/index.js
+++ b/test/specmap/index.js
@@ -549,6 +549,7 @@ describe('specmap', function () {
           })
             .then((res) => {
               expect(res.spec.one.$$ref).toEqual('#/two')
+              expect(res.spec.two.$$ref).toEqual(undefined)
             })
         })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

`$$ref` meta patches were being attached to the path referenced by a `$ref` as well as the destination, which was caused by the JSON Patch processor linking the $ref source and destination by referencing the same in-memory Object in both positions. This is bad for two reasons:
1. there's no need for information about the $ref source path, as it can be deduced by the data's back itself
2. it becomes impossible to consume $$refs as a marker of a $ref previously being in that position

This PR eliminates this issue by breaking the Object reference between the source and destination.

It also:
- moves to `fast-json-patch@1.2`
- refactors use of `op: '_get'` to `fast-json-patch`'s new `getValueByPointer` interface


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

- Unblocks https://github.com/swagger-api/swagger-editor/issues/1560.
- Paves the way for our lazy resolver implementation.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I updated a handful of unit tests to match the new $$ref implementation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Breaking internal API change (requires minor version bump).

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.