### PR TITLE
resolve  $refs for operation requestBody

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -18,7 +18,10 @@ export default function (options, req) {
 
   req = applySecurities({request: req, securities, operation, spec})
 
-  const requestBodyDef = operation.requestBody || {}
+  let requestBodyDef = operation.requestBody || {}
+  if (requestBodyDef.$ref) {
+    requestBodyDef = get(spec, requestBodyDef.$ref.substr(2).split('/'))
+  }
   const requestBodyMediaTypes = Object.keys(requestBodyDef.content || {})
 
   // for OAS3: set the Content-Type

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -412,7 +412,9 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
         method: 'POST',
         url: 'http://petstore.swagger.io/v2/pet',
         credentials: 'same-origin',
-        headers: {},
+        headers: {
+          'Content-Type': 'application/json'
+        },
         body: {
           one: 1
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Operation object's `requestBody` may be a reference to `components/requestBodies` object but this is not supported by this lib which results in `Content-Type` header not being sent (see tests change)

### How Has This Been Tested?
I have tested it using test OAS3 spec from this repo (https://github.com/swagger-api/swagger-js/blob/master/test/oas3/data/petstore-oas3.yaml)

### Types of changes
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
