### PR TITLE
Support asynchronous responseInterceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Swagger.http(request)
 // Interceptors
 Swagger.http({
   requestInterceptor: (req: Request) => Request
-  responseInterceptor: (res: Response) => Response
+  responseInterceptor: (res: Response) => Response | Promise
 })
 
 // Custom Fetch

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Swagger.http(request)
 
 // Interceptors
 Swagger.http({
-  requestInterceptor: (req: Request) => Request
-  responseInterceptor: (res: Response) => Response | Promise
+  requestInterceptor: (req: Request) => Request | Promise<Request>
+  responseInterceptor: (res: Response) => Response | Promise<Response>
 })
 
 // Custom Fetch

--- a/src/http.js
+++ b/src/http.js
@@ -43,22 +43,20 @@ export default function http(url, request = {}) {
         _res = request.responseInterceptor(_res) || _res
       }
       return _res
-    })
-
-    if (!res.ok) {
+    }).then((_res) => {
+      if (!_res.ok) {
+        const error = new Error(_res.statusText)
+        error.statusCode = error.status = _res.status
+        error.response = _res
+        throw error
+      }
+      return _res
+    }, (resError) => {
       const error = new Error(res.statusText)
       error.statusCode = error.status = res.status
-      return serialized.then(
-        (_res) => {
-          error.response = _res
-          throw error
-        },
-        (resError) => {
-          error.responseError = resError
-          throw error
-        }
-      )
-    }
+      error.responseError = resError
+      throw error
+    })
 
     return serialized
   })

--- a/src/http.js
+++ b/src/http.js
@@ -25,7 +25,7 @@ export default async function http(url, request = {}) {
   self.mergeInQueryOrForm(request)
 
   if (request.requestInterceptor) {
-    request = request.requestInterceptor(request) || request
+    request = await request.requestInterceptor(request) || request
   }
 
   // for content-type=multipart\/form-data remove content-type from request before fetch

--- a/test/http.js
+++ b/test/http.js
@@ -60,6 +60,46 @@ describe('http', () => {
     )
   })
 
+  it('should call request interceptor', () => {
+    xapp = xmock()
+    xapp.get('http://swagger.io', (req, res) => res.status(req.requestHeaders.mystatus).send('hi'))
+
+    return http({
+      url: 'http://swagger.io',
+      requestInterceptor: (req) => {
+        req.headers.mystatus = 200
+        return req
+      }
+    })
+    .then(
+      (res) => {
+        expect(res.status).toEqual(200)
+      }
+    )
+  })
+
+  it('should allow the requestInterceptor to return a promise', () => {
+    xapp = xmock()
+    xapp.get('http://swagger.io', (req, res) => res.status(req.requestHeaders.mystatus).send('hi'))
+
+    return http({
+      url: 'http://swagger.io',
+      requestInterceptor: (req) => {
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            req.headers.mystatus = 200
+            resolve(req)
+          }, 20)
+        })
+      }
+    })
+    .then(
+      (res) => {
+        expect(res.status).toEqual(200)
+      }
+    )
+  })
+
   it('should apply responseInterceptor to error responses', () => {
     xapp = xmock()
     xapp.get('http://swagger.io', (req, res) => res.status(400).send('hi'))

--- a/test/http.js
+++ b/test/http.js
@@ -80,6 +80,25 @@ describe('http', () => {
     )
   })
 
+  it('should allow the responseInterceptor to return a promise for a final response', () => {
+    xapp = xmock()
+    xapp.get('http://swagger.io', (req, res) => res.status(400).send('doit'))
+    xapp.get('http://example.com', (req, res) => res.send('hi'))
+
+    return http({
+      url: 'http://swagger.io',
+      responseInterceptor: (res) => {
+        return http({
+          url: 'http://example.com'
+        })
+      }
+    })
+      .then((res) => {
+        expect(res.status).toEqual(200)
+        expect(res.text).toEqual('hi')
+      })
+  })
+
   it('should set responseError on responseInterceptor Error', () => {
     xapp = xmock()
     xapp.get('http://swagger.io', (req, res) => res.status(400).send('hi'))


### PR DESCRIPTION
### Description

Analogous to Issue #1249, I would need the responseInterceptor to be able to modify the response asynchronously.

### Motivation and Context

The idea is for the responseInterceptor to make another request and use the result in place of the previously received one. In particular I need this, because I need to handle redirect requests myself, because I need to receive cookies set on the redirect response. 

### How Has This Been Tested?

I've added a test to the test suite that performs a new request from the responseInterceptor (although from an error response, not a redirect).

### Types of changes
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
