### PR TITLE
fix: don't classify remote document references as indirect circrefs

### DIFF
--- a/src/specmap/lib/refs.js
+++ b/src/specmap/lib/refs.js
@@ -330,8 +330,11 @@ function pointerIsAParent(pointer, parentPointer) {
     return true
   }
   const nextChar = pointer.charAt(parentPointer.length)
+  const lastParentChar = parentPointer.slice(-1)
+
   return pointer.indexOf(parentPointer) === 0
     && (!nextChar || nextChar === '/' || nextChar === '#')
+    && lastParentChar !== '#'
 }
 
 

--- a/test/specmap/refs.js
+++ b/test/specmap/refs.js
@@ -435,7 +435,7 @@ describe('refs', function () {
   })
 
   describe('deeply resolved', function () {
-    it('should resolve deeply nested $refs, across documents', function () {
+    it('should resolve deeply serial $refs, across documents', function () {
       xmock().get('http://example.com/doc-a', function (req, res, next) {
         xmock().restore()
         return res.send({
@@ -459,6 +459,58 @@ describe('refs', function () {
       }).then((res) => {
         expect(res.spec).toEqual({
           four: 4
+        })
+      })
+    })
+    it('should resolve deeply nested $refs, across documents', function () {
+      xmock().get('http://example.com/doc-a', function (req, res, next) {
+        xmock().restore()
+        return res.send({
+          two: {
+            innerTwo: {
+              $ref: '#/three'
+            }
+          },
+          three: {
+            innerThree: {
+              $ref: '#/four'
+            }
+          },
+          four: {
+            four: 4,
+          }
+        })
+      })
+
+      return mapSpec({
+        plugins: [plugins.refs],
+        spec: {
+          result: {
+            $ref: 'http://example.com/doc-a#'
+          }
+        },
+        context: {
+          baseDoc: 'http://example.com/main.json'
+        }
+      }).then((res) => {
+        expect(res.spec).toEqual({
+          result: {
+            two: {
+              innerTwo: {
+                innerThree: {
+                  four: 4
+                }
+              }
+            },
+            three: {
+              innerThree: {
+                four: 4
+              }
+            },
+            four: {
+              four: 4
+            }
+          }
         })
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR adds a new stopgap that prevents specmap from misclassifying local references within a remote document referenced by a whole-document pointer as indirect circular references.

Some notes I made while digging into this:
- The core issue appears to be that local references within the remote document are being flagged as an indirect cyclic reference, after we have crossed into that document with a top level reference (e.g. `./myDoc.json#`).
- The effect of this is that the $ref is left in place after the resolution cycle.
- Swagger-UI is throwing a "cannot resolve" error because the result of its first resolve cycle is fed in as the starting point for its second cycle, which is something we do to avoid needless duplicate resolutions. For debugging purposes, this message can be ignored: there's a deeper problem causing it.
	- Since Swagger-Client leaves the $ref in the remote document alone _after_ the remote document has been grafted into the main document, it appears to be a local reference to the main document when that result is passed in again.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes a privately-reported issue from a user.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added new unit tests.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.