### PR TITLE
Normalize Swagger definitions before resolving a subtree

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -117,7 +117,7 @@ export function normalizeSwagger(parsedSpec) {
   const {paths} = spec
   const map = {}
 
-  if (!paths) {
+  if (!paths || spec.$$normalized) {
     return parsedSpec
   }
 
@@ -205,6 +205,8 @@ export function normalizeSwagger(parsedSpec) {
       }
     }
   }
+
+  spec.$$normalized = true
 
   return parsedSpec
 }

--- a/src/subtree-resolver/index.js
+++ b/src/subtree-resolver/index.js
@@ -24,6 +24,7 @@
 
 import get from 'lodash/get'
 import resolve from '../resolver'
+import {normalizeSwagger} from '../helpers'
 
 export default async function resolveSubtree(obj, path, opts = {}) {
   const {
@@ -44,10 +45,15 @@ export default async function resolveSubtree(obj, path, opts = {}) {
     modelPropertyMacro
   }
 
+  const {spec: normalized} = normalizeSwagger({
+    spec: obj
+  })
+
   const result = await resolve({
     ...resolveOptions,
-    spec: obj,
+    spec: normalized,
     allowMetaPatches: true,
+    skipNormalization: true
   })
 
   if (!returnEntireTree && Array.isArray(path) && path.length) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -349,6 +349,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           consumes: ['application/json'],
           paths: {
             '/two': {
@@ -374,6 +375,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           consumes: ['application/json'],
           paths: {
             '/two': {
@@ -402,6 +404,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           produces: ['application/json'],
           paths: {
             '/two': {
@@ -427,6 +430,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           produces: ['application/json'],
           paths: {
             '/two': {
@@ -455,6 +459,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           security: ['test'],
           paths: {
             '/two': {
@@ -480,6 +485,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           security: ['test1'],
           paths: {
             '/two': {
@@ -506,6 +512,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           paths: {
             '/two': {
               parameters: [{name: 'a', in: 'path'}],
@@ -538,6 +545,7 @@ describe('helpers', function () {
         const resultSpec = normalizeSwagger(spec)
 
         expect(resultSpec).toEqual({spec: {
+          $$normalized: true,
           paths: {
             '/two': {
               parameters: [

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -419,6 +419,7 @@ describe('resolver', () => {
         expect(obj.errors).toEqual([])
         expect(obj.spec).toEqual({
           swagger: '2.0',
+          $$normalized: true,
           paths: {
             '/pet': {
               post: {

--- a/test/subtree-resolver.js
+++ b/test/subtree-resolver.js
@@ -169,6 +169,7 @@ describe('subtree $ref resolver', function () {
     expect(res).toEqual({
       errors: [],
       spec: {
+        $$normalized: true,
         swagger: '2.0',
         consumes: ['application/json'],
         paths: {
@@ -202,6 +203,7 @@ describe('subtree $ref resolver', function () {
     expect(res).toEqual({
       errors: [],
       spec: {
+        $$normalized: true,
         swagger: '2.0',
         produces: ['application/json'],
         paths: {
@@ -264,6 +266,7 @@ describe('subtree $ref resolver', function () {
     expect(res).toEqual({
       errors: [],
       spec: {
+        $$normalized: true,
         swagger: '2.0',
         parameters: {
           petId: {

--- a/test/subtree-resolver.js
+++ b/test/subtree-resolver.js
@@ -215,6 +215,209 @@ describe('subtree $ref resolver', function () {
       }
     })
   })
+  it('should normalize Swagger 2.0 parameters', async () => {
+    const input = {
+      swagger: '2.0',
+      parameters: {
+        petId: {
+          name: 'petId',
+          in: 'path',
+          description: 'ID of pet to return',
+          required: true,
+          type: 'integer',
+          format: 'int64'
+        }
+      },
+      paths: {
+        '/': {
+          parameters: [
+            {
+              $ref: '#/parameters/petId'
+            }
+          ],
+          get: {
+            parameters: [
+              {
+                name: 'name',
+                in: 'formData',
+                description: 'Updated name of the pet',
+                required: false,
+                type: 'string'
+              },
+              {
+                name: 'status',
+                in: 'formData',
+                description: 'Updated status of the pet',
+                required: false,
+                type: 'string'
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    const res = await resolve(input, ['paths', '/', 'get'], {
+      returnEntireTree: true
+    })
+
+    expect(res).toEqual({
+      errors: [],
+      spec: {
+        swagger: '2.0',
+        parameters: {
+          petId: {
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet to return',
+            required: true,
+            type: 'integer',
+            format: 'int64'
+          }
+        },
+        paths: {
+          '/': {
+            parameters: [
+              {
+                $ref: '#/parameters/petId'
+              }
+            ],
+            get: {
+              parameters: [
+                {
+                  name: 'name',
+                  in: 'formData',
+                  description: 'Updated name of the pet',
+                  required: false,
+                  type: 'string'
+                },
+                {
+                  name: 'status',
+                  in: 'formData',
+                  description: 'Updated status of the pet',
+                  required: false,
+                  type: 'string'
+                },
+                {
+                  name: 'petId',
+                  in: 'path',
+                  description: 'ID of pet to return',
+                  required: true,
+                  type: 'integer',
+                  format: 'int64',
+                  $$ref: '#/parameters/petId'
+                }
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
+  it('should normalize idempotently', async () => {
+    const input = {
+      swagger: '2.0',
+      parameters: {
+        petId: {
+          name: 'petId',
+          in: 'path',
+          description: 'ID of pet to return',
+          required: true,
+          type: 'integer',
+          format: 'int64'
+        }
+      },
+      paths: {
+        '/': {
+          parameters: [
+            {
+              $ref: '#/parameters/petId'
+            }
+          ],
+          get: {
+            parameters: [
+              {
+                name: 'name',
+                in: 'formData',
+                description: 'Updated name of the pet',
+                required: false,
+                type: 'string'
+              },
+              {
+                name: 'status',
+                in: 'formData',
+                description: 'Updated status of the pet',
+                required: false,
+                type: 'string'
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    const intermediate = await resolve(input, ['paths', '/', 'get'], {
+      returnEntireTree: true
+    })
+
+    const res = await resolve(intermediate.spec, ['paths', '/', 'get'], {
+      returnEntireTree: true
+    })
+
+    expect(res).toEqual({
+      errors: [],
+      spec: {
+        swagger: '2.0',
+        $$normalized: true,
+        parameters: {
+          petId: {
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet to return',
+            required: true,
+            type: 'integer',
+            format: 'int64'
+          }
+        },
+        paths: {
+          '/': {
+            parameters: [
+              {
+                $ref: '#/parameters/petId'
+              }
+            ],
+            get: {
+              parameters: [
+                {
+                  name: 'name',
+                  in: 'formData',
+                  description: 'Updated name of the pet',
+                  required: false,
+                  type: 'string'
+                },
+                {
+                  name: 'status',
+                  in: 'formData',
+                  description: 'Updated status of the pet',
+                  required: false,
+                  type: 'string'
+                },
+                {
+                  name: 'petId',
+                  in: 'path',
+                  description: 'ID of pet to return',
+                  required: true,
+                  type: 'integer',
+                  format: 'int64',
+                  $$ref: '#/parameters/petId'
+                }
+              ]
+            }
+          }
+        }
+      }
+    })
+  })
   it('should resolve complex allOf correctly', async () => {
     const input = {
       definitions: {


### PR DESCRIPTION
This PR: 
- normalizes subtree data _before_ attempting to resolve it, to solve the problem of path parameters outside of an operation's resolution discriminator being added to the operation in an unresolved form
- adds a top-level `$$normalized` marker to resolved definitions, in order to make the subtree resolver idempotent when its previous result is passed in as an input.

Fixes https://github.com/swagger-api/swagger-ui/issues/4327.
