### PR TITLE
add test for nested allOf + $ref

### DIFF
--- a/src/specmap/lib/all-of.js
+++ b/src/specmap/lib/all-of.js
@@ -28,7 +28,7 @@ export default {
     // Remove the `allOf` property so it doesn't get added to the result of the `allOf` plugin
     let originalDefinitionObj = patch.value
     parent.forEach((part) => {
-      if(!originalDefinitionObj) return // bail out if we've lost sight of our target
+      if (!originalDefinitionObj) return // bail out if we've lost sight of our target
       originalDefinitionObj = originalDefinitionObj[part]
     })
     originalDefinitionObj = Object.assign({}, originalDefinitionObj)

--- a/src/specmap/lib/all-of.js
+++ b/src/specmap/lib/all-of.js
@@ -28,6 +28,7 @@ export default {
     // Remove the `allOf` property so it doesn't get added to the result of the `allOf` plugin
     let originalDefinitionObj = patch.value
     parent.forEach((part) => {
+      if(!originalDefinitionObj) return // bail out if we've lost sight of our target
       originalDefinitionObj = originalDefinitionObj[part]
     })
     originalDefinitionObj = Object.assign({}, originalDefinitionObj)

--- a/test/specmap/all-of.js
+++ b/test/specmap/all-of.js
@@ -328,6 +328,68 @@ describe('allOf', function () {
     })
   })
 
+  it('should suppport nested allOfs with $refs', function () {
+    return mapSpec({
+      plugins: [plugins.refs, plugins.allOf],
+      spec: {
+        definitions: {
+          Alpha: {
+            allOf: [{type: 'object'}],
+            properties: {
+              one: {
+                $ref: '#/definitions/Bravo'
+              },
+              two: {
+                type: 'string'
+              }
+            }
+          },
+          Bravo: {
+            allOf: [{
+              type: 'object',
+              properties: {
+                three: {
+                  type: 'string'
+                }
+              }
+            }]
+          }
+        }
+      }
+    }).then((res) => {
+      // To show the error, unfortunately, the expect call doesn't pretty print it nicely
+      // console.log(res.errors[0])
+      expect(res.errors).toEqual([])
+      expect(res.spec).toEqual({
+        definitions: {
+          Alpha: {
+            type: 'object',
+            properties: {
+              one: {
+                type: 'object',
+                properties: {
+                  three: {
+                    type: 'string',
+                  }
+                }
+              },
+              two: {
+                type: 'string'
+              }
+            }
+          },
+          Bravo: {
+            type: 'object',
+            properties: {
+              three: {
+                type: 'string'
+              }
+            }
+          }
+        },
+      })
+    })
+  })
   it('merges arrays inside of an `allOf`', function () {
     return mapSpec({
       plugins: [plugins.refs, plugins.allOf],


### PR DESCRIPTION
_originally from @ponelat in #1264_

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This adds a test, highlighting a bug.
With nested allOfs + $refs.

Example defintition fragment:
```yaml
definitions:
  Alpha:
    allOf:
    - type: object
    properties:
      test:
        $ref: '#/definitions/Bravo'
 
  Bravo:
    allOf: 
      - type: object
        properties:
          two: 
            type: string
```
Causes: ` TypeError: Cannot read property 'Alpha' of undefined`


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
