### PR TITLE
docs(2to3-migration): add `Default Content-Type values` section

### DIFF
--- a/docs/MIGRATION_2_X.md
+++ b/docs/MIGRATION_2_X.md
@@ -136,3 +136,17 @@ https://github.com/swagger-api/swagger-ui/issues/2793
 
 > NOTE: Cookie authentication is not implemented. 
 
+#### Default Content-Type values
+
+Swagger-Client no longer assumes you want `Content-Type: application/json` if you don't provide any `consumes` values. If you want to preserve that behavior, you'll need to implement it yourself with a `requestInterceptor`:
+
+```js
+Swagger({
+  url: "http://petstore.swagger.io/v2/swagger.json",
+  requestInterceptor: req => {
+    if(req.body && !req.headers["Content-Type"]) {
+      req.headers["Content-Type"] = "application/json"
+    }
+  }
+})
+```


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-js/issues/1272.