### PR TITLE
fix: http error handling regression

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -46,6 +46,11 @@ export default async function http(url, request = {}) {
     }
   }
   catch (resError) {
+    if (!res) {
+      // res is completely absent, so we can't construct our own error
+      // so we'll just throw the error we got
+      throw resError
+    }
     const error = new Error(res.statusText)
     error.statusCode = error.status = res.status
     error.responseError = resError

--- a/test/client.js
+++ b/test/client.js
@@ -172,6 +172,20 @@ describe('http', () => {
   })
 
   /**
+   * See https://github.com/swagger-api/swagger-js/issues/1277
+   */
+  it('should return a helpful error when the connection is refused', () => {
+    return Swagger('http://localhost:1/untouchable.yaml')
+      .then((client) => {
+        throw new Error('Expected an error.')
+      })
+      .catch((error) => {
+        expect(error.message).toEqual('request to http://localhost:1/untouchable.yaml failed, reason: connect ECONNREFUSED 127.0.0.1:1')
+        expect(error.name).toEqual('FetchError')
+      })
+  })
+
+  /**
    * See https://github.com/swagger-api/swagger-js/issues/1002
    */
   it.skip('should return an error when a spec doesnt exist', (done) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR modifies `http` to throw the original error from Fetch if the request itself failed to transport (as opposed to a non-OK status code, etc). This was necessary because #1261 caused this behavior to regress.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1277.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A unit test has been added.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
