### PR TITLE
fix: $ref+allOf object inheritance-related allOf value bleed

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",
     "lodash": "^4.16.2",
+    "object-assign-deep": "^0.4.0",
     "qs": "^6.3.0",
     "url": "^0.11.0",
     "utf8-bytes": "0.0.1",

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -241,6 +241,211 @@ describe('resolver', () => {
     }
   })
 
+  describe('complex allOf+$ref', () => {
+    it('should be able to resolve without meta patches', () => {
+      // Given
+      const spec = {
+        components: {
+          schemas: {
+            Error: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string'
+                }
+              }
+            },
+            UnauthorizedError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 401
+                    },
+                    message: {
+                      example: 'Unauthorized'
+                    }
+                  }
+                }
+              ]
+            },
+            NotFoundError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 404
+                    },
+                    message: {
+                      example: 'Resource Not Found'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      // When
+      return Swagger.resolve({spec, allowMetaPatches: false})
+      .then(handleResponse)
+
+      // Then
+      function handleResponse(obj) {
+        expect(obj.errors).toEqual([])
+        expect(obj.spec).toEqual({
+          components: {
+            schemas: {
+              Error: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string'
+                  }
+                }
+              },
+              UnauthorizedError: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string',
+                    example: 'Unauthorized'
+
+                  },
+                  code: {
+                    example: 401
+                  },
+                }
+              },
+              NotFoundError: {
+                type: 'object',
+                properties: {
+                  code: {
+                    example: 404
+                  },
+                  message: {
+                    type: 'string',
+                    example: 'Resource Not Found'
+                  }
+                }
+              }
+            }
+          }
+        })
+      }
+    })
+    it('should be able to resolve with meta patches', () => {
+      // Given
+      const spec = {
+        components: {
+          schemas: {
+            Error: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string'
+                }
+              }
+            },
+            UnauthorizedError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 401
+                    },
+                    message: {
+                      example: 'Unauthorized'
+                    }
+                  }
+                }
+              ]
+            },
+            NotFoundError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 404
+                    },
+                    message: {
+                      example: 'Resource Not Found'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      // When
+      return Swagger.resolve({spec, allowMetaPatches: true})
+      .then(handleResponse)
+
+      // Then
+      function handleResponse(obj) {
+        expect(obj.errors).toEqual([])
+        expect(obj.spec).toEqual({
+          components: {
+            schemas: {
+              Error: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string'
+                  }
+                }
+              },
+              UnauthorizedError: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string',
+                    example: 'Unauthorized'
+
+                  },
+                  code: {
+                    example: 401
+                  },
+                }
+              },
+              NotFoundError: {
+                type: 'object',
+                properties: {
+                  code: {
+                    example: 404
+                  },
+                  message: {
+                    type: 'string',
+                    example: 'Resource Not Found'
+                  }
+                }
+              }
+            }
+          }
+        })
+      }
+    })
+  })
+
   it('should not throw errors on resvered-keywords in freely-named-fields', () => {
     // Given
     const ReservedKeywordSpec = jsYaml.safeLoad(fs.readFileSync(path.resolve(__dirname, './data/reserved-keywords.yaml'), 'utf8'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

When a $ref and a nested object value are present as members of an `allOf` array, the nested object value is extended onto the location the $ref points to, because inheritance between the grafted $ref value and the source location is not being broken.

This only shows up with nested inline object values, due to the fact that we have our own merging logic for shallow objects which _does_ take care of inheritance issues.

The solution: use a deep assign library to break inheritance with existing objects at any depth, before deeply extending the object.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes https://github.com/swagger-api/swagger-ui/issues/4510.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added two unit tests.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.