### PR TITLE
fix: handle empty servers list in oas3 spec when getting baseUrl (#1307)

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -270,7 +270,7 @@ function oas3BaseUrl({spec, pathName, method, server, contextUrl, serverVariable
   let selectedServerUrl = ''
   let selectedServerObj = null
 
-  if (server && servers) {
+  if (server && servers && servers.length) {
     const serverUrls = servers.map(srv => srv.url)
 
     if (serverUrls.indexOf(server) > -1) {
@@ -279,7 +279,7 @@ function oas3BaseUrl({spec, pathName, method, server, contextUrl, serverVariable
     }
   }
 
-  if (!selectedServerUrl && servers) {
+  if (!selectedServerUrl && servers && servers.length) {
     // default to the first server if we don't have one by now
     selectedServerUrl = servers[0].url
     selectedServerObj = servers[0]

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -755,6 +755,20 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
 
       expect(res).toEqual('http://google.com')
     })
+    it('should fall back to contextUrls if servers list is empty', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: []
+      }
+
+      const res = baseUrl({
+        spec,
+        server: 'http://some-invalid-server.com/',
+        contextUrl: 'http://google.com/'
+      })
+
+      expect(res).toEqual('http://google.com')
+    })
     it('should create a relative url based on a relative server if no contextUrl is available', function () {
       const spec = {
         openapi: '3.0.0',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
According to: https://swagger.io/docs/specification/api-host-and-base-path/
If the server block doesn't exist, or is empty then it shall default to '/'
This seems to work for a missing servers block, but not for an empty list.

The old code attempted to access the first element in an array without checking if the list was empty.
This fix ensures that the array is not empty.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #1307 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested that the change fixes the following bug in swagger-ui https://github.com/swagger-api/swagger-ui/issues/4505
I used [this spec](https://gist.githubusercontent.com/dtkav/c49eeb14bcf5bd2370f74ba79cce9358/raw/21ac1f4a18813e7cde2da51596d1a91fd86233a1/petstore.yml) to trigger the failure.
I also added a new unit test to cover the change.

### Screenshots (if appropriate):
n/a

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
