### PR TITLE
Relative URL construction based on remote definition URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ Swagger.prototype = {
       spec: this.spec,
       http: this.http,
       securities: {authorized: this.authorizations},
+      contextUrl: typeof this.url === 'string' ? this.url : undefined,
       ...argHash
     })
   },

--- a/test/client.js
+++ b/test/client.js
@@ -227,6 +227,38 @@ describe('http', () => {
       })
   })
 
+  it('use the host from whence the spec was fetched when constructing swagger2 URLs from a basePath', async () => {
+    const client = await Swagger('http://localhost:8000/relative-host.swagger.yaml')
+    try {
+      const res = await client.apis.default.myOp()
+      expect(res.status).toBe(404)
+    }
+    catch (e) {
+      expect(e).toInclude({
+        status: 404,
+        response: {
+          url: 'http://localhost:8000/v1/endpoint'
+        }
+      })
+    }
+  })
+
+  it('use the host from whence the spec was fetched when constructing OAS3 URLs from relative servers entries', async () => {
+    const client = await Swagger('http://localhost:8000/relative-server.openapi.yaml')
+    try {
+      const res = await client.apis.default.myOp()
+      expect(res.status).toBe(404)
+    }
+    catch (e) {
+      expect(e).toInclude({
+        status: 404,
+        response: {
+          url: 'http://localhost:8000/v1/endpoint'
+        }
+      })
+    }
+  })
+
   it('should err gracefully when requesting https from an http server', () => {
     return Swagger({
       url: 'http://localhost:8000/petstore.json',

--- a/test/data/relative-host.swagger.yaml
+++ b/test/data/relative-host.swagger.yaml
@@ -1,0 +1,10 @@
+swagger: "2.0"
+basePath: "/v1/"
+paths:
+  /endpoint:
+    get:
+      summary: an operation!
+      operationId: myOp
+      parameters:
+      - name: filter
+        in: query

--- a/test/data/relative-server.openapi.yaml
+++ b/test/data/relative-server.openapi.yaml
@@ -1,0 +1,13 @@
+openapi: "3.0.0"
+servers:
+- url: "/v1/"
+paths:
+  /endpoint:
+    get:
+      summary: an operation!
+      operationId: myOp
+      parameters:
+      - name: filter
+        in: query
+        schema:
+          type: string


### PR DESCRIPTION
This allows OAS3 definitions to take advantage of relative server URLs.

Previous behavior:
- In a browser, the requests were made against the current page's host instead of the definition URL host
- In Node, the request failed

Swagger 2 analog test added as well, for completeness.