### PR TITLE
v3.8.2: use Node.js 4-compatible fork of `object-assign-deep`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "isomorphic-form-data": "0.0.1",
     "js-yaml": "^3.8.1",
     "lodash": "^4.16.2",
-    "object-assign-deep": "^0.4.0",
+    "@kyleshockey/object-assign-deep": "^0.4.0",
     "qs": "^6.3.0",
     "url": "^0.11.0",
     "utf8-bytes": "0.0.1",

--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -1,7 +1,7 @@
 import jsonPatch from 'fast-json-patch'
 import regenerator from 'babel-runtime/regenerator'
 import deepExtend from 'deep-extend'
-import deepAssign from 'object-assign-deep'
+import deepAssign from '@kyleshockey/object-assign-deep'
 
 export default {
   add,


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-js/issues/1315.