### PR TITLE
Locked deep-extend version to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "btoa": "1.1.2",
     "cookie": "^0.3.1",
     "cross-fetch": "0.0.8",
-    "deep-extend": "^0.5.1",
+    "deep-extend": "0.5.1",
     "encode-3986": "^1.0.0",
     "fast-json-patch": "^2.0.6",
     "isomorphic-form-data": "0.0.1",


### PR DESCRIPTION
Locked deep-extend version to 0.5.1

### Description
https://github.com/swagger-api/swagger-js/issues/1326



### Motivation and Context
It is the deep-extend 0.6.0 version that is breaking the code, changed the package.json version to fixed 0.5.1 at the swagger-client and it worked.



### How Has This Been Tested?
Locally tested, I can send evidences if needed
