### PR TITLE
fix + patch version: explicitly rely on buffer module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-client",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "SwaggerJS - a collection of interfaces for OAI specs",
   "main": "dist/index.js",
   "repository": "git@github.com:swagger-api/swagger-js.git",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@kyleshockey/object-assign-deep": "^0.4.0",
     "babel-runtime": "^6.23.0",
     "btoa": "1.1.2",
+    "buffer": "^5.1.0",
     "cookie": "^0.3.1",
     "cross-fetch": "0.0.8",
     "deep-extend": "^0.5.1",

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -3,7 +3,7 @@
 import assign from 'lodash/assign'
 import get from 'lodash/get'
 import btoa from 'btoa'
-import Buffer from 'buffer'
+import {Buffer} from 'buffer/'
 
 export default function (options, req) {
   const {

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -3,6 +3,7 @@
 import assign from 'lodash/assign'
 import get from 'lodash/get'
 import btoa from 'btoa'
+import Buffer from 'buffer'
 
 export default function (options, req) {
   const {

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -68,7 +68,7 @@ export default function (options, req) {
               }
 
               if (typeof Buffer !== 'undefined') {
-                isFile = isFile || val instanceof Buffer
+                isFile = isFile || Buffer.isBuffer(val)
               }
 
               if (typeof val === 'object' && !isFile) {


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-js/issues/1326.

CC: https://github.com/strongloop/loopback-next/issues/1367, https://github.com/strongloop/loopback/issues/3894, https://github.com/strongloop/loopback-cli/issues/65.

This PR moves us to explicitly using `buffer` as our Buffer implementation, instead of relying on Webpack to prepare usage of Buffer globals.