### PR TITLE
URL encode parameters for OpenApiSpec 3

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -14,7 +14,7 @@ function path({req, value, parameter}) {
     value,
     style: style || 'simple',
     explode: explode || false,
-    escape: false,
+    escape: true,
   })
 
   req.url = req.url.replace(`{${name}}`, styledValue)

--- a/test/oas3/execute/style-explode/path.js
+++ b/test/oas3/execute/style-explode/path.js
@@ -35,7 +35,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
           spec,
           operationId: 'myOperation',
           parameters: {
-            id: "wow!"
+            id: 'wow!'
           }
         })
 

--- a/test/oas3/execute/style-explode/path.js
+++ b/test/oas3/execute/style-explode/path.js
@@ -35,13 +35,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
           spec,
           operationId: 'myOperation',
           parameters: {
-            id: 5
+            id: "wow!"
           }
         })
 
         expect(req).toEqual({
           method: 'GET',
-          url: '/path/5',
+          url: '/path/wow%21',
           credentials: 'same-origin',
           headers: {},
         })
@@ -76,13 +76,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
           spec,
           operationId: 'myOperation',
           parameters: {
-            id: 5
+            id: 'wow!'
           }
         })
 
         expect(req).toEqual({
           method: 'GET',
-          url: '/path/5',
+          url: '/path/wow%21',
           credentials: 'same-origin',
           headers: {},
         })
@@ -115,13 +115,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
         spec,
         operationId: 'myOperation',
         parameters: {
-          id: 5
+          id: 'wow!'
         }
       })
 
       expect(req).toEqual({
         method: 'GET',
-        url: '/path/5',
+        url: '/path/wow%21',
         credentials: 'same-origin',
         headers: {},
       })
@@ -155,13 +155,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
           spec,
           operationId: 'myOperation',
           parameters: {
-            id: 5
+            id: 'wow!'
           }
         })
 
         expect(req).toEqual({
           method: 'GET',
-          url: '/path/.5',
+          url: '/path/.wow%21',
           credentials: 'same-origin',
           headers: {},
         })
@@ -194,13 +194,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
         spec,
         operationId: 'myOperation',
         parameters: {
-          id: 5
+          id: 'wow!'
         }
       })
 
       expect(req).toEqual({
         method: 'GET',
-        url: '/path/.5',
+        url: '/path/.wow%21',
         credentials: 'same-origin',
         headers: {},
       })
@@ -234,13 +234,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
           spec,
           operationId: 'myOperation',
           parameters: {
-            id: 5
+            id: 'wow!'
           }
         })
 
         expect(req).toEqual({
           method: 'GET',
-          url: '/path/;id=5',
+          url: '/path/;id=wow%21',
           credentials: 'same-origin',
           headers: {},
         })
@@ -273,13 +273,13 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
         spec,
         operationId: 'myOperation',
         parameters: {
-          id: 5
+          id: 'wow!'
         }
       })
 
       expect(req).toEqual({
         method: 'GET',
-        url: '/path/;id=5',
+        url: '/path/;id=wow%21',
         credentials: 'same-origin',
         headers: {},
       })


### PR DESCRIPTION
URL encode parameters for OpenApiSpec 3

### Description
Fixes this issue in swagger-ui https://github.com/swagger-api/swagger-ui/issues/4025

### Motivation and Context

I guess it was disabled by accident in https://github.com/swagger-api/swagger-js/pull/1181 which was about allowing to skip url encode for query params if `Paramter.allowReserved` is set to true. But [specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md) says clearly: 

`
Determines whether the parameter value SHOULD allow reserved characters, as defined by RFC3986 :/?#[]@!$&'()*+,;= to be included without percent-encoding. This property only applies to parameters with an in value of query. The default value is false.
`. So it should be applied only to query params and path parameters should use encoding all the time

### How Has This Been Tested?

I'm not familiar with your testing strategy, but I've recompiled your library and checked that it works correctly using swagger-ui:

Before:
<img width="511" alt="image" src="https://user-images.githubusercontent.com/6191712/41769995-a08ec78a-7619-11e8-9318-d2197879fe47.png">
After:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/6191712/41769846-462e3a8c-7619-11e8-8ab5-70f7529b30ae.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.