### PR TITLE
Allow omission of `allowEmptyValue: true` parameters

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -85,7 +85,7 @@ function query({req, value, parameter}) {
       }
     }
   }
-  else if (parameter.allowEmptyValue) {
+  else if (parameter.allowEmptyValue && value !== undefined) {
     const paramName = parameter.name
     req.query[paramName] = req.query[paramName] || {}
     req.query[paramName].allowEmptyValue = true

--- a/src/execute/swagger2/parameter-builders.js
+++ b/src/execute/swagger2/parameter-builders.js
@@ -59,7 +59,7 @@ function queryBuilder({req, value, parameter}) {
       value
     }
   }
-  else if (parameter.allowEmptyValue) {
+  else if (parameter.allowEmptyValue && value !== undefined) {
     const paramName = parameter.name
     req.query[paramName] = req.query[paramName] || {}
     req.query[paramName].allowEmptyValue = true

--- a/test/execute/main.js
+++ b/test/execute/main.js
@@ -429,43 +429,6 @@ describe('execute', () => {
       })
     })
 
-    test(
-      'should add an empty query param if the value is empty and allowEmptyValue: true',
-      () => {
-        // Given
-        const spec = {
-          host: 'swagger.io',
-          basePath: '/v1',
-          consumes: ['application/json'],
-          paths: {
-            '/pets/findByStatus': {
-              get: {
-                operationId: 'getMe',
-                parameters: [{
-                  in: 'query',
-                  name: 'status',
-                  type: 'string',
-                  required: false,
-                  allowEmptyValue: true
-                }]
-              }
-            }
-          }
-        }
-
-        // When
-        const req = buildRequest({spec, operationId: 'getMe', parameters: {}})
-
-        // Then
-        expect(req).toEqual({
-          url: 'http://swagger.io/v1/pets/findByStatus?status=',
-          method: 'GET',
-          credentials: 'same-origin',
-          headers: { }
-        })
-      }
-    )
-
     test('should correctly process boolean parameters', () => {
       // Given
       const spec = {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -910,19 +910,19 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
       })
     })
   })
-  describe("allowEmptyValue", () => {
-    describe("query", () => {
-      it("should include empty parameter values for a query param with allowEmptyValue", () => {
+  describe('allowEmptyValue', () => {
+    describe('query', () => {
+      it('should include empty parameter values for a query param with allowEmptyValue', () => {
         const spec = {
           openapi: '3.0.0',
           paths: {
             '/one': {
               get: {
-                operationId: 'getMe', 
+                operationId: 'getMe',
                 parameters: [
                   {
-                    name: "name",
-                    in: "query",
+                    name: 'name',
+                    in: 'query',
                     allowEmptyValue: true
                   }
                 ]
@@ -936,7 +936,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           spec,
           operationId: 'getMe',
           parameters: {
-            name: ""
+            name: ''
           }
         })
 
@@ -947,7 +947,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           headers: {},
         })
       })
-      it("should not include omitted parameter values for a query param with allowEmptyValue", () => {
+      it('should not include omitted parameter values for a query param with allowEmptyValue', () => {
         const spec = {
           openapi: '3.0.0',
           paths: {
@@ -956,8 +956,8 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
                 operationId: 'getMe',
                 parameters: [
                   {
-                    name: "name",
-                    in: "query",
+                    name: 'name',
+                    in: 'query',
                     allowEmptyValue: true
                   }
                 ]
@@ -980,7 +980,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           headers: {},
         })
       })
-      it("should not include empty parameter values for a query param lacking allowEmptyValue", () => {
+      it('should not include empty parameter values for a query param lacking allowEmptyValue', () => {
         const spec = {
           openapi: '3.0.0',
           paths: {
@@ -989,8 +989,8 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
                 operationId: 'getMe',
                 parameters: [
                   {
-                    name: "name",
-                    in: "query"
+                    name: 'name',
+                    in: 'query'
                   }
                 ]
               }
@@ -1003,7 +1003,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           spec,
           operationId: 'getMe',
           parameters: {
-            name: ""
+            name: ''
           }
         })
 
@@ -1014,7 +1014,7 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
           headers: {},
         })
       })
-      it("should not include omitted parameter values for a query param lacking allowEmptyValue", () => {
+      it('should not include omitted parameter values for a query param lacking allowEmptyValue', () => {
         const spec = {
           openapi: '3.0.0',
           paths: {
@@ -1023,8 +1023,8 @@ describe('buildRequest - OpenAPI Specification 3.0', function () {
                 operationId: 'getMe',
                 parameters: [
                   {
-                    name: "name",
-                    in: "query"
+                    name: 'name',
+                    in: 'query'
                   }
                 ]
               }

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -10,9 +10,9 @@ const petstoreSpec = jsYaml.safeLoad(fs.readFileSync(path.join('test', 'oas3', '
 // Supported shape...  { spec, operationId, parameters, securities, fetch }
 // One can use operationId or pathItem + method
 
-describe('buildRequest - OpenAPI Specification 3.0', () => {
-  describe('fundamentals', () => {
-    test('should build a request for the given operationId', () => {
+describe('buildRequest - OpenAPI Specification 3.0', function () {
+  describe('fundamentals', function () {
+    it('should build a request for the given operationId', function () {
       // Given
       const spec = {
         openapi: '3.0.0',
@@ -39,114 +39,105 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       })
     })
 
-    test(
-      'should build a request for the given operationId, using the first server by default',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            },
-            {
-              url: 'http://not-real-petstore.swagger.io/v2',
-              name: 'Fake Petstore (should not be selected)'
-            },
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getMe'
-              }
+    it('should build a request for the given operationId, using the first server by default', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          },
+          {
+            url: 'http://not-real-petstore.swagger.io/v2',
+            name: 'Fake Petstore (should not be selected)'
+          },
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getMe'
             }
           }
         }
-
-        // when
-        const req = buildRequest({spec, operationId: 'getMe'})
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {},
-        })
       }
-    )
 
-    test(
-      'should build a request for the given operationId, using a specfied server',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://not-real-petstore.swagger.io/v2',
-              name: 'Fake Petstore (should not be selected)'
-            },
-            {
-              url: 'http://petstore.swagger.io/{version}',
-              name: 'Petstore',
-              variables: {
-                version: {
-                  default: 'v1'
-                }
+      // when
+      const req = buildRequest({spec, operationId: 'getMe'})
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {},
+      })
+    })
+
+    it('should build a request for the given operationId, using a specfied server', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://not-real-petstore.swagger.io/v2',
+            name: 'Fake Petstore (should not be selected)'
+          },
+          {
+            url: 'http://petstore.swagger.io/{version}',
+            name: 'Petstore',
+            variables: {
+              version: {
+                default: 'v1'
               }
             }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getMe'
-              }
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getMe'
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getMe',
-          server: 'http://petstore.swagger.io/{version}',
-          serverVariables: {
-            version: 'v2'
-          }
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {},
-        })
       }
-    )
 
-    test(
-      'should build a request for the given operationId with a requestBody',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getOne',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object'
-                      }
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getMe',
+        server: 'http://petstore.swagger.io/{version}',
+        serverVariables: {
+          version: 'v2'
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {},
+      })
+    })
+
+    it('should build a request for the given operationId with a requestBody', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getOne',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object'
                     }
                   }
                 }
@@ -154,30 +145,30 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getOne',
-          requestBody: {
-            a: 1,
-            b: 2
-          }
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: {a: 1, b: 2}
-        })
       }
-    )
 
-    test('should stringify object values of form data bodies', () => {
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getOne',
+        requestBody: {
+          a: 1,
+          b: 2
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {a: 1, b: 2}
+      })
+    })
+
+    it('should stringify object values of form data bodies', function () {
       // Given
       const spec = {
         openapi: '3.0.0',
@@ -229,28 +220,25 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       })
     })
 
-    test(
-      'should build a request for the given operationId with a requestBody, and not be overriden by an invalid Swagger2 body parameter value',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getOne',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object'
-                      }
+    it('should build a request for the given operationId with a requestBody, and not be overriden by an invalid Swagger2 body parameter value', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getOne',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object'
                     }
                   }
                 }
@@ -258,57 +246,54 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getOne',
-          requestBody: {
-            a: 1,
-            b: 2
-          },
-          parameters: {
-            body: {
-              c: 3,
-              d: 4
-            }
-          }
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: {a: 1, b: 2}
-        })
       }
-    )
 
-    test(
-      'should build a request for the given operationId with a requestBody and a defined requestContentType',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getOne',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object'
-                      }
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getOne',
+        requestBody: {
+          a: 1,
+          b: 2
+        },
+        parameters: {
+          body: {
+            c: 3,
+            d: 4
+          }
+        }
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {a: 1, b: 2}
+      })
+    })
+
+    it('should build a request for the given operationId with a requestBody and a defined requestContentType', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getOne',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object'
                     }
                   }
                 }
@@ -316,52 +301,49 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getOne',
-          requestBody: {
-            a: 1,
-            b: 2
-          },
-          requestContentType: 'application/json'
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: {a: 1, b: 2}
-        })
       }
-    )
 
-    test(
-      'should build an operation without a body or Content-Type if the requestBody definition lacks the requestContentType',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getOne',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object'
-                      }
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getOne',
+        requestBody: {
+          a: 1,
+          b: 2
+        },
+        requestContentType: 'application/json'
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {a: 1, b: 2}
+      })
+    })
+
+    it('should build an operation without a body or Content-Type if the requestBody definition lacks the requestContentType', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getOne',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object'
                     }
                   }
                 }
@@ -369,49 +351,46 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getOne',
-          requestBody: {
-            a: 1,
-            b: 2
-          },
-          requestContentType: 'application/not-json'
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {}
-        })
       }
-    )
 
-    test(
-      'should build a request body-bearing operation with a provided requestContentType that appears in the requestBody definition even if no payload is present',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getOne',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object'
-                      }
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getOne',
+        requestBody: {
+          a: 1,
+          b: 2
+        },
+        requestContentType: 'application/not-json'
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {}
+      })
+    })
+
+    it('should build a request body-bearing operation with a provided requestContentType that appears in the requestBody definition even if no payload is present', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getOne',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object'
                     }
                   }
                 }
@@ -419,47 +398,44 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getOne',
-          requestContentType: 'application/json'
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        })
       }
-    )
 
-    test(
-      'should build a request body-bearing operation without a provided requestContentType that does not appear in the requestBody definition even if no payload is present',
-      () => {
-        // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://petstore.swagger.io/v2',
-              name: 'Petstore'
-            }
-          ],
-          paths: {
-            '/one': {
-              get: {
-                operationId: 'getOne',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'object'
-                      }
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getOne',
+        requestContentType: 'application/json'
+      })
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+    })
+
+    it('should build a request body-bearing operation without a provided requestContentType that does not appear in the requestBody definition even if no payload is present', function () {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://petstore.swagger.io/v2',
+            name: 'Petstore'
+          }
+        ],
+        paths: {
+          '/one': {
+            get: {
+              operationId: 'getOne',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object'
                     }
                   }
                 }
@@ -467,48 +443,45 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        // when
-        const req = buildRequest({
-          spec,
-          operationId: 'getOne',
-          requestContentType: 'application/not-json'
-        })
-
-        expect(req).toEqual({
-          method: 'GET',
-          url: 'http://petstore.swagger.io/v2/one',
-          credentials: 'same-origin',
-          headers: {}
-        })
       }
-    )
 
-    test(
-      'should not add a Content-Type when the operation has no OAS3 request body definition',
-      () => {
-            // Given
-        const spec = {
-          openapi: '3.0.0',
-          servers: [{url: 'http://swagger.io/'}],
-          paths: {'/one': {get: {operationId: 'getMe'}}}
-        }
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'getOne',
+        requestContentType: 'application/not-json'
+      })
 
-            // When
-        const req = buildRequest({spec, operationId: 'getMe', requestContentType: 'application/josh'})
+      expect(req).toEqual({
+        method: 'GET',
+        url: 'http://petstore.swagger.io/v2/one',
+        credentials: 'same-origin',
+        headers: {}
+      })
+    })
 
-            // Then
-        expect(req).toEqual({
-          url: 'http://swagger.io/one',
-          headers: {},
-          credentials: 'same-origin',
-          method: 'GET'
-        })
+    it('should not add a Content-Type when the operation has no OAS3 request body definition', function () {
+          // Given
+      const spec = {
+        openapi: '3.0.0',
+        servers: [{url: 'http://swagger.io/'}],
+        paths: {'/one': {get: {operationId: 'getMe'}}}
       }
-    )
+
+          // When
+      const req = buildRequest({spec, operationId: 'getMe', requestContentType: 'application/josh'})
+
+          // Then
+      expect(req).toEqual({
+        url: 'http://swagger.io/one',
+        headers: {},
+        credentials: 'same-origin',
+        method: 'GET'
+      })
+    })
   })
-  describe('with petstore v3', () => {
-    test('should build updatePetWithForm correctly', () => {
+  describe('with petstore v3', function () {
+    it('should build updatePetWithForm correctly', function () {
       const req = buildRequest({
         spec: petstoreSpec,
         requestContentType: 'application/x-www-form-urlencoded',
@@ -533,7 +506,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       })
     })
 
-    test('should build addPet correctly', () => {
+    it('should build addPet correctly', function () {
       const req = buildRequest({
         spec: petstoreSpec,
         operationId: 'addPet',
@@ -553,45 +526,39 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       })
     })
   })
-  describe('baseUrl', () => {
-    test(
-      'should consider contextUrls correctly with relative server paths',
-      () => {
-        const spec = {
-          openapi: '3.0.0'
-        }
-
-        const res = baseUrl({
-          spec,
-          contextUrl: 'https://gist.githubusercontent.com/hkosova/d223eb45c5198db09d08f2603cc0e10a/raw/ae22e290b4f21e19bbfc02b97498289792579fec/relative-server.yaml'
-        })
-
-        expect(res).toEqual('https://gist.githubusercontent.com')
+  describe('baseUrl', function () {
+    it('should consider contextUrls correctly with relative server paths', function () {
+      const spec = {
+        openapi: '3.0.0'
       }
-    )
-    test(
-      'should default to using the first server if none is explicitly chosen',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'https://petstore.com'
-            },
-            {
-              url: 'https://petstore.net'
-            }
-          ]
-        }
 
-        const res = baseUrl({
-          spec
-        })
+      const res = baseUrl({
+        spec,
+        contextUrl: 'https://gist.githubusercontent.com/hkosova/d223eb45c5198db09d08f2603cc0e10a/raw/ae22e290b4f21e19bbfc02b97498289792579fec/relative-server.yaml'
+      })
 
-        expect(res).toEqual('https://petstore.com')
+      expect(res).toEqual('https://gist.githubusercontent.com')
+    })
+    it('should default to using the first server if none is explicitly chosen', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'https://petstore.com'
+          },
+          {
+            url: 'https://petstore.net'
+          }
+        ]
       }
-    )
-    test('should use an explicitly chosen server', () => {
+
+      const res = baseUrl({
+        spec
+      })
+
+      expect(res).toEqual('https://petstore.com')
+    })
+    it('should use an explicitly chosen server', function () {
       const spec = {
         openapi: '3.0.0',
         servers: [
@@ -611,60 +578,57 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
 
       expect(res).toEqual('https://petstore.net')
     })
-    test(
-      'should use an explicitly chosen server at the operation level',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'https://petstore.com'
-            },
-            {
-              url: 'https://petstore.net'
-            }
-          ],
-          paths: {
-            '/': {
-              get: {
-                servers: [
-                  {
-                    url: 'https://petstore-operation.net/{path}',
-                    variables: {
-                      path: {
-                        default: 'foobar'
-                      }
+    it('should use an explicitly chosen server at the operation level', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'https://petstore.com'
+          },
+          {
+            url: 'https://petstore.net'
+          }
+        ],
+        paths: {
+          '/': {
+            get: {
+              servers: [
+                {
+                  url: 'https://petstore-operation.net/{path}',
+                  variables: {
+                    path: {
+                      default: 'foobar'
                     }
                   }
-                ]
-              }
+                }
+              ]
             }
           }
         }
-
-        const res = baseUrl({
-          spec,
-          server: 'https://petstore-operation.net/{path}',
-          pathName: '/',
-          method: 'GET'
-        })
-
-        const resWithVariables = baseUrl({
-          spec,
-          server: 'https://petstore-operation.net/{path}',
-          serverVariables: {
-            path: 'fizzbuzz'
-          },
-          pathName: '/',
-          method: 'GET'
-        })
-
-        expect(res).toEqual('https://petstore-operation.net/foobar')
-        expect(resWithVariables).toEqual('https://petstore-operation.net/fizzbuzz')
       }
-    )
 
-    test('should use an explicitly chosen server at the path level', () => {
+      const res = baseUrl({
+        spec,
+        server: 'https://petstore-operation.net/{path}',
+        pathName: '/',
+        method: 'GET'
+      })
+
+      const resWithVariables = baseUrl({
+        spec,
+        server: 'https://petstore-operation.net/{path}',
+        serverVariables: {
+          path: 'fizzbuzz'
+        },
+        pathName: '/',
+        method: 'GET'
+      })
+
+      expect(res).toEqual('https://petstore-operation.net/foobar')
+      expect(resWithVariables).toEqual('https://petstore-operation.net/fizzbuzz')
+    })
+
+    it('should use an explicitly chosen server at the path level', function () {
       const spec = {
         openapi: '3.0.0',
         servers: [
@@ -712,30 +676,27 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       expect(res).toEqual('https://petstore-path.net/foobar')
       expect(resWithVariables).toEqual('https://petstore-path.net/fizzbuzz')
     })
-    test(
-      'should not use an explicitly chosen server that is not present in the spec',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'https://petstore.com'
-            },
-            {
-              url: 'https://petstore.net'
-            }
-          ]
-        }
-
-        const res = baseUrl({
-          spec,
-          server: 'https://petstore.org'
-        })
-
-        expect(res).toEqual('https://petstore.com')
+    it('should not use an explicitly chosen server that is not present in the spec', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'https://petstore.com'
+          },
+          {
+            url: 'https://petstore.net'
+          }
+        ]
       }
-    )
-    test('should handle server variable substitution', () => {
+
+      const res = baseUrl({
+        spec,
+        server: 'https://petstore.org'
+      })
+
+      expect(res).toEqual('https://petstore.com')
+    })
+    it('should handle server variable substitution', function () {
       const spec = {
         openapi: '3.0.0',
         servers: [
@@ -759,7 +720,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
 
       expect(res).toEqual('https://petstore.org')
     })
-    test('should handle server variable substitution defaults', () => {
+    it('should handle server variable substitution defaults', function () {
       const spec = {
         openapi: '3.0.0',
         servers: [
@@ -780,23 +741,20 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
 
       expect(res).toEqual('https://petstore.com')
     })
-    test(
-      'should fall back to contextUrls if no servers are provided',
-      () => {
-        const spec = {
-          openapi: '3.0.0'
-        }
-
-        const res = baseUrl({
-          spec,
-          server: 'http://some-invalid-server.com/',
-          contextUrl: 'http://google.com/'
-        })
-
-        expect(res).toEqual('http://google.com')
+    it('should fall back to contextUrls if no servers are provided', function () {
+      const spec = {
+        openapi: '3.0.0'
       }
-    )
-    test('should fall back to contextUrls if servers list is empty', () => {
+
+      const res = baseUrl({
+        spec,
+        server: 'http://some-invalid-server.com/',
+        contextUrl: 'http://google.com/'
+      })
+
+      expect(res).toEqual('http://google.com')
+    })
+    it('should fall back to contextUrls if servers list is empty', function () {
       const spec = {
         openapi: '3.0.0',
         servers: []
@@ -810,63 +768,54 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
 
       expect(res).toEqual('http://google.com')
     })
-    test(
-      'should create a relative url based on a relative server if no contextUrl is available',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: '/mypath'
-            }
-          ]
-        }
-
-        const res = baseUrl({
-          spec,
-          server: '/mypath'
-        })
-
-        expect(res).toEqual('/mypath')
+    it('should create a relative url based on a relative server if no contextUrl is available', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: '/mypath'
+          }
+        ]
       }
-    )
-    test(
-      'should return an empty string if no servers or contextUrl are provided',
-      () => {
-        const spec = {
-          openapi: '3.0.0'
-        }
 
-        const res = baseUrl({
-          spec,
-          server: 'http://some-invalid-server.com/'
-        })
+      const res = baseUrl({
+        spec,
+        server: '/mypath'
+      })
 
-        expect(res).toEqual('')
+      expect(res).toEqual('/mypath')
+    })
+    it('should return an empty string if no servers or contextUrl are provided', function () {
+      const spec = {
+        openapi: '3.0.0'
       }
-    )
+
+      const res = baseUrl({
+        spec,
+        server: 'http://some-invalid-server.com/'
+      })
+
+      expect(res).toEqual('')
+    })
   })
   describe('attachContentTypeForEmptyPayload', () => {
-    test(
-      'should attach the first media type as Content-Type to an OAS3 operation with a request body defined but no body provided',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://swagger.io/'
-            }
-          ],
-          paths: {
-            '/one': {
-              post: {
-                operationId: 'myOp',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'string'
-                      }
+    it('should attach the first media type as Content-Type to an OAS3 operation with a request body defined but no body provided', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://swagger.io/'
+          }
+        ],
+        paths: {
+          '/one': {
+            post: {
+              operationId: 'myOp',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string'
                     }
                   }
                 }
@@ -874,76 +823,70 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        const req = buildRequest({
-          spec,
-          operationId: 'myOp',
-          attachContentTypeForEmptyPayload: true
-        })
-
-        expect(req).toEqual({
-          url: 'http://swagger.io/one',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          credentials: 'same-origin',
-          method: 'POST'
-        })
       }
-    )
-    test(
-      'should not attach a Content-Type to an OAS3 operation with no request body definition present',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://swagger.io/'
-            }
-          ],
-          paths: {
-            '/one': {
-              post: {
-                operationId: 'myOp'
-              }
+
+      const req = buildRequest({
+        spec,
+        operationId: 'myOp',
+        attachContentTypeForEmptyPayload: true
+      })
+
+      expect(req).toEqual({
+        url: 'http://swagger.io/one',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        credentials: 'same-origin',
+        method: 'POST'
+      })
+    })
+    it('should not attach a Content-Type to an OAS3 operation with no request body definition present', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://swagger.io/'
+          }
+        ],
+        paths: {
+          '/one': {
+            post: {
+              operationId: 'myOp'
             }
           }
         }
-
-        const req = buildRequest({
-          spec,
-          operationId: 'myOp',
-          attachContentTypeForEmptyPayload: true
-        })
-
-        expect(req).toEqual({
-          url: 'http://swagger.io/one',
-          headers: {},
-          credentials: 'same-origin',
-          method: 'POST'
-        })
       }
-    )
-    test(
-      'should not attach the first media type as Content-Type without the option enabled',
-      () => {
-        const spec = {
-          openapi: '3.0.0',
-          servers: [
-            {
-              url: 'http://swagger.io/'
-            }
-          ],
-          paths: {
-            '/one': {
-              post: {
-                operationId: 'myOp',
-                requestBody: {
-                  content: {
-                    'application/json': {
-                      schema: {
-                        type: 'string'
-                      }
+
+      const req = buildRequest({
+        spec,
+        operationId: 'myOp',
+        attachContentTypeForEmptyPayload: true
+      })
+
+      expect(req).toEqual({
+        url: 'http://swagger.io/one',
+        headers: {},
+        credentials: 'same-origin',
+        method: 'POST'
+      })
+    })
+    it('should not attach the first media type as Content-Type without the option enabled', function () {
+      const spec = {
+        openapi: '3.0.0',
+        servers: [
+          {
+            url: 'http://swagger.io/'
+          }
+        ],
+        paths: {
+          '/one': {
+            post: {
+              operationId: 'myOp',
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string'
                     }
                   }
                 }
@@ -951,25 +894,163 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
             }
           }
         }
-
-        const req = buildRequest({
-          spec,
-          operationId: 'myOp',
-          // attachContentTypeForEmptyPayload is omitted
-        })
-
-        expect(req).toEqual({
-          url: 'http://swagger.io/one',
-          headers: {},
-          credentials: 'same-origin',
-          method: 'POST'
-        })
       }
-    )
+
+      const req = buildRequest({
+        spec,
+        operationId: 'myOp',
+        // attachContentTypeForEmptyPayload is omitted
+      })
+
+      expect(req).toEqual({
+        url: 'http://swagger.io/one',
+        headers: {},
+        credentials: 'same-origin',
+        method: 'POST'
+      })
+    })
   })
-  describe('special media types', () => {
-    describe('file-as-body types', () => {
-      test('should preserve blobs for application/octet-stream', () => {
+  describe("allowEmptyValue", () => {
+    describe("query", () => {
+      it("should include empty parameter values for a query param with allowEmptyValue", () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe', 
+                parameters: [
+                  {
+                    name: "name",
+                    in: "query",
+                    allowEmptyValue: true
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {
+            name: ""
+          }
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one?name=',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+      it("should not include omitted parameter values for a query param with allowEmptyValue", () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: "name",
+                    in: "query",
+                    allowEmptyValue: true
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {}
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+      it("should not include empty parameter values for a query param lacking allowEmptyValue", () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: "name",
+                    in: "query"
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {
+            name: ""
+          }
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+      it("should not include omitted parameter values for a query param lacking allowEmptyValue", () => {
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: "name",
+                    in: "query"
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {}
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+    })
+  })
+  describe('special media types', function () {
+    describe('file-as-body types', function () {
+      it('should preserve blobs for application/octet-stream', () => {
         const spec = {
           openapi: '3.0.0',
           paths: {

--- a/test/swagger2/execute/build-request.js
+++ b/test/swagger2/execute/build-request.js
@@ -1,8 +1,8 @@
 import {buildRequest} from '../../../src/execute'
 
 describe('buildRequest - swagger 2.0', () => {
-  describe("allowEmptyValue parameters", () => {
-    describe("query", () => {
+  describe('allowEmptyValue parameters', () => {
+    describe('query', () => {
       it('should include empty parameter values for a query param with allowEmptyValue', () => {
         const spec = {
           swagger: '2.0',
@@ -23,7 +23,7 @@ describe('buildRequest - swagger 2.0', () => {
         }
 
     // when
-    const req = buildRequest({
+        const req = buildRequest({
           spec,
           operationId: 'getMe',
           parameters: {
@@ -31,7 +31,7 @@ describe('buildRequest - swagger 2.0', () => {
           }
         })
 
-    expect(req).toMatchObject({
+        expect(req).toMatchObject({
           method: 'GET',
           url: '/one?name=',
           credentials: 'same-origin',
@@ -141,7 +141,7 @@ describe('buildRequest - swagger 2.0', () => {
         })
       })
     })
-    describe("formData", () => {
+    describe('formData', () => {
       it('should include empty parameter values for a query param with allowEmptyValue', () => {
         const spec = {
           swagger: '2.0',
@@ -162,7 +162,7 @@ describe('buildRequest - swagger 2.0', () => {
         }
 
     // when
-    const req = buildRequest({
+        const req = buildRequest({
           spec,
           operationId: 'getMe',
           parameters: {
@@ -170,14 +170,14 @@ describe('buildRequest - swagger 2.0', () => {
           }
         })
 
-    expect(req).toMatchObject({
+        expect(req).toMatchObject({
           method: 'GET',
           url: '/one',
           credentials: 'same-origin',
           headers: {
-            "Content-Type": "application/x-www-form-urlencoded"
+            'Content-Type': 'application/x-www-form-urlencoded'
           },
-          body: "name="
+          body: 'name='
         })
       })
 

--- a/test/swagger2/execute/build-request.js
+++ b/test/swagger2/execute/build-request.js
@@ -1,7 +1,7 @@
-import { buildRequest } from '../../../src/execute'
+import {buildRequest} from '../../../src/execute'
 
-describe("buildRequest - swagger 2.0", () => {
-  it("should include empty parameter values for a query param with allowEmptyValue", () => {
+describe('buildRequest - swagger 2.0', () => {
+  it('should include empty parameter values for a query param with allowEmptyValue', () => {
     const spec = {
       swagger: '2.0',
       paths: {
@@ -10,8 +10,8 @@ describe("buildRequest - swagger 2.0", () => {
             operationId: 'getMe',
             parameters: [
               {
-                name: "name",
-                in: "query",
+                name: 'name',
+                in: 'query',
                 allowEmptyValue: true
               }
             ]
@@ -25,7 +25,7 @@ describe("buildRequest - swagger 2.0", () => {
       spec,
       operationId: 'getMe',
       parameters: {
-        name: ""
+        name: ''
       }
     })
 
@@ -37,7 +37,7 @@ describe("buildRequest - swagger 2.0", () => {
     })
   })
 
-  it("should not include omitted parameter values for a query param with allowEmptyValue", () => {
+  it('should not include omitted parameter values for a query param with allowEmptyValue', () => {
     const spec = {
       swagger: '2.0',
       paths: {
@@ -46,8 +46,8 @@ describe("buildRequest - swagger 2.0", () => {
             operationId: 'getMe',
             parameters: [
               {
-                name: "name",
-                in: "query",
+                name: 'name',
+                in: 'query',
                 allowEmptyValue: true
               }
             ]
@@ -71,7 +71,7 @@ describe("buildRequest - swagger 2.0", () => {
     })
   })
 
-  it("should not include empty parameter values for a query param lacking allowEmptyValue", () => {
+  it('should not include empty parameter values for a query param lacking allowEmptyValue', () => {
     const spec = {
       swagger: '2.0',
       paths: {
@@ -80,8 +80,8 @@ describe("buildRequest - swagger 2.0", () => {
             operationId: 'getMe',
             parameters: [
               {
-                name: "name",
-                in: "query"
+                name: 'name',
+                in: 'query'
               }
             ]
           }
@@ -94,7 +94,7 @@ describe("buildRequest - swagger 2.0", () => {
       spec,
       operationId: 'getMe',
       parameters: {
-        name: ""
+        name: ''
       }
     })
 
@@ -106,7 +106,7 @@ describe("buildRequest - swagger 2.0", () => {
     })
   })
 
-  it("should not include omitted parameter values for a query param lacking allowEmptyValue", () => {
+  it('should not include omitted parameter values for a query param lacking allowEmptyValue', () => {
     const spec = {
       swagger: '2.0',
       paths: {
@@ -115,8 +115,8 @@ describe("buildRequest - swagger 2.0", () => {
             operationId: 'getMe',
             parameters: [
               {
-                name: "name",
-                in: "query"
+                name: 'name',
+                in: 'query'
               }
             ]
           }

--- a/test/swagger2/execute/build-request.js
+++ b/test/swagger2/execute/build-request.js
@@ -1,141 +1,287 @@
 import {buildRequest} from '../../../src/execute'
 
 describe('buildRequest - swagger 2.0', () => {
-  it('should include empty parameter values for a query param with allowEmptyValue', () => {
-    const spec = {
-      swagger: '2.0',
-      paths: {
-        '/one': {
-          get: {
-            operationId: 'getMe',
-            parameters: [
-              {
-                name: 'name',
-                in: 'query',
-                allowEmptyValue: true
+  describe("allowEmptyValue parameters", () => {
+    describe("query", () => {
+      it('should include empty parameter values for a query param with allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'query',
+                    allowEmptyValue: true
+                  }
+                ]
               }
-            ]
+            }
           }
         }
-      }
-    }
 
     // when
     const req = buildRequest({
-      spec,
-      operationId: 'getMe',
-      parameters: {
-        name: ''
-      }
-    })
+          spec,
+          operationId: 'getMe',
+          parameters: {
+            name: ''
+          }
+        })
 
     expect(req).toMatchObject({
-      method: 'GET',
-      url: '/one?name=',
-      credentials: 'same-origin',
-      headers: {},
-    })
-  })
+          method: 'GET',
+          url: '/one?name=',
+          credentials: 'same-origin',
+          headers: { },
+        })
+      })
 
-  it('should not include omitted parameter values for a query param with allowEmptyValue', () => {
-    const spec = {
-      swagger: '2.0',
-      paths: {
-        '/one': {
-          get: {
-            operationId: 'getMe',
-            parameters: [
-              {
-                name: 'name',
-                in: 'query',
-                allowEmptyValue: true
+      it('should not include omitted parameter values for a query param with allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'query',
+                    allowEmptyValue: true
+                  }
+                ]
               }
-            ]
+            }
           }
         }
-      }
-    }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {}
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+
+      it('should not include empty parameter values for a query param lacking allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'query'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {
+            name: ''
+          }
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+
+      it('should not include omitted parameter values for a query param lacking allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'query'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {}
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+    })
+    describe("formData", () => {
+      it('should include empty parameter values for a query param with allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'formData',
+                    allowEmptyValue: true
+                  }
+                ]
+              }
+            }
+          }
+        }
 
     // when
     const req = buildRequest({
-      spec,
-      operationId: 'getMe',
-      parameters: {}
-    })
+          spec,
+          operationId: 'getMe',
+          parameters: {
+            name: ''
+          }
+        })
 
     expect(req).toMatchObject({
-      method: 'GET',
-      url: '/one',
-      credentials: 'same-origin',
-      headers: {},
-    })
-  })
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+          },
+          body: "name="
+        })
+      })
 
-  it('should not include empty parameter values for a query param lacking allowEmptyValue', () => {
-    const spec = {
-      swagger: '2.0',
-      paths: {
-        '/one': {
-          get: {
-            operationId: 'getMe',
-            parameters: [
-              {
-                name: 'name',
-                in: 'query'
+      it('should not include omitted parameter values for a query param with allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'formData',
+                    allowEmptyValue: true
+                  }
+                ]
               }
-            ]
+            }
           }
         }
-      }
-    }
 
-    // when
-    const req = buildRequest({
-      spec,
-      operationId: 'getMe',
-      parameters: {
-        name: ''
-      }
-    })
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {}
+        })
 
-    expect(req).toMatchObject({
-      method: 'GET',
-      url: '/one',
-      credentials: 'same-origin',
-      headers: {},
-    })
-  })
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
 
-  it('should not include omitted parameter values for a query param lacking allowEmptyValue', () => {
-    const spec = {
-      swagger: '2.0',
-      paths: {
-        '/one': {
-          get: {
-            operationId: 'getMe',
-            parameters: [
-              {
-                name: 'name',
-                in: 'query'
+      it('should not include empty parameter values for a query param lacking allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'formData'
+                  }
+                ]
               }
-            ]
+            }
           }
         }
-      }
-    }
 
-    // when
-    const req = buildRequest({
-      spec,
-      operationId: 'getMe',
-      parameters: {}
-    })
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {
+            name: ''
+          }
+        })
 
-    expect(req).toMatchObject({
-      method: 'GET',
-      url: '/one',
-      credentials: 'same-origin',
-      headers: {},
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
+
+      it('should not include omitted parameter values for a query param lacking allowEmptyValue', () => {
+        const spec = {
+          swagger: '2.0',
+          paths: {
+            '/one': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    name: 'name',
+                    in: 'formData'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'getMe',
+          parameters: {}
+        })
+
+        expect(req).toMatchObject({
+          method: 'GET',
+          url: '/one',
+          credentials: 'same-origin',
+          headers: {},
+        })
+      })
     })
   })
 })

--- a/test/swagger2/execute/build-request.js
+++ b/test/swagger2/execute/build-request.js
@@ -1,0 +1,141 @@
+import { buildRequest } from '../../../src/execute'
+
+describe("buildRequest - swagger 2.0", () => {
+  it("should include empty parameter values for a query param with allowEmptyValue", () => {
+    const spec = {
+      swagger: '2.0',
+      paths: {
+        '/one': {
+          get: {
+            operationId: 'getMe',
+            parameters: [
+              {
+                name: "name",
+                in: "query",
+                allowEmptyValue: true
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    // when
+    const req = buildRequest({
+      spec,
+      operationId: 'getMe',
+      parameters: {
+        name: ""
+      }
+    })
+
+    expect(req).toMatchObject({
+      method: 'GET',
+      url: '/one?name=',
+      credentials: 'same-origin',
+      headers: {},
+    })
+  })
+
+  it("should not include omitted parameter values for a query param with allowEmptyValue", () => {
+    const spec = {
+      swagger: '2.0',
+      paths: {
+        '/one': {
+          get: {
+            operationId: 'getMe',
+            parameters: [
+              {
+                name: "name",
+                in: "query",
+                allowEmptyValue: true
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    // when
+    const req = buildRequest({
+      spec,
+      operationId: 'getMe',
+      parameters: {}
+    })
+
+    expect(req).toMatchObject({
+      method: 'GET',
+      url: '/one',
+      credentials: 'same-origin',
+      headers: {},
+    })
+  })
+
+  it("should not include empty parameter values for a query param lacking allowEmptyValue", () => {
+    const spec = {
+      swagger: '2.0',
+      paths: {
+        '/one': {
+          get: {
+            operationId: 'getMe',
+            parameters: [
+              {
+                name: "name",
+                in: "query"
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    // when
+    const req = buildRequest({
+      spec,
+      operationId: 'getMe',
+      parameters: {
+        name: ""
+      }
+    })
+
+    expect(req).toMatchObject({
+      method: 'GET',
+      url: '/one',
+      credentials: 'same-origin',
+      headers: {},
+    })
+  })
+
+  it("should not include omitted parameter values for a query param lacking allowEmptyValue", () => {
+    const spec = {
+      swagger: '2.0',
+      paths: {
+        '/one': {
+          get: {
+            operationId: 'getMe',
+            parameters: [
+              {
+                name: "name",
+                in: "query"
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    // when
+    const req = buildRequest({
+      spec,
+      operationId: 'getMe',
+      parameters: {}
+    })
+
+    expect(req).toMatchObject({
+      method: 'GET',
+      url: '/one',
+      credentials: 'same-origin',
+      headers: {},
+    })
+  })
+})


### PR DESCRIPTION
This PR paves the way for a UI-based resolution of https://github.com/swagger-api/swagger-ui/issues/4223.

### Rationale

TLDR: `allowEmptyValue` is different from `required`.

Previously, there was no way to express to Swagger Client that an `allowEmptyValue` parameter should not be present. 

### Previous behavior 

Given:
```yaml
parameters:
- name: myParam
  in: query
  allowEmptyValue: true
```

All of these execute `parameters` values would result in `/?myParam=`:

```js
{}
```

```js
{
  myParam: undefined
}
```

```js
{
  myParam: ""
}
```
### New behavior 

Given:
```yaml
parameters:
- name: myParam
  in: query
  allowEmptyValue: true
```

....these execute `parameters` values result in the following:


```js
{} 
```

yields `/`.

```js
{
  myParam: undefined
}
```

yields `/`.

```js
{
  myParam: ""
}
```

yields `/?myParam=`.

### TODO

- [x] Review parameter types covered by the tests

### Request for review

_@webron_

This is, strictly speaking, a breaking change - but the behavior is due to a nonstandard implementation present since `3.0.0`. I'd appreciate your read on whether this should be: 
1. shipped as a bugfix, 
2. held back as a breaking change, or 
3. modified so that `{}`'s behavior doesn't change, but the more esoteric `{ myParam: undefined }` form does change.