### PR TITLE
Colon path parameters

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -17,6 +17,10 @@ function path({req, value, parameter}) {
     escape: false,
   })
 
+  if (req.url.substring(req.url.indexOf('//')).indexOf(':') > 0) {
+    req.url.replace(`:${name}`, styledValue)
+  }
+  
   req.url = req.url.replace(`{${name}}`, styledValue)
 }
 

--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -16,11 +16,9 @@ function path({req, value, parameter}) {
     explode: explode || false,
     escape: false,
   })
-
   if (req.url.substring(req.url.indexOf('//')).indexOf(':') > 0) {
     req.url.replace(`:${name}`, styledValue)
   }
-  
   req.url = req.url.replace(`{${name}}`, styledValue)
 }
 

--- a/src/execute/swagger2/parameter-builders.js
+++ b/src/execute/swagger2/parameter-builders.js
@@ -38,6 +38,11 @@ function headerBuilder({req, parameter, value}) {
 
 // Replace path paramters, with values ( ie: the URL )
 function pathBuilder({req, value, parameter}) {
+
+  if (req.url.substring(req.url.indexOf('//')).indexOf(':') > 0) {
+    req.url.replace(`:${parameter.name}`, encodeURIComponent(value))
+  }
+  
   req.url = req.url.replace(`{${parameter.name}}`, encodeURIComponent(value))
 }
 

--- a/src/execute/swagger2/parameter-builders.js
+++ b/src/execute/swagger2/parameter-builders.js
@@ -38,11 +38,10 @@ function headerBuilder({req, parameter, value}) {
 
 // Replace path paramters, with values ( ie: the URL )
 function pathBuilder({req, value, parameter}) {
-
   if (req.url.substring(req.url.indexOf('//')).indexOf(':') > 0) {
     req.url.replace(`:${parameter.name}`, encodeURIComponent(value))
   }
-  
+
   req.url = req.url.replace(`{${parameter.name}}`, encodeURIComponent(value))
 }
 


### PR DESCRIPTION
## Colon prefix parameter substitution

### Description
Detect if a colon exists in the URL and then attempt to substitute matched parameter.

### Motivation and Context
I have created OpenAPI v3 spec generation in JAVA using Vertx framework. This generates urls which have colon prefixed parameters in the PATH rather than bracketed path variables. I needed to be able to substitute colon parameters if detected.

### How Has This Been Tested?
Source code changes ported over into `swagger-ui-bundle.js` for testing.


### Screenshots (if appropriate):
![capture](https://user-images.githubusercontent.com/6728822/42224169-5791c7ba-7ed1-11e8-89dd-59bf1cb7d2f7.PNG)


### Types of changes

- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
