### PR TITLE
build(automated-release): remove custom npm config

### DIFF
--- a/release/.release-it.json
+++ b/release/.release-it.json
@@ -10,9 +10,6 @@
     "push": false,
     "beforeStartCommand": "run-s test:unit test:webpack lint"
   },
-  "npm": {
-    "tag": null
-  },
   "github": {
     "release": true,
     "releaseName": "Swagger Client v%s Released!",


### PR DESCRIPTION
This change allows the `@latest` npm tag to be updated when releases occur.