### PR TITLE
revert: "remove babel-runtime runtime dependency"

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "deep-extend": "^0.5.1",
     "encode-3986": "^1.0.0",
     "fast-json-patch": "^2.0.6",
-    "is-generator-fn": "^1.0.0",
     "isomorphic-form-data": "0.0.1",
     "lodash": "^4.16.2",
     "qs": "^6.3.0",

--- a/src/specmap/index.js
+++ b/src/specmap/index.js
@@ -75,7 +75,7 @@ class SpecMap {
 
     return Object.assign(fn.bind(ctx), {
       pluginName: plugin.name || name,
-      isGeneratorFunction: lib.isGeneratorFunction(fn)
+      isGenerator: lib.isGenerator(fn)
     })
 
     // Expected plugin interface: {key: string, plugin: fn*}
@@ -361,7 +361,7 @@ class SpecMap {
       const lastMutationIndex = that.mutations.length - 1
 
       try {
-        if (plugin.isGeneratorFunction) {
+        if (plugin.isGenerator) {
           for (const yieldedPatches of plugin(mutations, that.getLib())) {
             updatePatches(yieldedPatches)
           }

--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -1,6 +1,6 @@
 import jsonPatch from 'fast-json-patch'
+import regenerator from 'babel-runtime/regenerator'
 import deepExtend from 'deep-extend'
-import isGeneratorFunction from 'is-generator-fn'
 import deepAssign from '@kyleshockey/object-assign-deep'
 
 export default {
@@ -24,7 +24,7 @@ export default {
   isPatch,
   isMutation,
   isAdditiveMutation,
-  isGeneratorFunction,
+  isGenerator,
   isFunction,
   isObject,
   isError
@@ -332,6 +332,10 @@ function isJsonPatch(patch) {
     return op === 'add' || op === 'remove' || op === 'replace'
   }
   return false
+}
+
+function isGenerator(thing) {
+  return regenerator.isGeneratorFunction(thing)
 }
 
 function isMutation(patch) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

⚠️ This PR reverts f8fccb4 aka #1203.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

The original PR introduced a browser-specific issue (https://github.com/swagger-api/swagger-ui/issues/4748) in the resolver.

The exact mechanism causing the failure was not identified, but my manual testing confirmed that specmap patches were not being applied at all within IE11.

According to our `size-check` script, this change has a negligible (`<1K`) impact on our bundle size. I assume this is because we never realized the ~22K savings from dropping the regenerator, because we still had the `transform-runtime` plugin in our Babel config:

https://github.com/swagger-api/swagger-js/blob/9c5e991b8e0b26d7b18216be7c02bc968494d103/.babelrc#L27

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've manually tested the changes.

Forthcoming cross-browser tests in Swagger UI would have caught this prior to release of that project.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.