### PR TITLE
fix(resolver): drop patches that reference nonexistent paths

### DIFF
--- a/src/specmap/lib/refs.js
+++ b/src/specmap/lib/refs.js
@@ -120,8 +120,21 @@ const plugin = {
       return [patch, lib.context(parent, {baseDoc: basePath})]
     }
 
-    if (!patchValueAlreadyInPath(specmap.state, patch)) {
-      return patch
+    try {
+      if (!patchValueAlreadyInPath(specmap.state, patch)) {
+        return patch
+      }
+    }
+    catch (e) {
+      // if we're catching here, path traversal failed, so we should
+      // ditch without sending any patches back up.
+      //
+      // this is a narrow fix for the larger problem of patches being queued
+      // and then having the state they were generated against be modified
+      // before they are applied.
+      //
+      // TODO: re-engineer specmap patch/state management to avoid this
+      return null
     }
   }
 }

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -309,208 +309,191 @@ describe('resolver', () => {
     }
   })
 
-  describe('complex allOf+$ref', () => {
-    test('should be able to resolve without meta patches', () => {
+  describe('complex allOf+$ref+circular-reference', () => {
+    test('should be able to resolve without meta patches', async () => {
       // Given
       const spec = {
-        components: {
-          schemas: {
-            Error: {
-              type: 'object',
-              properties: {
-                message: {
-                  type: 'string'
+        swagger: '2.0',
+        info: {
+          version: '0.2.1',
+          title: 'Resolver Issue, undefind of \'0\'',
+          description: 'Resolver issue'
+        },
+        paths: {
+        },
+        definitions: {
+          First: {
+            allOf: [
+              {
+                $ref: '#/definitions/Second'
+              }
+            ]
+          },
+          Second: {
+            allOf: [
+              {
+                $ref: '#/definitions/Third'
+              }
+            ]
+          },
+          Third: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
               }
-            },
-            UnauthorizedError: {
-              allOf: [
-                {
-                  $ref: '#/components/schemas/Error'
-                },
-                {
-                  type: 'object',
-                  properties: {
-                    code: {
-                      example: 401
-                    },
-                    message: {
-                      example: 'Unauthorized'
-                    }
-                  }
-                }
-              ]
-            },
-            NotFoundError: {
-              allOf: [
-                {
-                  $ref: '#/components/schemas/Error'
-                },
-                {
-                  type: 'object',
-                  properties: {
-                    code: {
-                      example: 404
-                    },
-                    message: {
-                      example: 'Resource Not Found'
-                    }
-                  }
-                }
-              ]
             }
           }
         }
       }
 
       // When
-      return Swagger.resolve({spec, allowMetaPatches: false})
-      .then(handleResponse)
+      const result = await Swagger.resolve({spec, allowMetaPatches: false})
 
       // Then
-      function handleResponse(obj) {
-        expect(obj.errors).toEqual([])
-        expect(obj.spec).toEqual({
-          components: {
-            schemas: {
-              Error: {
-                type: 'object',
-                properties: {
-                  message: {
-                    type: 'string'
-                  }
+      if (result.errors && result.errors.length) {
+        // For debugging
+        throw result.errors[0]
+      }
+      expect(result.errors).toEqual([])
+      expect(result.spec).toEqual({
+        $$normalized: true,
+        swagger: '2.0',
+        info: {
+          version: '0.2.1',
+          title: 'Resolver Issue, undefind of \'0\'',
+          description: 'Resolver issue'
+        },
+        paths: {
+        },
+        definitions: {
+          First: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
-              },
-              UnauthorizedError: {
-                type: 'object',
-                properties: {
-                  message: {
-                    type: 'string',
-                    example: 'Unauthorized'
-
-                  },
-                  code: {
-                    example: 401
-                  },
+              }
+            }
+          },
+          Second: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
-              },
-              NotFoundError: {
-                type: 'object',
-                properties: {
-                  code: {
-                    example: 404
-                  },
-                  message: {
-                    type: 'string',
-                    example: 'Resource Not Found'
-                  }
+              }
+            }
+          },
+          Third: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
               }
             }
           }
-        })
-      }
+        }
+      })
     })
-    test('should be able to resolve with meta patches', () => {
+    test('should be able to resolve with meta patches', async () => {
       // Given
       const spec = {
-        components: {
-          schemas: {
-            Error: {
-              type: 'object',
-              properties: {
-                message: {
-                  type: 'string'
+        swagger: '2.0',
+        info: {
+          version: '0.2.1',
+          title: 'Resolver Issue, undefind of \'0\'',
+          description: 'Resolver issue'
+        },
+        paths: {
+        },
+        definitions: {
+          First: {
+            allOf: [
+              {
+                $ref: '#/definitions/Second'
+              }
+            ]
+          },
+          Second: {
+            allOf: [
+              {
+                $ref: '#/definitions/Third'
+              }
+            ]
+          },
+          Third: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
               }
-            },
-            UnauthorizedError: {
-              allOf: [
-                {
-                  $ref: '#/components/schemas/Error'
-                },
-                {
-                  type: 'object',
-                  properties: {
-                    code: {
-                      example: 401
-                    },
-                    message: {
-                      example: 'Unauthorized'
-                    }
-                  }
-                }
-              ]
-            },
-            NotFoundError: {
-              allOf: [
-                {
-                  $ref: '#/components/schemas/Error'
-                },
-                {
-                  type: 'object',
-                  properties: {
-                    code: {
-                      example: 404
-                    },
-                    message: {
-                      example: 'Resource Not Found'
-                    }
-                  }
-                }
-              ]
             }
           }
         }
       }
 
       // When
-      return Swagger.resolve({spec, allowMetaPatches: true})
-      .then(handleResponse)
+      const result = await Swagger.resolve({spec, allowMetaPatches: true})
 
       // Then
-      function handleResponse(obj) {
-        expect(obj.errors).toEqual([])
-        expect(obj.spec).toEqual({
-          components: {
-            schemas: {
-              Error: {
-                type: 'object',
-                properties: {
-                  message: {
-                    type: 'string'
-                  }
-                }
-              },
-              UnauthorizedError: {
-                type: 'object',
-                properties: {
-                  message: {
-                    type: 'string',
-                    example: 'Unauthorized'
+      if (result.errors && result.errors.length) {
+        // For debugging
+        throw result.errors[0]
+      }
 
-                  },
-                  code: {
-                    example: 401
-                  },
+      expect(result.errors).toEqual([])
+      expect(result.spec).toEqual({
+        $$normalized: true,
+        swagger: '2.0',
+        info: {
+          version: '0.2.1',
+          title: 'Resolver Issue, undefind of \'0\'',
+          description: 'Resolver issue'
+        },
+        paths: {
+        },
+        definitions: {
+          First: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
-              },
-              NotFoundError: {
-                type: 'object',
-                properties: {
-                  code: {
-                    example: 404
-                  },
-                  message: {
-                    type: 'string',
-                    example: 'Resource Not Found'
-                  }
+              }
+            }
+          },
+          Second: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
+                }
+              }
+            }
+          },
+          Third: {
+            properties: {
+              children: {
+                type: 'array',
+                items: {
+                  $ref: '#/definitions/Third'
                 }
               }
             }
           }
-        })
-      }
+        }
+      })
     })
   })
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -309,6 +309,211 @@ describe('resolver', () => {
     }
   })
 
+  describe('complex allOf+$ref', () => {
+    test('should be able to resolve without meta patches', () => {
+      // Given
+      const spec = {
+        components: {
+          schemas: {
+            Error: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string'
+                }
+              }
+            },
+            UnauthorizedError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 401
+                    },
+                    message: {
+                      example: 'Unauthorized'
+                    }
+                  }
+                }
+              ]
+            },
+            NotFoundError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 404
+                    },
+                    message: {
+                      example: 'Resource Not Found'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      // When
+      return Swagger.resolve({spec, allowMetaPatches: false})
+        .then(handleResponse)
+
+      // Then
+      function handleResponse(obj) {
+        expect(obj.errors).toEqual([])
+        expect(obj.spec).toEqual({
+          components: {
+            schemas: {
+              Error: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string'
+                  }
+                }
+              },
+              UnauthorizedError: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string',
+                    example: 'Unauthorized'
+
+                  },
+                  code: {
+                    example: 401
+                  },
+                }
+              },
+              NotFoundError: {
+                type: 'object',
+                properties: {
+                  code: {
+                    example: 404
+                  },
+                  message: {
+                    type: 'string',
+                    example: 'Resource Not Found'
+                  }
+                }
+              }
+            }
+          }
+        })
+      }
+    })
+    test('should be able to resolve with meta patches', () => {
+      // Given
+      const spec = {
+        components: {
+          schemas: {
+            Error: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string'
+                }
+              }
+            },
+            UnauthorizedError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 401
+                    },
+                    message: {
+                      example: 'Unauthorized'
+                    }
+                  }
+                }
+              ]
+            },
+            NotFoundError: {
+              allOf: [
+                {
+                  $ref: '#/components/schemas/Error'
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    code: {
+                      example: 404
+                    },
+                    message: {
+                      example: 'Resource Not Found'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
+      // When
+      return Swagger.resolve({spec, allowMetaPatches: true})
+        .then(handleResponse)
+
+      // Then
+      function handleResponse(obj) {
+        expect(obj.errors).toEqual([])
+        expect(obj.spec).toEqual({
+          components: {
+            schemas: {
+              Error: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string'
+                  }
+                }
+              },
+              UnauthorizedError: {
+                type: 'object',
+                properties: {
+                  message: {
+                    type: 'string',
+                    example: 'Unauthorized'
+
+                  },
+                  code: {
+                    example: 401
+                  },
+                }
+              },
+              NotFoundError: {
+                type: 'object',
+                properties: {
+                  code: {
+                    example: 404
+                  },
+                  message: {
+                    type: 'string',
+                    example: 'Resource Not Found'
+                  }
+                }
+              }
+            }
+          }
+        })
+      }
+    })
+  })
+
   describe('complex allOf+$ref+circular-reference', () => {
     test('should be able to resolve without meta patches', async () => {
       // Given


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR modifies the `$ref` plugin to shield it from generating `replace` patches that point to paths not currently in Specmap's state.

This prevents an edge case caused by state slippage due to interactions between plugins touching the same path in one patch-generation pass, though this is a narrow fix for a broad problem. A more comprehensive fix would require a major overhaul to Specmap.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

This PR fixes an issue that was reported privately (id ~`SWOS-22`~ `SWOS-34`).

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests were added to cover the case in question, and the resulting Swagger Client build was tested in integration with Swagger UI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.