### PR TITLE
fix: drop browser global whitelisting from test harnesses

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
   "extends": "eslint-config-airbnb-base",
   "env": {
-    "browser": true,
     "node": true
   },
   "rules": {

--- a/package.json
+++ b/package.json
@@ -97,9 +97,6 @@
     "utfstring": "^2.0.0"
   },
   "jest": {
-    "globals": {
-      "navigator": true
-    },
     "testEnvironment": "node",
     "testMatch": [
       "**/test/*.js?(x)",

--- a/src/http.js
+++ b/src/http.js
@@ -134,7 +134,11 @@ export function serializeHeaders(headers = {}) {
   return obj
 }
 
-export function isFile(obj, navigatorObj = navigator) {
+export function isFile(obj, navigatorObj) {
+  if (!navigatorObj && typeof navigator !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    navigatorObj = navigator
+  }
   if (navigatorObj && navigatorObj.product === 'ReactNative') {
     if (obj && typeof obj === 'object' && typeof obj.uri === 'string') {
       return true
@@ -142,6 +146,7 @@ export function isFile(obj, navigatorObj = navigator) {
     return false
   }
   if (typeof File !== 'undefined') {
+    // eslint-disable-next-line no-undef
     return obj instanceof File
   }
   return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function'

--- a/test/http.js
+++ b/test/http.js
@@ -436,7 +436,8 @@ describe('http', () => {
     const mockReactNativeNavigator = {
       product: 'ReactNative'
     }
-    const browserFile = new File()
+
+    const browserFile = new global.File()
     const reactNativeFileObject = {
       uri: '/mock/path'
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR reverts part of #1374. While the use of the browser's `navigator` object is welcome, #1374 also introduced browser global tolerance to our test harness configs, which allowed code that will only work in a browser to slip through.

The changes within should resolve that.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #1382.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The configuration changes make the tests effective 😄 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.