### PR TITLE
Fix lack of leading zero on low unicode values

### DIFF
--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -33,7 +33,7 @@ export function encodeDisallowedCharacters(str, {escape} = {}, parse) {
     }
 
     const encoded = (toUTF8Bytes(char) || [])
-      .map(byte => ("0"+byte.toString(16).toUpperCase()).slice(-2))
+      .map(byte => (`0${byte.toString(16).toUpperCase()).slice(-2)}`)
       .map(encodedByte => `%${encodedByte}`)
       .join('')
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -33,7 +33,7 @@ export function encodeDisallowedCharacters(str, {escape} = {}, parse) {
     }
 
     const encoded = (toUTF8Bytes(char) || [])
-      .map(byte => (`0${byte.toString(16).toUpperCase()}`.slice(-2))
+      .map(byte => `0${byte.toString(16).toUpperCase()}`.slice(-2)
       .map(encodedByte => `%${encodedByte}`)
       .join('')
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -33,7 +33,7 @@ export function encodeDisallowedCharacters(str, {escape} = {}, parse) {
     }
 
     const encoded = (toUTF8Bytes(char) || [])
-      .map(byte => byte.toString(16).toUpperCase())
+      .map(byte => ("0"+byte.toString(16).toUpperCase()).slice(-2))
       .map(encodedByte => `%${encodedByte}`)
       .join('')
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -33,7 +33,7 @@ export function encodeDisallowedCharacters(str, {escape} = {}, parse) {
     }
 
     const encoded = (toUTF8Bytes(char) || [])
-      .map(byte => (`0${byte}`.toString(16).toUpperCase()).slice(-2))
+      .map(byte => (`0${byte.toString(16).toUpperCase()}`.slice(-2))
       .map(encodedByte => `%${encodedByte}`)
       .join('')
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -33,7 +33,7 @@ export function encodeDisallowedCharacters(str, {escape} = {}, parse) {
     }
 
     const encoded = (toUTF8Bytes(char) || [])
-      .map(byte => (`0${byte.toString(16).toUpperCase()).slice(-2)}`)
+      .map(byte => (`0${byte}`.toString(16).toUpperCase()).slice(-2))
       .map(encodedByte => `%${encodedByte}`)
       .join('')
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -33,7 +33,7 @@ export function encodeDisallowedCharacters(str, {escape} = {}, parse) {
     }
 
     const encoded = (toUTF8Bytes(char) || [])
-      .map(byte => `0${byte.toString(16).toUpperCase()}`.slice(-2)
+      .map(byte => `0${byte.toString(16).toUpperCase()}`.slice(-2))
       .map(encodedByte => `%${encodedByte}`)
       .join('')
 

--- a/test/oas3/execute/style-serializer.js
+++ b/test/oas3/execute/style-serializer.js
@@ -26,6 +26,7 @@ describe('OAS3 style serializer', () => {
       expect(tested('[')).toEqual('%5B')
       expect(tested(']')).toEqual('%5D')
       expect(tested('%')).toEqual('%25')
+      expect(tested('\n')).toEqual('%0A')
     })
 
     test('should correctly encode non-ASCII characters', () => {
@@ -58,6 +59,7 @@ describe('OAS3 style serializer', () => {
       expect(tested('@')).toEqual('@')
       expect(tested('[')).toEqual('[')
       expect(tested(']')).toEqual(']')
+      expect(tested('\n')).toEqual('\n')
 
       // Non-ASCII too!
       expect(tested('♥')).toEqual('♥')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Low value unicode characters were not encoded properly. For example, 'LINE FEED (LF)' (U+000A) was encoded as '%A' instead of '%0A' which cannot be decoded properly.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Low value unicode characters were not encoded properly. For example, 'LINE FEED (LF)' (U+000A) was encoded as '%A' instead of '%0A' which cannot be decoded properly.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the output directly in the browser


### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/10687569/45579796-80e8f000-b83f-11e8-93ba-f23190ff97a2.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
