### PR TITLE
housekeeping: remove `test:webpack`from release configuration

### DIFF
--- a/release/.release-it.json
+++ b/release/.release-it.json
@@ -8,7 +8,7 @@
     "commitMessage": "release: v%s",
     "tagName": "v%s",
     "push": false,
-    "beforeStartCommand": "run-s test:unit test:webpack test:lint",
+    "beforeStartCommand": "run-s test:unit test:lint",
     "afterReleaseCommand": "echo GIT_TAG=v${version} > release/.version"
   },
   "github": {


### PR DESCRIPTION
`test:webpack` no longer exists, it was folded into `test:unit` in #1438