### PR TITLE
Send streams directly when using OAS3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Swagger Client <img src="https://raw.githubusercontent.com/swagger-api/swagger.io/wordpress/images/assets/SW-logo-clr.png" height="50" align="right">
 
 [![Build Status](https://travis-ci.org/swagger-api/swagger-js.svg?branch=master)](https://travis-ci.org/swagger-api/swagger-js)
+[![Build Status](https://jenkins.swagger.io/view/OSS%20-%20JavaScript/job/oss-swagger-js-master/badge/icon?subject=jenkins%20build)](https://jenkins.swagger.io/view/OSS%20-%20JavaScript/job/oss-swagger-js-master/)
 
 **Swagger Client** is a JavaScript module that allows you to fetch, resolve, and interact with Swagger/OpenAPI documents.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-client",
-  "version": "3.8.26",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1599,7 +1599,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -1924,15 +1925,6 @@
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
-    },
-    "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -5909,7 +5901,8 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-client",
-  "version": "3.8.25",
+  "version": "3.8.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9152,7 +9152,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -11640,8 +11640,7 @@
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "treeify": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "@kyleshockey/object-assign-deep": "^0.4.0",
     "babel-runtime": "^6.26.0",
     "btoa": "1.1.2",
-    "buffer": "^5.1.0",
     "cookie": "^0.3.1",
     "cross-fetch": "0.0.8",
     "deep-extend": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-client",
-  "version": "3.8.26",
+  "version": "3.9.0",
   "description": "SwaggerJS - a collection of interfaces for OAI specs",
   "main": "dist/index.js",
   "unpkg": "browser/index.js",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "nock": "^10.0.6",
     "npm-run-all": "^4.1.3",
     "release-it": "^7.4.8",
-    "traverse": "^0.6.6",
     "webpack": "^3.11.0",
     "webpack-bundle-size-analyzer": "^2.2.0",
     "xmock": "^0.3.0"
@@ -102,6 +101,7 @@
     "lodash": "^4.16.2",
     "qs": "^6.3.0",
     "querystring-browser": "^1.0.4",
+    "traverse": "^0.6.6",
     "url": "^0.11.0",
     "utf8-bytes": "0.0.1",
     "utfstring": "^2.0.0"

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -3,7 +3,7 @@
 import assign from 'lodash/assign'
 import get from 'lodash/get'
 import btoa from 'btoa'
-import {Buffer} from 'buffer/'
+import {isFile} from '../../http'
 
 export default function (options, req) {
   const {
@@ -57,21 +57,7 @@ export default function (options, req) {
               const val = requestBody[k]
               let newVal
 
-              let isFile
-
-              if (typeof File !== 'undefined') {
-                isFile = val instanceof File // eslint-disable-line no-undef
-              }
-
-              if (typeof Blob !== 'undefined') {
-                isFile = isFile || val instanceof Blob // eslint-disable-line no-undef
-              }
-
-              if (typeof Buffer !== 'undefined') {
-                isFile = isFile || Buffer.isBuffer(val)
-              }
-
-              if (typeof val === 'object' && !isFile) {
+              if (typeof val === 'object' && !isFile(val)) {
                 if (Array.isArray(val)) {
                   newVal = val.toString()
                 }

--- a/src/http.js
+++ b/src/http.js
@@ -139,15 +139,14 @@ export function isFile(obj, navigatorObj) {
     // eslint-disable-next-line no-undef
     navigatorObj = navigator
   }
-  if (navigatorObj && navigatorObj.product === 'ReactNative') {
-    if (obj && typeof obj === 'object' && typeof obj.uri === 'string') {
-      return true
-    }
-    return false
+  if (typeof Blob !== 'undefined' && obj instanceof Blob) { // eslint-disable-line no-undef
+    return true
   }
-  if (typeof File !== 'undefined') {
-    // eslint-disable-next-line no-undef
-    return obj instanceof File
+  if (navigatorObj && navigatorObj.product === 'ReactNative') {
+    return obj && typeof obj === 'object' && typeof obj.uri === 'string'
+  }
+  if (typeof File !== 'undefined' && obj instanceof File) { // eslint-disable-line no-undef
+    return true
   }
   return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function'
 }

--- a/src/http.js
+++ b/src/http.js
@@ -143,7 +143,10 @@ export function isFile(obj, navigatorObj) {
     return true
   }
   if (navigatorObj && navigatorObj.product === 'ReactNative') {
-    return obj && typeof obj === 'object' && typeof obj.uri === 'string'
+    if (obj && typeof obj === 'object' && typeof obj.uri === 'string') {
+      return true
+    }
+    return false
   }
   if (typeof File !== 'undefined' && obj instanceof File) { // eslint-disable-line no-undef
     return true

--- a/test/http.js
+++ b/test/http.js
@@ -1,5 +1,6 @@
 import xmock from 'xmock'
 import fetchMock from 'fetch-mock'
+import {Readable} from 'stream'
 import http, {
   serializeHeaders, mergeInQueryOrForm, encodeFormOrQuery, serializeRes,
   shouldDownloadAsText, isFile
@@ -429,6 +430,7 @@ describe('http', () => {
   describe('isFile', () => {
     // mock browser File class
     global.File = class MockBrowserFile {}
+    global.Blob = class MockBlob {}
 
     const mockBrowserNavigator = {
       product: 'Gecko'
@@ -438,9 +440,11 @@ describe('http', () => {
     }
 
     const browserFile = new global.File()
+    const browserBlobFile = new global.Blob()
     const reactNativeFileObject = {
       uri: '/mock/path'
     }
+    const nodeStream = new Readable()
 
     test('should return true for browser File type', () => {
       expect(isFile(browserFile)).toEqual(true)
@@ -462,6 +466,14 @@ describe('http', () => {
       expect(isFile(reactNativeFileObject, mockReactNativeNavigator)).toEqual(true)
     })
 
+    test('should return true for browser Blob type and browser user agent', () => {
+      expect(isFile(browserBlobFile, mockBrowserNavigator)).toEqual(true)
+    })
+
+    test('should return true for readable node streams', () => {
+      expect(isFile(nodeStream)).toEqual(true)
+    })
+
     test('should return false for non-File type and browser user agent', () => {
       expect(isFile(undefined, mockBrowserNavigator)).toEqual(false)
       expect(isFile('', mockBrowserNavigator)).toEqual(false)
@@ -476,6 +488,14 @@ describe('http', () => {
       expect(isFile(123, mockReactNativeNavigator)).toEqual(false)
       expect(isFile([], mockReactNativeNavigator)).toEqual(false)
       expect(isFile({}, mockReactNativeNavigator)).toEqual(false)
+    })
+
+    test('should return false for non-object type and no user agent', () => {
+      expect(isFile(undefined)).toEqual(false)
+      expect(isFile('')).toEqual(false)
+      expect(isFile(123)).toEqual(false)
+      expect(isFile([])).toEqual(false)
+      expect(isFile({})).toEqual(false)
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

It basically fixes the problem reported in [this comment](https://github.com/swagger-api/swagger-js/issues/1426#issuecomment-509713866).

The problem is, that streams are serialized by the swagger client to a string (via JSON.stringify), which should not be done. They should be passed on to the `FormData` as is.

### How Has This Been Tested?

I tested uploading files via stream. Before it did not work, after it did.

### Types of changes
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

I'm not sure about the breaking change. I removed the Buffer handling from the code. But it was not working anyway. So I'm not sure if you want to treat this as breaking.

The problem is, that for buffers, a file name has to be set since it cannot be inferred by FormData. (See form-data's [alternative submission methods section](https://github.com/form-data/form-data#alternative-submission-methods)):

> Form-Data can recognize and fetch all the required information from common types of streams (`fs.readStream`, `http.response` and `mikeal`'s request), for some other types of streams you'd need to provide "file"-related information manually

The problem is, that we cannot just set `buffer` or some constant. The server can then not infer the file type since there is no mime type and no file extension for the file.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I'm not sure about code style. The linter does not compalin, but I don't know if you have any additional code style rules.