### PR TITLE
Fix inconsistency between security 'scheme' implementation and OAI3 specs.

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -147,18 +147,13 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'http') {
-          let scheme = schema.scheme;
-          if (scheme) {
-            scheme = scheme.toLowerCase()
-          }
-
-          if (scheme === 'basic') {
+          if ((schema.scheme || "").toLowerCase() === 'basic') {
             const {username, password} = value
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }
 
-          if (scheme === 'bearer') {
+          if ((schema.scheme || "").toLowerCase() === 'bearer') {
             result.headers.Authorization = `Bearer ${value}`
           }
         }

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -147,13 +147,18 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'http') {
-          if (schema.scheme === 'basic') {
+          let scheme = schema.scheme;
+          if (scheme) {
+            scheme = scheme.toLowerCase()
+          }
+
+          if (scheme === 'basic') {
             const {username, password} = value
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }
 
-          if (schema.scheme === 'bearer') {
+          if (scheme === 'bearer') {
             result.headers.Authorization = `Bearer ${value}`
           }
         }

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -147,13 +147,13 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'http') {
-          if ((schema.scheme || "").toLowerCase() === 'basic') {
+          if ((schema.scheme || '').toLowerCase() === 'basic') {
             const {username, password} = value
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }
 
-          if ((schema.scheme || "").toLowerCase() === 'bearer') {
+          if ((schema.scheme || '').toLowerCase() === 'bearer') {
             result.headers.Authorization = `Bearer ${value}`
           }
         }


### PR DESCRIPTION
<!--- Describe your changes in detail -->
I have casted security scheme parsing to lowercase. As it is done in swagger-ui project.

### Motivation and Context
[Specification](https://tools.ietf.org/html/rfc7235#section-2.1) said that scheme should be parsed as case-insensitive.
I've stumbled apon this issue, and found a [lot](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1197) [of](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1171) [issues](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1277) in community with behavior when it is required it to be lower-case to properly work.
Also in [OAI github](https://github.com/OAI/OpenAPI-Specification/issues/1876) and swagger-ui [issue](https://github.com/swagger-api/swagger-ui/issues/5265) and [commit](https://github.com/swagger-api/swagger-ui/commit/3f6e21e3b17a8dd015e45724fbbf471445d7c5c7#diff-1f1ed82014201498a81e975726f5e0d0)

### How Has This Been Tested?
I've only ran various tests defined in package.json

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 