### PR TITLE
URL encode the query parameter name

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -87,9 +87,10 @@ export function query({req, value, parameter}) {
       })
     }
     else {
-      req.query[parameter.name] = {
+      const paramName = encodeURIComponent(parameter.name)
+      req.query[paramName] = {
         value: stylize({
-          key: parameter.name,
+          key: paramName,
           value,
           style: parameter.style || 'form',
           explode: typeof parameter.explode === 'undefined' ? true : parameter.explode,

--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -87,10 +87,10 @@ export function query({req, value, parameter}) {
       })
     }
     else {
-      const paramName = encodeURIComponent(parameter.name)
-      req.query[paramName] = {
+      const encodedParamName = encodeURIComponent(parameter.name)
+      req.query[encodedParamName] = {
         value: stylize({
-          key: paramName,
+          key: encodedParamName,
           value,
           style: parameter.style || 'form',
           explode: typeof parameter.explode === 'undefined' ? true : parameter.explode,

--- a/test/oas3/execute/style-explode/query.js
+++ b/test/oas3/execute/style-explode/query.js
@@ -146,6 +146,83 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - query parameters', () 
       }
     )
 
+    test('should build a query parameter with escaped non-RFC3986 characters in parameter name',
+      () => {
+        // Given
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/users': {
+              get: {
+                operationId: 'myOperation',
+                parameters: [
+                  {
+                    name: 'id[role]',
+                    in: 'query'
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          parameters: {
+            'id[role]': 'admin'
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/users?id%5Brole%5D=admin',
+          credentials: 'same-origin',
+          headers: {}
+        })
+      }
+    )
+
+    test('should build an empty query parameter with escaped non-RFC3986 characters in parameter name',
+      () => {
+        // Given
+        const spec = {
+          openapi: '3.0.0',
+          paths: {
+            '/users': {
+              get: {
+                operationId: 'myOperation',
+                parameters: [
+                  {
+                    name: 'id[role]',
+                    in: 'query',
+                    allowEmptyValue: true
+                  }
+                ]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          parameters: {
+            'id[role]': ''
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/users?id%5Brole%5D=',
+          credentials: 'same-origin',
+          headers: {}
+        })
+      }
+    )
+
     test('should build a query parameter in form/explode format', () => {
       // Given
       const spec = {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
URL encode the query parameter name which can contain restricted characters like square brackets: []


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
JSON:API suggests using query parameters to specify pagination controls like this: `page[offset]=0`. When using OAS 3.0 the square brackets in this parameter name are not being URL encoded, which causes Try It Out attempts that specify these parameters to fail. This was not a problem with Swagger 2.0 files. The URL encoding did happen there.

This has already been reported in swagger-api/swagger-ui#5304


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have written a unit test for this change which is included in the PR.

I have not been able to test this fully integrated into Swagger UI however.  I'm just not clear on how to do that honestly.  Looks like I'm not the only one: #1461. I would be happy to do that testing if someone can explain how.


### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
