### PR TITLE
Support x-tokenName extension in OpenAPI 3.0 specs

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -160,14 +160,14 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
         else if (type === 'oauth2') {
           const token = auth.token || {}
           const tokenName = schema['x-tokenName'] || 'access_token'
-          const oauthToken = token[tokenName]
+          const tokenValue = token[tokenName]
           let tokenType = token.token_type
 
           if (!tokenType || tokenType.toLowerCase() === 'bearer') {
             tokenType = 'Bearer'
           }
 
-          result.headers.Authorization = `${tokenType} ${oauthToken}`
+          result.headers.Authorization = `${tokenType} ${tokenValue}`
         }
       }
     }

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -159,14 +159,15 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
         }
         else if (type === 'oauth2') {
           const token = auth.token || {}
-          const accessToken = token.access_token
+          const tokenName = schema['x-tokenName'] || 'access_token'
+          const oauthToken = token[tokenName]
           let tokenType = token.token_type
 
           if (!tokenType || tokenType.toLowerCase() === 'bearer') {
             tokenType = 'Bearer'
           }
 
-          result.headers.Authorization = `${tokenType} ${accessToken}`
+          result.headers.Authorization = `${tokenType} ${oauthToken}`
         }
       }
     }

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -596,4 +596,50 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
       }
     )
   })
+  test('should use a custom oAuth token name if defined', () => {
+    const spec = {
+      openapi: '3.0.0',
+      components: {
+        securitySchemes: {
+          myOAuth2Implicit: {
+            type: 'oauth2',
+            'x-tokenName': 'id_token'
+          }
+        }
+      },
+      paths: {
+        '/': {
+          get: {
+            operationId: 'myOperation',
+            security: [
+              {myOAuth2Implicit: []}
+            ]
+          }
+        }
+      }
+    }
+
+    const req = buildRequest({
+      spec,
+      operationId: 'myOperation',
+      securities: {
+        authorized: {
+          myOAuth2Implicit: {
+            token: {
+              access_token: 'otherTokenValue',
+              id_token: 'myTokenValue'
+            }
+          }
+        }
+      }
+    })
+    expect(req).toEqual({
+      method: 'GET',
+      url: '/',
+      credentials: 'same-origin',
+      headers: {
+        Authorization: 'Bearer myTokenValue'
+      },
+    })
+  })
 })


### PR DESCRIPTION

### Description
Enables using `x-tokenName` in OpenAPI 3.0 OAuth security schemes in order to select a different field from the token JSON for use as the bearer token.

### Motivation and Context
Fixes swagger-api/swagger-ui#4084.

### How Has This Been Tested?
I've added a test case for it that provides both the default `access_token` and a non-default `id_token`, and confirms the latter is used.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
    - Something about my environment doesn't play well with most of the tests, causing failures via timeout, but the new and all existing `test/oas3/execute` tests pass.
