### PR TITLE
making baseUrl method available for consumption

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import Http, {makeHttp, serializeRes, serializeHeaders} from './http'
 import Resolver, {clearCache} from './resolver'
 import resolveSubtree from './subtree-resolver'
 import {makeApisTagOperation} from './interfaces'
-import {execute, buildRequest} from './execute'
+import {execute, buildRequest, baseUrl} from './execute'
 import {opId} from './helpers'
 
 Swagger.http = Http
@@ -20,6 +20,7 @@ Swagger.clearCache = clearCache
 Swagger.makeApisTagOperation = makeApisTagOperation
 Swagger.buildRequest = buildRequest
 Swagger.helpers = {opId}
+Swagger.baseUrl = baseUrl
 
 function Swagger(url, opts = {}) {
   // Allow url as a separate argument

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ Swagger.clearCache = clearCache
 Swagger.makeApisTagOperation = makeApisTagOperation
 Swagger.buildRequest = buildRequest
 Swagger.helpers = {opId}
-Swagger.baseUrl = baseUrl
+Swagger.getBaseUrl = baseUrl
 
 function Swagger(url, opts = {}) {
   // Allow url as a separate argument

--- a/test/webpack-bundle/index.js
+++ b/test/webpack-bundle/index.js
@@ -17,6 +17,7 @@ describe('webpack build', () => {
     expect(Swagger.makeApisTagOperation).toBeInstanceOf(Function)
     expect(Swagger.buildRequest).toBeInstanceOf(Function)
     expect(Object.keys(Swagger.helpers)).toContain('opId')
+    expect(Swagger.getBaseUrl).toBeInstanceOf(Function)
   })
 
 


### PR DESCRIPTION
Exposing **baseUrl** method

### Description
Making **baseUrl** method available for consumption.


### Motivation and Context
We have a requirement where our users desire route URLs on **swagger-ui** to have a copy-to-clipboard functionality. To do so, we need the output of the **baseUrl** method to be appended with a specific path sub URL to obtain the absolute URL for a route. Currently, the **baseUrl** method is not exposed for consumption. 
We are aware of the **buildRequest** method. Unfortunately, it does not work without the mandatory route parameters. However, the functionality that we are looking for just requires fetching the route path without appending the parameter values. 



### How Has This Been Tested?
The baseUrl method has been tested for in the existing test cases. As part of this change, the method has been exposed. Hence, it is not expected to break any existing functionality.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
**Note**: existing test cases already cover the validations
