### PR TITLE
Basic auth: Support empty passwords

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -148,7 +148,8 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
         }
         else if (type === 'http') {
           if (schema.scheme === 'basic') {
-            const {username, password} = value
+            const username = value.username
+            const password = typeof value.password === "string" || value.password instanceof String ? value.password : ""
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -148,8 +148,8 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
         }
         else if (type === 'http') {
           if (schema.scheme === 'basic') {
-            const username = value.username
-            const password = typeof value.password === "string" || value.password instanceof String ? value.password : ""
+            const username = value.username || ''
+            const password = value.password || ''
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }

--- a/src/execute/swagger2/build-request.js
+++ b/src/execute/swagger2/build-request.js
@@ -88,8 +88,8 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
             result.headers.authorization = value.header
           }
           else {
-            const username = value.username
-            const password = typeof value.password === "string" || value.password instanceof String ? value.password : ""
+            const username = value.username || ''
+            const password = value.password || ''
             value.base64 = btoa(`${username}:${password}`)
             result.headers.authorization = `Basic ${value.base64}`
           }

--- a/src/execute/swagger2/build-request.js
+++ b/src/execute/swagger2/build-request.js
@@ -88,8 +88,9 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
             result.headers.authorization = value.header
           }
           else {
+            const username = value.username
             const password = typeof value.password === "string" || value.password instanceof String ? value.password : ""
-            value.base64 = btoa(`${value.username}:${password}`)
+            value.base64 = btoa(`${username}:${password}`)
             result.headers.authorization = `Basic ${value.base64}`
           }
         }

--- a/src/execute/swagger2/build-request.js
+++ b/src/execute/swagger2/build-request.js
@@ -88,7 +88,8 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
             result.headers.authorization = value.header
           }
           else {
-            value.base64 = btoa(`${value.username}:${value.password}`)
+            const password = typeof value.password === "string" || value.password instanceof String ? value.password : ""
+            value.base64 = btoa(`${value.username}:${password}`)
             result.headers.authorization = `Basic ${value.base64}`
           }
         }

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -157,7 +157,10 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
             paths: {
               '/': {
                 get: {
-                  operationId: 'myOperation'
+                  operationId: 'myOperation',
+                  security: [{
+                    myBasicAuth: []
+                  }],
                 }
               }
             }

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -140,6 +140,53 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
           })
         }
       )
+      test(
+        'should allow empty password without casting undefined to string',
+        () => {
+          const spec = {
+            openapi: '3.0.0',
+            components: {
+              securitySchemes: {
+                myBasicAuth: {
+                  type: 'http',
+                  in: 'header',
+                  scheme: 'basic'
+                }
+              }
+            },
+            paths: {
+              '/': {
+                get: {
+                  operationId: 'myOperation'
+                }
+              }
+            }
+          }
+
+          // when
+          const req = buildRequest({
+            spec,
+            operationId: 'myOperation',
+            securities: {
+              authorized: {
+                myBasicAuth: {
+                  username: 'somebody',
+                  password: undefined
+                }
+              }
+            }
+          })
+
+          expect(req).toEqual({
+            method: 'GET',
+            url: '/',
+            credentials: 'same-origin',
+            headers: {
+              Authorization: `Basic ${btoa('somebody:')}`
+            },
+          })
+        }
+      )
     })
     describe('Bearer', () => {
       test('should add token to the Authorization header', () => {

--- a/test/swagger2/execute/apply-securities.js
+++ b/test/swagger2/execute/apply-securities.js
@@ -123,6 +123,47 @@ describe('swagger2 - execute - applySecurities', () => {
     })
   })
 
+  test('should allow empty password without casting undefined to string', () => {
+    const spec = {
+      host: 'swagger.io',
+      basePath: '/v1',
+      security: [{authMe: []}],
+      paths: {
+        '/one': {
+          get: {
+            operationId: 'getMe',
+            security: [{authMe: []}]
+          }
+        }
+      },
+      securityDefinitions: {
+        authMe: {
+          type: 'basic'
+        }
+      }
+    }
+
+    const request = {
+      url: 'http://swagger.io/v1/one',
+      method: 'GET',
+      query: {}
+    }
+    const securities = {
+      authorized: {
+        authMe: {
+          username: 'foo',
+          password: undefined
+        }
+      }
+    }
+
+    const applySecurity = applySecurities({request, securities, operation: spec.paths['/one'].get, spec})
+
+    expect(applySecurity.headers).toEqual({
+      authorization: 'Basic Zm9vOg=='
+    })
+  })
+
   test('should be able to apply multiple auths', () => {
     const spec = {
       host: 'swagger.io',


### PR DESCRIPTION
### Description

Don't cast non-string passwords to string (e.g. undefined to "undefined").

I'm not sure if `value.password instanceof String` is needed or if a test for plain strings would be sufficient. Or should it explicitly test for `undefined`? Because people expect whatever they pass to be converted to string implicitly, except the blank password case?

Should the username also be checked?

### Motivation and Context

Empty passwords for basic HTTP authorization is a valid use case (see https://github.com/swagger-api/swagger-ui/issues/5410) and I opened a PR to allow this in the frontend (https://github.com/swagger-api/swagger-ui/pull/5812), but it turned out that the swagger-client casts the undefined `password` to a string, leading to an incorrect base64-encoded password.

- `"root:undefined"` → `"cm9vdDp1bmRlZmluZWQ="` ❌
- `"root:"` → `"cm9vdDo="` ✔

### How Has This Been Tested?

```
webpack --config webpack\test_webpack_build.babel.js
jest --runInBand -t "swagger2 - execute - applySecurities"
jest --runInBand -t "Authorization - OpenAPI Specification 3.0"
```

### Types of changes

- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new ~and existing~ tests passed.
