### PR TITLE
Parse OAS3 HTTP-Auth schemes case-insensitively

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -147,14 +147,15 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'http') {
-          if (schema.scheme === 'basic') {
+          const scheme = schema.scheme && schema.scheme.toLowerCase()
+          if (scheme === 'basic') {
             const username = value.username || ''
             const password = value.password || ''
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }
 
-          if (schema.scheme === 'bearer') {
+          if (scheme === 'bearer') {
             result.headers.Authorization = `Bearer ${value}`
           }
         }


### PR DESCRIPTION
According to the authors of the OAI spec (https://github.com/OAI/OpenAPI-Specification/pull/1880#issuecomment-584730191), schemes are case-insensitive. Even if they were not, the current checks against lowercase versions of scheme names do not match the IANA registry's canonical versions (https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml#table-authschemes), which are "Basic" and "Bearer".

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

If users are overly-adhering to the spec, they may copy-paste HTTP auth scheme names directly from the IANA registry. If they do, the request builder will omit the necessary headers, because it performs a case-sensitive comparison of the scheme name to a lower-case version.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?

I have not yet tested this change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
