### PR TITLE
test(resolver): remove explicit return from generated describe block

### DIFF
--- a/test/resolver/index.js
+++ b/test/resolver/index.js
@@ -61,7 +61,7 @@ testDocuments.forEach((doc) => {
 
           afterAll(nock.restore)
 
-          return assertCaseExpectations(
+          assertCaseExpectations(
             currentCase,
             async () => getValueForAction(currentCase.action)
           )


### PR DESCRIPTION
Explicit return was returning a Promise which caused jest to think
that we rely on describe block resolving the Promise before running
tests.

Ref #1529

### Motivation and Context

Warnings inside tests


### How Has This Been Tested?
By running tests

```sh
(node:4106) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  test/resolver/index.js
 PASS  test/specmap/refs.js
 PASS  test/client.js
 PASS  test/specmap/index.js
 PASS  test/index.js
(node:4106) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'ok' of undefined
(node:4106) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:4106) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
 PASS  test/execute/main.js
 PASS  test/resolver.js
 PASS  test/http.js
 PASS  test/oas3/execute/main.js
 PASS  test/oas3/execute/style-explode/query.js
 PASS  test/specmap/all-of.js
 PASS  test/oas3/execute/style-explode/path.js
 PASS  test/oas3/client.js
 PASS  test/subtree-resolver.js
 PASS  test/oas3/execute/style-explode/cookie.js
 PASS  test/helpers.js
 PASS  test/webpack-bundle/index.js
 PASS  test/swagger2/execute/apply-securities.js
 PASS  test/oas3/execute/style-explode/header.js
 PASS  test/index-authorizations.js
 PASS  test/interfaces.js
 PASS  test/oas3/execute/authorization.js
 PASS  test/execute/baseurl.js
 PASS  test/bugs/ui-4228.js
 PASS  test/bugs/ui-4466.js
 PASS  test/specmap/properties.js
 PASS  test/swagger2/execute/build-request.js
 PASS  test/specmap/parameters.js
 PASS  test/specmap/complex.js
 PASS  test/bugs/editor-1661.js
 PASS  test/bugs/ui-4924.js
 PASS  test/specmap/live.js
 PASS  test/oas3/execute/style-serializer.js
 PASS  test/specmap/context-tree.js
 PASS  test/bugs/ui-4071.js
 PASS  test/specmap/lib.js
 PASS  test/oas3/helpers.js

Test Suites: 37 passed, 37 total
Tests:       30 skipped, 461 passed, 491 total
Snapshots:   0 total
Time:        9.435s
Ran all test suites.

Process finished with exit code 0
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
