### PR TITLE
Form data monkey patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,14 +1701,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@tim-lai/isomorphic-form-data": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tim-lai/isomorphic-form-data/-/isomorphic-form-data-1.0.0.tgz",
-      "integrity": "sha512-ukWANS+8w3NCj4Qmnc4zo0XWcoqnDAiqaBXVdh/z6CPtOL+z6I13H3AKOdGzeAaPCeXRL3sPqaPgrSqEgtF8Xg==",
-      "requires": {
-        "formdata-node": "^2.1.1"
-      }
-    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -2559,8 +2551,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -3733,7 +3724,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4491,8 +4481,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -6178,24 +6167,14 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
-    "formdata-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-2.1.1.tgz",
-      "integrity": "sha512-XfwCd3Edkt2N81Uh1G72kakbavjEOhRuGdiOV6Ekba/DrFrWFWgkjN4dZn5EPNbjmg+QC+i0ckeYukAbuTRHjw==",
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
-        "@babel/runtime": "7.8.4",
-        "mime-types": "2.1.26",
-        "nanoid": "2.1.11"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-          "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -8214,6 +8193,14 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
+    },
+    "isomorphic-form-data": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
+      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
+      "requires": {
+        "form-data": "^2.3.2"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -10299,11 +10286,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
-    },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@kyleshockey/object-assign-deep": "^0.4.0",
-    "@tim-lai/isomorphic-form-data": "^1.0.0",
     "btoa": "1.1.2",
     "buffer": "^5.1.0",
     "cookie": "^0.3.1",
@@ -106,6 +105,7 @@
     "deep-extend": "^0.5.1",
     "encode-3986": "^1.0.0",
     "fast-json-patch": "~2.1.0",
+    "isomorphic-form-data": "^2.0.0",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.14",
     "qs": "^6.3.0",

--- a/src/http.js
+++ b/src/http.js
@@ -3,7 +3,7 @@ import qs from 'qs'
 import jsYaml from 'js-yaml'
 import isString from 'lodash/isString'
 import isFunction from 'lodash/isFunction'
-import FormData from '@tim-lai/isomorphic-form-data'
+import FormData from './internal/form-data-monkey-patch'
 
 // For testing
 export const self = {

--- a/src/internal/form-data-monkey-patch.js
+++ b/src/internal/form-data-monkey-patch.js
@@ -1,0 +1,74 @@
+import isFunction from 'lodash/isFunction'
+import IsomorphicFormData from 'isomorphic-form-data'
+
+// patches FormData type by mutating it.
+// patch :: FormData -> PatchedFormData
+export const patch = (FormData) => {
+  const createEntry = (field, value) => ({name: field, value})
+  /** We return original type if prototype already contains one of methods we're trying to patch.
+   * Reasoning: if one of the methods already exists, it would access data in other
+   * property than our `_entryList`. That could potentially create nasty
+   * hardly detectable bugs if `form-data` library implements only couple of
+   * methods that it misses, instead of implementing all of them.
+   * Current solution will fail the tests to let us know that form-data library
+   * already implements some of the methods that we try to monkey-patch, and our
+   * monkey-patch code should then compensate the library changes easily.
+   */
+  if (
+    isFunction(FormData.prototype.set)
+    || isFunction(FormData.prototype.get)
+    || isFunction(FormData.prototype.getAll)
+    || isFunction(FormData.prototype.has)
+  ) {
+    return FormData
+  }
+  class PatchedFormData extends FormData {
+    constructor(form) {
+      super(form)
+      this._entryList = []
+    }
+
+    append(field, value, options) {
+      this._entryList.push(createEntry(field, value))
+      return super.append(field, value, options)
+    }
+
+    set(field, value) {
+      const newEntry = createEntry(field, value)
+
+      this._entryList = this._entryList.filter((entry) => {
+        return entry.name !== field
+      })
+
+      this._entryList.push(newEntry)
+    }
+
+    get(field) {
+      const foundEntry = this._entryList.find((entry) => {
+        return entry.name === field
+      })
+
+      return foundEntry === undefined ? null : foundEntry
+    }
+
+    getAll(field) {
+      return this._entryList
+        .filter((entry) => {
+          return entry.name === field
+        })
+        .map((entry) => {
+          return entry.value
+        })
+    }
+
+    has(field) {
+      return this._entryList.some((entry) => {
+        return entry.name === field
+      })
+    }
+  }
+
+  return PatchedFormData
+}
+
+export default patch(IsomorphicFormData)

--- a/test/execute/main.js
+++ b/test/execute/main.js
@@ -1,4 +1,4 @@
-import FormData from '@tim-lai/isomorphic-form-data'
+import FormData from '../../src/internal/form-data-monkey-patch'
 import {execute, buildRequest, baseUrl, self as stubs} from '../../src/execute'
 import {normalizeSwagger} from '../../src/helpers'
 

--- a/test/http-multipart.js
+++ b/test/http-multipart.js
@@ -1,5 +1,5 @@
-import FormData from '@tim-lai/isomorphic-form-data'
 import fetchMock from 'fetch-mock'
+import FormData from '../src/internal/form-data-monkey-patch'
 import {buildRequest} from '../src/execute'
 import sampleMultipartOpenApi2 from './data/sample-multipart-oas2'
 import sampleMultipartOpenApi3 from './data/sample-multipart-oas3'
@@ -52,16 +52,15 @@ describe('buildRequest - openapi 2.0', () => {
     test.skip('should (Live) POST multipart-formdata with entry item entries', () => {
       return fetch('http://localhost:3300/api/v1/formdata', { // eslint-disable-line no-undef
         method: 'POST',
-        body: req.body.stream, // per formdata-node docs
-        headers: req.body.headers // per formdata-node docs
+        body: req.body
       })
         .then((res) => {
           return res.json()
         })
         .then((json) => {
-          expect(json.email.length).toEqual(2)
-          expect(json.email[0]).toEqual('person1')
-          expect(json.email[1]).toEqual('person2')
+          expect(json.data.email.length).toEqual(2)
+          expect(json.data.email[0]).toEqual('person1')
+          expect(json.data.email[1]).toEqual('person2')
         })
     })
 
@@ -84,8 +83,7 @@ describe('buildRequest - openapi 2.0', () => {
 
       return fetch('http://localhost:3300/api/v1/formdata', { // eslint-disable-line no-undef
         method: 'POST',
-        body: req.body.stream, // per formdata-node docs
-        headers: req.body.headers // per formdata-node docs
+        body: req.body,
       })
         .then((res) => {
           return res.json()
@@ -94,10 +92,10 @@ describe('buildRequest - openapi 2.0', () => {
           expect(json.data.email.length).toEqual(2)
           expect(json.data.email[0]).toEqual('person1')
           expect(json.data.email[1]).toEqual('person2')
-          // duck typing that fetch received a formdata-node Stream instead of plain object
+          // duck typing that fetch received a FormData instance instead of plain object
           const lastOptions = fetchMock.lastOptions()
           expect(lastOptions.body.readable).toEqual(true)
-          expect(lastOptions.body._readableState).toBeDefined()
+          // expect(lastOptions.body._streams).toBeDefined()
         })
     })
   })
@@ -139,16 +137,15 @@ describe('buildRequest - openapi 3.0', () => {
     test.skip('should (Live) POST multipart-formdata with entry item entries', () => {
       return fetch('http://localhost:3300/api/v1/formdata', { // eslint-disable-line no-undef
         method: 'POST',
-        body: req.body.stream, // per formdata-node docs
-        headers: req.body.headers // per formdata-node docs
+        body: req.body
       })
       .then((res) => {
         return res.json()
       })
       .then((json) => {
-        expect(json.email.length).toEqual(2)
-        expect(json.email[0]).toEqual('person1')
-        expect(json.email[1]).toEqual('person2')
+        expect(json.data.email.length).toEqual(2)
+        expect(json.data.email[0]).toEqual('person1')
+        expect(json.data.email[1]).toEqual('person2')
       })
     })
 
@@ -171,8 +168,7 @@ describe('buildRequest - openapi 3.0', () => {
 
       return fetch('http://localhost:3300/api/v1/formdata', { // eslint-disable-line no-undef
         method: 'POST',
-        body: req.body.stream, // per formdata-node docs
-        headers: req.body.headers // per formdata-node docs
+        body: req.body,
       })
         .then((res) => {
           return res.json()
@@ -181,10 +177,10 @@ describe('buildRequest - openapi 3.0', () => {
           expect(json.data.email.length).toEqual(2)
           expect(json.data.email[0]).toEqual('person1')
           expect(json.data.email[1]).toEqual('person2')
-          // duck typing that fetch received a formdata-node Stream instead of plain object
+          // duck typing that fetch received a FormData instance instead of plain object
           const lastOptions = fetchMock.lastOptions()
           expect(lastOptions.body.readable).toEqual(true)
-          expect(lastOptions.body._readableState).toBeDefined()
+          // expect(lastOptions.body._streams).toBeDefined()
         })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Replace `formdata-node` with an internal patch of `form-data`. Update tests to reflect dependency change.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

commit  b35d36b introduced a dependency change from `form-data` to `formdata-node`. The reason was that `form-data` is missing matching methods for FormData. However, `formdata-node` also required Node 10, which is technically a breaking semver change for `swagger-client`, but not noted as a breaking semver change in the release v3.10.3.

We are choosing to maintain `swagger-client` in a non-breaking semver state. As a result, we are applying an internal patch to `form-data` and removing `formdata-node`.

Note: Node 8 has been EOL for some time now, and remains technically unsupported by `swagger-client`.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests updated to reflect change between `formdata-node` and `form-data` + patch

### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
