### PR TITLE
fix: oas2 collectionFormat when not 'multi'

### DIFF
--- a/test/data/sample-multipart-oas2.js
+++ b/test/data/sample-multipart-oas2.js
@@ -56,9 +56,59 @@ export default {
           {
             in: 'formData',
             name: 'email[]',
-            description: 'The list of emails.',
+            description: 'The list of emails as multi.',
             type: 'array',
             collectionFormat: 'multi',
+            items: {
+              type: 'string'
+            }
+          },
+          {
+            in: 'formData',
+            name: 'none[]',
+            description: 'The list of emails as none.',
+            type: 'array',
+            collectionFormat: 'none',
+            items: {
+              type: 'string'
+            }
+          },
+          {
+            in: 'formData',
+            name: 'csv[]',
+            description: 'The list of emails as csv.',
+            type: 'array',
+            collectionFormat: 'csv',
+            items: {
+              type: 'string'
+            }
+          },
+          {
+            in: 'formData',
+            name: 'tsv[]',
+            description: 'The list of emails as tsv.',
+            type: 'array',
+            collectionFormat: 'tsv',
+            items: {
+              type: 'string'
+            }
+          },
+          {
+            in: 'formData',
+            name: 'ssv[]',
+            description: 'The list of emails as ssv.',
+            type: 'array',
+            collectionFormat: 'ssv',
+            items: {
+              type: 'string'
+            }
+          },
+          {
+            in: 'formData',
+            name: 'pipes[]',
+            description: 'The list of emails as pipes.',
+            type: 'array',
+            collectionFormat: 'pipes',
             items: {
               type: 'string'
             }

--- a/test/http-multipart.js
+++ b/test/http-multipart.js
@@ -23,11 +23,16 @@ describe('buildRequest - openapi 2.0', () => {
       parameters: {
         'formData.hhlContent:sort': 'id',
         'formData.hhlContent:order': 'desc',
-        'formData.email[]': ["person1", "person2"] // eslint-disable-line quotes
+        'formData.email[]': ["person1", "person2"], // eslint-disable-line quotes
+        'formData.none[]': ['foo', 'bar'],
+        'formData.csv[]': ['foo', 'bar'],
+        'formData.tsv[]': ['foo', 'bar'],
+        'formData.ssv[]': ['foo', 'bar'],
+        'formData.pipes[]': ['foo', 'bar'],
       }
     })
 
-    test('should return FormData entry list and entry item entries (in order)', () => {
+    test('should return appropriate response media type', () => {
       expect(req).toMatchObject({
         method: 'POST',
         url: '/api/v1/land/content/ViewOfAuthOwner',
@@ -36,12 +41,48 @@ describe('buildRequest - openapi 2.0', () => {
           'Content-Type': 'multipart/form-data'
         },
       })
+    })
+
+    test('should build request body as FormData', () => {
       const validateFormDataInstance = req.body instanceof FormData
       expect(validateFormDataInstance).toEqual(true)
+    })
+
+    test('should return "collectionFormat: multi" as FormData entry list and entry item entries (in order)', () => {
       const itemEntries = req.body.getAll('email[]')
       expect(itemEntries.length).toEqual(2)
       expect(itemEntries[0]).toEqual('person1')
       expect(itemEntries[1]).toEqual('person2')
+    })
+
+    test('should return "collectionFormat: none" as single FormData entry in csv format', () => {
+      const itemEntriesNone = req.body.getAll('none[]')
+      expect(itemEntriesNone.length).toEqual(1)
+      expect(itemEntriesNone[0]).toEqual('foo,bar')
+    })
+
+    test('should return "collectionFormat: csv" as single FormData entry in csv format', () => {
+      const itemEntriesCsv = req.body.getAll('csv[]')
+      expect(itemEntriesCsv.length).toEqual(1)
+      expect(itemEntriesCsv[0]).toEqual('foo,bar')
+    })
+
+    test('should return "collectionFormat: tsv" as single FormData entry in tsv format', () => {
+      const itemEntriesTsv = req.body.getAll('tsv[]')
+      expect(itemEntriesTsv.length).toEqual(1)
+      expect(itemEntriesTsv[0]).toEqual('foo%09bar')
+    })
+
+    test('should return "collectionFormat: ssv" as single FormData entry in ssv format', () => {
+      const itemEntriesSsv = req.body.getAll('ssv[]')
+      expect(itemEntriesSsv.length).toEqual(1)
+      expect(itemEntriesSsv[0]).toEqual('foo%20bar')
+    })
+
+    test('should return "collectionFormat: pipes" as single FormData entry in pipes format', () => {
+      const itemEntriesPipes = req.body.getAll('pipes[]')
+      expect(itemEntriesPipes.length).toEqual(1)
+      expect(itemEntriesPipes[0]).toEqual('foo|bar')
     })
 
     /**
@@ -113,7 +154,7 @@ describe('buildRequest - openapi 3.0', () => {
       }
     })
 
-    test('should return FormData entry list and item entries (in order)', () => {
+    test('should return appropriate response media type', () => {
       expect(req).toMatchObject({
         method: 'POST',
         url: '/api/v1/land/content/ViewOfAuthOwner',
@@ -122,13 +163,20 @@ describe('buildRequest - openapi 3.0', () => {
           'Content-Type': 'multipart/form-data'
         },
       })
+    })
+
+    test('should build request body as FormData', () => {
       const validateFormDataInstance = req.body instanceof FormData
       expect(validateFormDataInstance).toEqual(true)
+    })
+
+    test('should return FormData entry list and item entries (in order)', () => {
       const itemEntries = req.body.getAll('email[]')
       expect(itemEntries.length).toEqual(2)
       expect(itemEntries[0]).toEqual('person1')
       expect(itemEntries[1]).toEqual('person2')
     })
+
     /**
      * Dev test only: assumes local server exists for POST
      * Expect server response format: { message: 'ok', data: returnData }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Fix OAS2 collectionFormat handling for non-multipart cases
```
collectionFormat: csv
collectionFormat: tsv
collectionFormat: ssv
collectionFormat: pipes
```


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Previous OAS2 multipart fixes did not cover non-multi cases.


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
