### PR TITLE
fix: Buffer deprecation warning

### DIFF
--- a/test/http.js
+++ b/test/http.js
@@ -494,13 +494,13 @@ describe('http', () => {
     })
 
     test('should return true for browser Buffer type', () => {
-      expect(isFile(new Buffer([]))).toEqual(true)
+      expect(isFile(Buffer.from([]))).toEqual(true)
     })
     test('should return true for browser Buffer type and browser user agent', () => {
-      expect(isFile(new Buffer([]), mockBrowserNavigator)).toEqual(true)
+      expect(isFile(Buffer.from([]), mockBrowserNavigator)).toEqual(true)
     })
     test('should return false for browser Buffer type and React Native user agent', () => {
-      expect(isFile(new Buffer([]), mockReactNativeNavigator)).toEqual(false)
+      expect(isFile(Buffer.from([]), mockReactNativeNavigator)).toEqual(false)
     })
 
     test('should return false for React Native-like file object', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Replace `new Buffer()` with `Buffer.from()`

ref: https://nodejs.org/fa/docs/guides/buffer-constructor-deprecation/


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
PR #1500 introduced new tests that used `new Buffer()`, which was not captured in the review.

> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

deprecation warnings no longer present in test result

### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
