### PR TITLE
fix(scheme): make scheme comparison case insensitive

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -120,14 +120,14 @@ export function applySecurities({request, securities = {}, operation = {}, spec}
           }
         }
         else if (type === 'http') {
-          if (schema.scheme === 'basic') {
+          if (/^basic$/i.test(schema.scheme)) {
             const username = value.username || ''
             const password = value.password || ''
             const encoded = btoa(`${username}:${password}`)
             result.headers.Authorization = `Basic ${encoded}`
           }
 
-          if (schema.scheme === 'bearer') {
+          if (/^bearer$/i.test(schema.scheme)) {
             result.headers.Authorization = `Bearer ${value}`
           }
         }

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -95,6 +95,54 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
           },
         })
       })
+
+      test('should consider scheme to be case insensitive', () => {
+        const spec = {
+          openapi: '3.0.0',
+          components: {
+            securitySchemes: {
+              myBasicAuth: {
+                type: 'http',
+                in: 'header',
+                scheme: 'Basic'
+              }
+            }
+          },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                security: [{
+                  myBasicAuth: []
+                }],
+              }
+            }
+          }
+        }
+
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          securities: {
+            authorized: {
+              myBasicAuth: {
+                username: 'somebody',
+                password: 'goodpass'
+              }
+            }
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {
+            Authorization: `Basic ${btoa('somebody:goodpass')}`
+          },
+        })
+      })
+
       test(
         'should not add credentials to operations without the security requirement',
         () => {
@@ -238,6 +286,54 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
           },
         })
       })
+
+      test('should consider scheme to be case insensitive', () => {
+        const spec = {
+          openapi: '3.0.0',
+          components: {
+            securitySchemes: {
+              myBearerAuth: {
+                type: 'http',
+                in: 'header',
+                scheme: 'Bearer'
+              }
+            }
+          },
+          paths: {
+            '/': {
+              get: {
+                operationId: 'myOperation',
+                security: [{
+                  myBearerAuth: []
+                }]
+              }
+            }
+          }
+        }
+
+        // when
+        const req = buildRequest({
+          spec,
+          operationId: 'myOperation',
+          securities: {
+            authorized: {
+              myBearerAuth: {
+                value: 'Asdf1234'
+              }
+            }
+          }
+        })
+
+        expect(req).toEqual({
+          method: 'GET',
+          url: '/',
+          credentials: 'same-origin',
+          headers: {
+            Authorization: 'Bearer Asdf1234'
+          },
+        })
+      })
+
       test(
         'should not add credentials to operations without the security requirement',
         () => {

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -293,7 +293,6 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
             securitySchemes: {
               myBearerAuth: {
                 type: 'http',
-                in: 'header',
                 scheme: 'Bearer'
               }
             }

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -103,7 +103,6 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
             securitySchemes: {
               myBasicAuth: {
                 type: 'http',
-                in: 'header',
                 scheme: 'Basic'
               }
             }


### PR DESCRIPTION
As per RFC7235 auth scheme is case insensitive.

2.1. Challenge and Response

HTTP provides a simple challenge-response authentication framework
that can be used by a server to challenge a client request and by a
client to provide authentication information. It uses a case-
insensitive token as a means to identify the authentication scheme,
followed by additional information necessary for achieving.

https://tools.ietf.org/html/rfc7235#section-2.1

Refs #1531, #1473
Refs https://github.com/OAI/OpenAPI-Specification/issues/1876
Refs https://github.com/swagger-api/swagger-ui/issues/5965

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
