### PR TITLE
refactor: replace custom build of object-assign-deep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3482,11 +3482,6 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@kyleshockey/object-assign-deep": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
-      "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
-    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -8330,12 +8325,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8350,17 +8347,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8477,7 +8477,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8489,6 +8490,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8503,6 +8505,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8510,12 +8513,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8534,6 +8539,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -8623,7 +8629,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8635,6 +8642,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8748,6 +8756,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.5.5",
-    "@kyleshockey/object-assign-deep": "^0.4.0",
     "btoa": "1.1.2",
     "buffer": "^5.1.0",
     "cookie": "^0.3.1",

--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -1,7 +1,7 @@
 import * as jsonPatch from 'fast-json-patch'
 import regenerator from '@babel/runtime-corejs2/regenerator'
 import deepExtend from 'deep-extend'
-import deepAssign from '@kyleshockey/object-assign-deep'
+import cloneDeep from 'lodash/cloneDeep'
 
 export default {
   add,
@@ -67,7 +67,7 @@ function applyPatch(obj, patch, opts) {
             //
             // we also deeply assign here, since we aren't in control of
             // how deepExtend affects existing nested objects
-            currentObj = deepExtend(deepAssign({}, currentObj), propVal)
+            currentObj = deepExtend(cloneDeep(currentObj), propVal)
             break
           }
           else {


### PR DESCRIPTION
Function was replaced by standard lodash.cloneDeep function.

<!--- Provide a general summary of your changes in the Title above -->

### Description

As we used custom build of object-assign-deep of unknown version which was exclusively use for deep cloning of recursive structures, it was replaced by standard lodash.cloneDeep function.


### Motivation and Context

Remove dep that we don't have control over.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
