### PR TITLE
ci(GA): runs code coverage with thresholds checks

### DIFF
--- a/config/jest/jest.unit.coverage.config.js
+++ b/config/jest/jest.unit.coverage.config.js
@@ -1,0 +1,15 @@
+const unitConfig = require('./jest.unit.config');
+
+module.exports = {
+  ...unitConfig,
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.js'],
+  coverageThreshold: {
+    './src/': {
+      branches: 87,
+      functions: 91,
+      lines: 90,
+      statements: 90,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     "build:bundlesize": "bundlesize --config ./bundlesize.config.json",
     "lint": "eslint src/ test/",
     "lint:fix": "npm run lint -- --fix",
-    "test": "run-s test:unit test:bundle",
-    "test:unit": "jest  --runInBand --config ./config/jest/jest.unit.config.js ",
-    "test:unit:watch": "jest --watch --config ./config/jest/jest.unit.config.js",
+    "test": "run-s test:unit:coverage test:bundle",
+    "test:unit": "jest --runInBand --config ./config/jest/jest.unit.config.js",
+    "test:unit:coverage": "jest --runInBand --config ./config/jest/jest.unit.coverage.config.js",
+    "test:unit:watch": "jest --runInBand --watch --config ./config/jest/jest.unit.config.js",
     "test:bundle": "run-s test:bundle:browser test:bundle:node",
     "test:bundle:browser": "npm run build:browser && jest --config ./config/jest/jest.bundle-browser.config.js",
     "test:bundle:node": "npm run build:node && jest --config ./config/jest/jest.bundle-node.config.js",
@@ -47,7 +48,7 @@
     "security-audit": "run-s -sc security-audit:all security-audit:prod",
     "security-audit:prod": "npm audit --production --audit-level=low",
     "security-audit:all": "npm audit --audit-level=moderate",
-    "clean": "rimraf ./browser ./dist ./.deps_check"
+    "clean": "rimraf ./browser ./dist ./.deps_check ./coverage"
   },
   "keywords": [
     "oai",


### PR DESCRIPTION
### Motivation and Context

In order to fail the CI if somebody introduces code without tests, we'll use jest coverage in order to achieve that.