### PR TITLE
build(release-it): configure proper release commit msg

### DIFF
--- a/release/.release-it.json
+++ b/release/.release-it.json
@@ -9,7 +9,7 @@
   "git": {
     "requireUpstream": false,
     "changelog": "./release/get-changelog.sh",
-    "commitMessage": "release: v${version}",
+    "commitMessage": "chore(release): cut the v${version} release",
     "tagName": "v${version}",
     "push": false
   },


### PR DESCRIPTION
### Motivation and Context

release-it was generating commit message not compliant with conventional commit specification. This PR fixes it.

### How Has This Been Tested?

Will be tested in next release

