### PR TITLE
build: remove regenerator-runtime from production deps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,7 @@
             "targets": {
               "node": "8"
             },
-            "forceAllTransforms": true,
+            "forceAllTransforms": false,
             "ignoreBrowserslistConfig": true
           }
         ]
@@ -40,27 +40,6 @@
         "@babel/proposal-class-properties",
         "@babel/proposal-object-rest-spread",
         "lodash"
-      ]
-    },
-    "node": {
-      "presets": [
-        [
-          "@babel/preset-env",
-          {
-            "debug": false,
-            "targets": {
-              "node": "8"
-            },
-            "useBuiltIns": "entry",
-            "corejs": 3,
-            "ignoreBrowserslistConfig": true
-          }
-        ]
-      ],
-      "plugins": [
-        "@babel/proposal-class-properties",
-        "@babel/proposal-object-rest-spread",
-        "@babel/plugin-transform-runtime"
       ]
     },
     "browser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3193,6 +3193,7 @@
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.3.tgz",
       "integrity": "sha512-enKvnR/kKFbZFgXYo165wtSA5OeiTlgsnU4jV3vpKRhfWUJjLS6dfVcjIPeRcgJbgEgdgu0I+UyBWqu6c0GumQ==",
+      "dev": true,
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -7189,7 +7190,8 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -15234,7 +15236,7 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
@@ -15604,7 +15606,7 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
@@ -19320,7 +19322,8 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "automated-release": "release-it --config ./release/.release-it.json",
     "build": "run-s build:umd:browser build:commonjs build:es",
-    "build:umd:browser": "cross-env BABEL_ENV=browser webpack --config config/webpack/browser.config.babel.js",
+    "build:umd:browser": "cross-env BABEL_ENV=browser webpack --progress --config config/webpack/browser.config.babel.js",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "lint": "eslint src/ test/",
@@ -72,6 +72,7 @@
     "@babel/register": "=7.10.3",
     "@commitlint/cli": "=9.0.1",
     "@commitlint/config-conventional": "=9.0.1",
+    "@babel/runtime-corejs2": "=7.10.3",
     "@release-it/conventional-changelog": "=1.1.0",
     "babel-loader": "=8.1.0",
     "babel-plugin-add-module-exports": "=1.0.2",
@@ -108,7 +109,6 @@
     "xmock": "=0.3.0"
   },
   "dependencies": {
-    "@babel/runtime-corejs2": "=7.10.3",
     "btoa": "=1.2.1",
     "buffer": "=5.6.0",
     "cookie": "=0.4.1",

--- a/src/specmap/lib/index.js
+++ b/src/specmap/lib/index.js
@@ -1,5 +1,4 @@
 import * as jsonPatch from 'fast-json-patch';
-import regenerator from '@babel/runtime-corejs2/regenerator';
 import deepExtend from 'deep-extend';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -349,7 +348,7 @@ function isJsonPatch(patch) {
 }
 
 function isGenerator(thing) {
-  return regenerator.isGeneratorFunction(thing);
+  return Object.prototype.toString.call(thing) === '[object GeneratorFunction]';
 }
 
 function isMutation(patch) {

--- a/test/build-artifacts/es.js
+++ b/test/build-artifacts/es.js
@@ -1,3 +1,4 @@
+import '@babel/runtime-corejs2/regenerator';
 import SwaggerClient from '../../es';
 
 describe('babel ES6 imports artifact', () => {

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,4 +1,3 @@
-import '@babel/runtime-corejs2/regenerator';
 import fetchMock from 'fetch-mock';
 import fetch, { Headers, Request, Response } from 'cross-fetch';
 


### PR DESCRIPTION
### Motivation and Context

We've been using `@babel/runtime-corejs2` as production dependency because of one single check - to tell if a function is a generator function. Now that we target `node >=8` regenerator-runtime is no longer needed except for other environments where ES5 compliant code with generator is required. This case will be handled implicitly by `@babel/plugin-transform-runtime` plugin. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
