### PR TITLE
ci(GA): add node 8.x artifacts tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -60,19 +60,19 @@ jobs:
       with:
         name: node-build-artifacts-10.x
     - name: Run Node.js 10.x build artifacts tests
-      run: node -p "require('./node-build-artifacts-10.x/lib')"
+      run: node -p "require('./node-build-artifacts-10.x')"
     - name: Download Node.js 12.x build artifacts
       uses: actions/download-artifact@v1
       with:
         name: node-build-artifacts-12.x
     - name: Run Node.js 12.x build artifacts tests
-      run: node -p "require('./node-build-artifacts-12.x/lib')"
+      run: node -p "require('./node-build-artifacts-12.x')"
     - name: Download Node.js 14.x build artifacts
       uses: actions/download-artifact@v1
       with:
         name: node-build-artifacts-14.x
     - name: Run Node.js 14.x build artifacts tests
-      run: node -p "require('./node-build-artifacts-14.x/lib')"
+      run: node -p "require('./node-build-artifacts-14.x')"
   release:
     if: contains(github.ref, 'master')
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -51,10 +51,13 @@ jobs:
     needs: [build]
 
     steps:
+    - uses: actions/checkout@v2
     - name: Use Node.js 8.x
       uses: actions/setup-node@v1
       with:
         node-version: 8.x
+    - name: Install dependencies
+      run: npm ci
     - name: Download Node.js 10.x build artifacts
       uses: actions/download-artifact@v1
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,6 +46,7 @@ jobs:
         path: ./lib/
 
   node-artifacts-test:
+    name: node-artifacts-test (8.x)
     runs-on: ubuntu-latest
     needs: [build]
 
@@ -59,19 +60,19 @@ jobs:
       with:
         name: node-build-artifacts-10.x
     - name: Run Node.js 10.x build artifacts tests
-      run: node -p "require('./lib')"
+      run: node -p "require('./node-build-artifacts-10.x/lib')"
     - name: Download Node.js 12.x build artifacts
       uses: actions/download-artifact@v1
       with:
         name: node-build-artifacts-12.x
     - name: Run Node.js 12.x build artifacts tests
-      run: node -p "require('./lib')"
+      run: node -p "require('./node-build-artifacts-12.x/lib')"
     - name: Download Node.js 14.x build artifacts
       uses: actions/download-artifact@v1
       with:
         name: node-build-artifacts-14.x
     - name: Run Node.js 14.x build artifacts tests
-      run: node -p "require('./lib')"
+      run: node -p "require('./node-build-artifacts-14.x/lib')"
   release:
     if: contains(github.ref, 'master')
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,7 +39,39 @@ jobs:
       run: npm run security-audit
     - name: Build swagger-js
       run: npm run build
+    - name: Upload Node.js build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: node-build-artifacts-${{ matrix.node-version }}
+        path: ./lib/
 
+  node-artifacts-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+    - name: Use Node.js 8.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 8.x
+    - name: Download Node.js 10.x build artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: node-build-artifacts-10.x
+    - name: Run Node.js 10.x build artifacts tests
+      run: node -p "require('./lib')"
+    - name: Download Node.js 12.x build artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: node-build-artifacts-12.x
+    - name: Run Node.js 12.x build artifacts tests
+      run: node -p "require('./lib')"
+    - name: Download Node.js 14.x build artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: node-build-artifacts-14.x
+    - name: Run Node.js 14.x build artifacts tests
+      run: node -p "require('./lib')"
   release:
     if: contains(github.ref, 'master')
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,14 +39,14 @@ jobs:
       run: npm run security-audit
     - name: Build swagger-js
       run: npm run build
-    - name: Upload Node.js build artifacts
+    - name: Upload commonjs build artifacts
       uses: actions/upload-artifact@v1
       with:
-        name: node-build-artifacts-${{ matrix.node-version }}
+        name: commonjs-${{ matrix.node-version }}
         path: ./lib/
 
-  node-artifacts-test:
-    name: node-artifacts-test (8.x)
+  commonjs-artifacts-test:
+    name: commonjs-artifacts-test (8.x)
     runs-on: ubuntu-latest
     needs: [build]
 
@@ -58,32 +58,33 @@ jobs:
         node-version: 8.x
     - name: Install dependencies
       run: npm ci
-    - name: Download Node.js 10.x build artifacts
+    - name: Download Node.js 10.x commonjs build artifacts
       uses: actions/download-artifact@v1
       with:
-        name: node-build-artifacts-10.x
-    - name: Run Node.js 10.x build artifacts tests
-      run: node -p "require('./node-build-artifacts-10.x')"
-    - name: Download Node.js 12.x build artifacts
+        name: commonjs-10.x
+    - name: Run Node.js 10.x commonjs build artifacts tests
+      run: node -p "require('./commonjs-10.x')"
+    - name: Download Node.js 12.x commonjs build artifacts
       uses: actions/download-artifact@v1
       with:
-        name: node-build-artifacts-12.x
-    - name: Run Node.js 12.x build artifacts tests
-      run: node -p "require('./node-build-artifacts-12.x')"
-    - name: Download Node.js 14.x build artifacts
+        name: commonjs-12.x
+    - name: Run Node.js 12.x commonjs build artifacts tests
+      run: node -p "require('./commonjs-12.x')"
+    - name: Download Node.js 14.x commonjs build artifacts
       uses: actions/download-artifact@v1
       with:
-        name: node-build-artifacts-14.x
-    - name: Run Node.js 14.x build artifacts tests
-      run: node -p "require('./node-build-artifacts-14.x')"
+        name: commonjs-14.x
+    - name: Run Node.js 14.x commonjs build artifacts tests
+      run: node -p "require('./commonjs-14.x')"
+
   release:
     if: contains(github.ref, 'master')
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, commonjs-artifacts-test]
 
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
+        node-version: 14.x


### PR DESCRIPTION
### Motivation and Context
We're building our node artifacts agains node >=8. We have to make sure that the artifacts are executable on node 8.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
