### PR TITLE
build(package): remove browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
-  "browser": "dist/swagger-client.browser.min.js",
   "unpkg": "dist/swagger-client.browser.min.js",
   "repository": "git@github.com:swagger-api/swagger-js.git",
   "contributors": [


### PR DESCRIPTION
According to this thread https://github.com/webpack/webpack/issues/4674
it's not recommended  to use browser field for isomorphic libraries.

Discussion about browser field:  https://github.com/webpack/webpack/issues/4674
Browser field specification:  https://github.com/defunctzombie/package-browser-field-spec

Refs #1542


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
