### PR TITLE
build(babel): decrease size of ES5 build fragment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -30,13 +30,19 @@
           "@babel/preset-env",
           {
             "debug": false,
-            "modules": false,
-            "forceAllTransforms": true,
-            "ignoreBrowserslistConfig": true
+            "modules": false
           }
         ]
       ],
       "plugins": [
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            "absoluteRuntime": false,
+            "corejs": 2,
+            "version": "^7.10.4"
+          }
+        ],
         "@babel/proposal-class-properties",
         "@babel/proposal-object-rest-spread",
         "lodash"
@@ -54,7 +60,10 @@
       "plugins": [
         [
           "@babel/plugin-transform-runtime",
-          { "corejs": 2 }
+          {
+            "corejs": 2,
+            "version": "^7.10.4"
+          }
         ],
         "@babel/proposal-class-properties",
         "@babel/proposal-object-rest-spread",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3812,7 +3812,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.4.tgz",
       "integrity": "sha512-9sArmpZDQsnR1yyAcU51DxQrntWxt0LUKjPp3pIyo7kVLfaqKt8muppcT87QmFkXV5H50qXAF8JWOjk0jaXRYA==",
-      "dev": true,
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -7809,8 +7808,7 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -15957,8 +15955,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@babel/plugin-transform-runtime": "=7.10.4",
     "@babel/preset-env": "=7.10.4",
     "@babel/register": "=7.10.4",
-    "@babel/runtime-corejs2": "=7.10.4",
     "@commitlint/cli": "=9.0.1",
     "@commitlint/config-conventional": "=9.0.1",
     "@release-it/conventional-changelog": "=1.1.0",
@@ -107,6 +106,7 @@
     "xmock": "=0.3.0"
   },
   "dependencies": {
+    "@babel/runtime-corejs2": "=7.10.4",
     "btoa": "=1.2.1",
     "buffer": "=5.6.0",
     "cookie": "=0.4.1",


### PR DESCRIPTION
Use property now utilize @babel/plugin-transform-runtime and use
@babel/runtime-corejs2 as a runtime dependency.

### Motivation and Context

Decrease size of build fragments.


### How Has This Been Tested?

Tested with swagger-ui.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
