### PR TITLE
installation.md - semicolon missing

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -16,7 +16,7 @@ After installed successfully:
 
 [ES6 imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)
 ```js
-import SwaggerClient from 'swagger-client'
+import SwaggerClient from 'swagger-client';
 ```
 
 [CommonJS imports](https://en.wikipedia.org/wiki/CommonJS)

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -21,7 +21,7 @@ import SwaggerClient from 'swagger-client'
 
 [CommonJS imports](https://en.wikipedia.org/wiki/CommonJS)
 ```js
-const SwaggerClient = require('swagger-client')
+const SwaggerClient = require('swagger-client');
 ```
 
 ### unpkg


### PR DESCRIPTION
`require` directives in node.js require a closing semicolon, otherwise a strange error message gets shown:

```
}) ()
   ^

TypeError: require(...)(...) is not a function
```

### Description
/

### Motivation and Context
/

### How Has This Been Tested?
Manually

### Screenshots (if appropriate):
/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
