### PR TITLE
Create swagger-attach-cookie.js

### DIFF
--- a/examples/swagger-attach-cookie.js
+++ b/examples/swagger-attach-cookie.js
@@ -1,0 +1,8 @@
+// this line will set the credentials to "include" instead of "same-origin", as a result a cookie will be attached to the request
+SwaggerClient.http.withCredentials = true;
+
+SwaggerClient({
+    url: process.env.REACT_APP_SWAGGER_URI.
+}).then(_swag => {
+    window.ReactAPI = swag;
+});


### PR DESCRIPTION
### Description
An example of creating swagger client object with cookie attached credentials (`include` instead of `same-origin`)


### Motivation and Context
if your api based on cookie authorization you should use it

### Todo:
add this to swagger options, for example
```javascript
 SwaggerClient({
            url: process.env.REACT_APP_SWAGGER_URI,
            **withCredentials: true**
        })
```