### PR TITLE
feat(build-request): Add support for openIdConnect

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -128,7 +128,7 @@ export function applySecurities({ request, securities = {}, operation = {}, spec
           if (/^bearer$/i.test(schema.scheme)) {
             result.headers.Authorization = `Bearer ${value}`;
           }
-        } else if (type === 'oauth2') {
+        } else if (type === 'oauth2' || type === 'openIdConnect') {
           const token = auth.token || {};
           const tokenName = schema['x-tokenName'] || 'access_token';
           const tokenValue = token[tokenName];

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -771,4 +771,47 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
       },
     });
   });
+  test('should support openIdConnect security scheme', () => {
+    const spec = {
+      openapi: '3.0.0',
+      components: {
+        securitySchemes: {
+          myOIDC: {
+            type: 'openIdConnect',
+            openIdConnectUrl: 'https://accounts.google.com/.well-known/openid-configuration',
+          },
+        },
+      },
+      paths: {
+        '/': {
+          get: {
+            operationId: 'myOperation',
+            security: [{ myOIDC: [] }],
+          },
+        },
+      },
+    };
+
+    const req = buildRequest({
+      spec,
+      operationId: 'myOperation',
+      securities: {
+        authorized: {
+          myOIDC: {
+            token: {
+              access_token: 'myTokenValue',
+            },
+          },
+        },
+      },
+    });
+    expect(req).toEqual({
+      method: 'GET',
+      url: '/',
+      credentials: 'same-origin',
+      headers: {
+        Authorization: 'Bearer myTokenValue',
+      },
+    });
+  });
 });


### PR DESCRIPTION
Securities are to be formatted the same way as oauth2, since OIDC is
just a layer on top of oauth2.
