### PR TITLE
ci(release): add workflow for release process

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -93,15 +93,3 @@ jobs:
         name: commonjs-16.x
     - name: Run Node.js 16.x commonjs build artifacts tests
       run: node -p "require('./commonjs-16.x')"
-
-  release:
-    if: contains(github.ref, 'master')
-    runs-on: ubuntu-latest
-    needs: [build, commonjs-artifacts-test]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  workflow_dispatch:
+    branches:
+      - master
+
+#  workflow_run:
+#    workflows:
+#      - "Node.js CI"
+#    branches:
+#      - master
+#    types:
+#      - completed
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Install dependencies
+        run: npm ci
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          dry_run: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.SWAGGER_BOT_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Release published
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo ${{ steps.semantic.outputs.new_release_version }}
+          echo ${{ steps.semantic.outputs.new_release_major_version }}
+          echo ${{ steps.semantic.outputs.new_release_minor_version }}
+          echo ${{ steps.semantic.outputs.new_release_patch_version }}


### PR DESCRIPTION
Release process can be triggered manually via GitHub Action UI or by conventional commits.

Closes #2049

