### PR TITLE
ci(dependabot): remove ignores for release-it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,9 @@ updates:
     interval: daily
   commit-message:
     prefix: "chore"
-    include: "scope"  
+    include: "scope"
   open-pull-requests-limit: 10
   ignore:
     # cross-fetch and node-fetch must be synced manually
     - dependency-name: "cross-fetch"
     - dependency-name: "node-fetch"
-    - dependency-name: "release-it"
-    - dependency-name: "@release-it/conventional-changelog"
-    


### PR DESCRIPTION
As release-it package is no longer used, we'll good
to remove these ignores.

Refs #2049

