### PR TITLE
chore(deps): update cross-fetch to v3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6645,18 +6645,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
       "requires": {
         "node-fetch": "2.6.1"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "cross-spawn": {
@@ -11866,8 +11859,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "btoa": "^1.2.1",
     "buffer": "^6.0.3",
     "cookie": "~0.4.1",
-    "cross-fetch": "^3.0.6",
+    "cross-fetch": "^3.1.4",
     "deep-extend": "~0.6.0",
     "fast-json-patch": "^3.0.0-1",
     "isomorphic-form-data": "~2.0.0",


### PR DESCRIPTION
This minor version bump is still uses node-fetch@2.6.1
under the hood which is in sync with our node-fetch
explicit dependency.
