### PR TITLE
fix: add failback error message in case if HTTP/2 in Chrome

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -71,14 +71,14 @@ export default async function http(url, request = {}) {
       // so we'll just throw the error we got
       throw resError;
     }
-    const error = new Error(res.statusText);
+    const error = new Error(res.statusText || `response status is ${res.status}`);
     error.status = res.status;
     error.statusCode = res.status;
     error.responseError = resError;
     throw error;
   }
   if (!res.ok) {
-    const error = new Error(res.statusText);
+    const error = new Error(res.statusText || `response status is ${res.status}`);
     error.status = res.status;
     error.statusCode = res.status;
     error.response = res;


### PR DESCRIPTION
### Description

I have found that at least in Chrome@90, `fetch` returns an empty string in `statusText` field of the response object. According to MDN:

> The default value is "". Note that HTTP/2 does not support status messages.

https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#value

`cross-fetch` behaves the same because I think it uses `fetch` as the underlying implementation in this case.

`statusText` is the only source of error messages thrown by `swagger-client`. The lack of `statusText` makes errors look unobvious, like:
```
Error
    at _callee$ (http.js?0c7c:170)
    ...
```

I'm proposing to improve it by adding a fallback message containing HTTP status code in case if `statusText` is empty.

```
Error: response status is 404
    at _callee$ (http.js?0c7c:170)
    ...
```


### How Has This Been Tested?
I've connected this version to the existing project using `npm link`. It behaved as expected.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
