### PR TITLE
refactor: extract FetchResponseError, expose it for instanceof

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ import { makeApisTagOperation } from './interfaces';
 import { execute, buildRequest, baseUrl } from './execute';
 import { opId } from './helpers';
 
+export { FetchResponseError } from './http';
+
 Swagger.http = Http;
 Swagger.makeHttp = makeHttp.bind(null, Swagger.http);
 Swagger.resolve = Resolver;


### PR DESCRIPTION
### Description

In our project, we have a global error handler that may catch an exception generated by `swagger-client`. We can detect such exceptions by the persistence of specific fields (`status`, `statusText`, `request`), but would be more robust to be able to use `instanceof` to do that.

We can't do it now because errors generated by `swagger-client` are just instances of `Error` with some additional fields. I'm proposing to add a new error class to use when a response is not ok or failed to process.

### How Has This Been Tested?
I've connected this version to the existing project using npm link. It behaved as expected.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
