### PR TITLE
chore(release): trigger release workflow only on success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Release workflow have been run even if "Node.js CI" workflow fails. This PR fixes this by running a release workflow only on successful completion of "Node.js CI" (not just completion which can mean success or failure).