### PR TITLE
chore(security): discontinue using npm audit script

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,10 +32,6 @@ jobs:
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm ci
-    - name: Security audit
-      run: npm run security-audit
-      env:
-        CI: true
     - name: Lint commit message
       run: git log -1 --pretty=format:"%s" | npx commitlint
     - name: Lint code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,11 +1210,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@char0n/npm-audit": {
-      "version": "gist:2964395223d7943c10396f59df9a8ea0#a90cd379703176d3ea0772d895628ece9dfa11d1",
-      "from": "gist:2964395223d7943c10396f59df9a8ea0",
-      "dev": true
-    },
     "@commitlint/cli": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "test:artifact:es": "npm run build:es && cross-env BABEL_ENV=commonjs jest --config ./config/jest/jest.artifact-es.config.js",
     "test:artifact:commonjs": "npm run build:commonjs && cross-env BABEL_ENV=commonjs jest --config ./config/jest/jest.artifact-commonjs.config.js",
     "deps:license": "license-checker --production --csv --out $npm_package_config_deps_check_dir/licenses.csv && license-checker --development --csv --out $npm_package_config_deps_check_dir/licenses-dev.csv",
-    "security-audit": "run-s -sc security-audit:prod security-audit:dev",
-    "security-audit:prod": "npm-audit --production --only=prod --audit-level=low",
-    "security-audit:dev": "npm-audit --only=dev --audit-level=moderate",
     "clean": "rimraf ./dist ./lib ./es ./.deps_check ./coverage"
   },
   "keywords": [
@@ -73,7 +70,6 @@
     "@babel/plugin-transform-runtime": "=7.16.5",
     "@babel/preset-env": "=7.16.5",
     "@babel/register": "=7.16.5",
-    "@char0n/npm-audit": "gist:2964395223d7943c10396f59df9a8ea0",
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
     "babel-loader": "=8.2.3",


### PR DESCRIPTION
Dependabot alerts will replace the script.

Closes #2325

