### PR TITLE
feat: add support aborting requests in tags interface

### DIFF
--- a/docs/usage/tags-interface.md
+++ b/docs/usage/tags-interface.md
@@ -267,3 +267,73 @@ SwaggerClient({ url: 'http://petstore.swagger.io/v2/swagger.json' })
   </body>
 </html>
 ```
+
+#### Request cancellation with AbortSignal
+
+You may cancel requests with [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+The AbortController interface represents a controller object that allows you to abort one or more Web requests as and when desired.
+Using AbortController, you can easily implement request timeouts.
+
+###### Node.js
+
+AbortController needs to be introduced in Node.js environment via [abort-controller](https://www.npmjs.com/package/abort-controller) npm package.
+
+```js
+const SwaggerClient = require('swagger-client');
+const AbortController = require('abort-controller');
+
+const controller = new AbortController();
+const { signal } = controller;
+const timeout = setTimeout(() => {
+  controller.abort();
+}, 1);
+
+(async () => {
+  try {
+    await new SwaggerClient({ spec })
+      .then(client => client.apis.default.getUserList({}, { signal }))
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.error('request was aborted');
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+})();
+```
+
+###### Browser
+
+AbortController is part of modern [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+No need to install it explicitly.
+
+```html
+<html>
+  <head>
+    <script src="//unpkg.com/swagger-client"></script>
+    <script>
+        const controller = new AbortController();
+        const { signal } = controller;
+        const timeout = setTimeout(() => {
+          controller.abort();
+        }, 1);
+
+        (async () => {
+          try {
+            await new SwaggerClient({ spec })
+              .then(client => client.apis.default.getUserList({}, { signal }))
+          } catch (error) {
+            if (error.name === 'AbortError') {
+              console.error('request was aborted');
+            }
+          } finally {
+            clearTimeout(timeout);
+          }
+        })();
+    </script>
+  </head>
+  <body>
+    check console in browser's dev. tools
+  </body>
+</html>
+``` 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2616,6 +2616,15 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
@@ -4365,6 +4374,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
     "events": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@babel/register": "=7.16.5",
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
+    "abort-controller": "^3.0.0",
     "babel-loader": "=8.2.3",
     "babel-plugin-lodash": "=3.3.4",
     "cross-env": "=7.0.3",

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -98,6 +98,7 @@ export function buildRequest(options) {
     server,
     serverVariables,
     http,
+    signal,
   } = options;
 
   let { parameters, parameterBuilders } = options;
@@ -122,6 +123,10 @@ export function buildRequest(options) {
     headers: {},
     cookies: {},
   };
+
+  if (signal) {
+    req.signal = signal;
+  }
 
   if (requestInterceptor) {
     req.requestInterceptor = requestInterceptor;

--- a/test/interfaces.js
+++ b/test/interfaces.js
@@ -1,3 +1,5 @@
+import AbortController from 'abort-controller';
+
 import {
   mapTagOperations,
   makeApisTagOperationsOperationExecute,
@@ -105,6 +107,31 @@ describe('intefaces', () => {
         option: 1,
         parameters: ['param'],
         pathName: '/one',
+      });
+    });
+
+    test('should pass signal option to execute', () => {
+      // Given
+      const spyMapTagOperations = jest.spyOn(stubs, 'mapTagOperations');
+      const spyExecute = jest.fn();
+      makeApisTagOperationsOperationExecute({ execute: spyExecute });
+      const { cb } = spyMapTagOperations.mock.calls[0][0];
+
+      // When
+      const controller = new AbortController();
+      const { signal } = controller;
+      const executer = cb({ pathName: '/one', method: 'GET' });
+      executer(['param'], { signal });
+
+      // Then
+      expect(spyExecute.mock.calls.length).toEqual(1);
+      expect(spyExecute.mock.calls[0][0]).toEqual({
+        spec: undefined,
+        operationId: undefined,
+        method: 'GET',
+        parameters: ['param'],
+        pathName: '/one',
+        signal,
       });
     });
 


### PR DESCRIPTION
- support was added to HTTP Client for OAS operations
- support was added to Tags Interface

Older versions of swagger-client can use request
interceptors to inject abort signal into requests.

Refs #2349

### How Has This Been Tested?

With automated tests and manually.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
