### PR TITLE
Fix setting bearer header

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -137,7 +137,7 @@ export function applySecurities({ request, securities = {}, operation = {}, spec
           }
 
           if (/^bearer$/i.test(schema.scheme)) {
-            result.headers.Authorization = `Bearer ${value}`;
+            result.headers.Authorization = `Bearer ${value.bearer || value}`;
           }
         } else if (type === 'oauth2' || type === 'openIdConnect') {
           const token = auth.token || {};


### PR DESCRIPTION
With latest swagger-ui-express (swagger-ui-dist has updated from 3.5 to 4) I'm receiving object `{ bearer: 'my key' }` instead of `'my key'` as value. 
```
curl -X 'GET' \
  'https://example.org/api/me' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer [object Object]'
```

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
It doesn't fix the source of the bug but at least it solves the problem.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
