### PR TITLE
Support reserved chars in path params

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -2,7 +2,7 @@ import stylize, { encodeDisallowedCharacters } from './style-serializer.js';
 import serialize from './content-serializer.js';
 
 export function path({ req, value, parameter }) {
-  const { name, style, explode, content } = parameter;
+  const { name, style, explode, content, allowReserved } = parameter;
 
   if (content) {
     const effectiveMediaType = Object.keys(content)[0];
@@ -18,7 +18,7 @@ export function path({ req, value, parameter }) {
     value,
     style: style || 'simple',
     explode: explode || false,
-    escape: true,
+    escape: allowReserved ? 'unsafe' : true,
   });
 
   req.url = req.url.split(`{${name}}`).join(styledValue);

--- a/test/oas3/execute/style-explode/path.js
+++ b/test/oas3/execute/style-explode/path.js
@@ -76,6 +76,45 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - path parameters', () =
       });
     });
 
+    test('should build a path parameter with escaped non-RFC3986 characters', () => {
+      // Given
+      const spec = {
+        openapi: '3.0.0',
+        paths: {
+          '/path/{id}': {
+            get: {
+              operationId: 'myOperation',
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'path',
+                  style: 'simple',
+                  explode: false,
+                  allowReserved: true,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        parameters: {
+          id: 'wow this is nice!',
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/path/wow%20this%20is%20nice!',
+        credentials: 'same-origin',
+        headers: {},
+      });
+    });
+
     test('should build a path parameter in a simple/explode format', () => {
       // Given
       const spec = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Add `allowReserved` to path parameter to support reserved characters like the query parameter already does. Default stays the same.

See `allowReserved` in the parameter documentation: https://swagger.io/specification/#parameter-object

### Motivation and Context

We are using URL's with reserved characters like an asterix in the path: `http://example.com/items/*1234abcd`
Swagger always encode this characters.

### How Has This Been Tested?

New test case added.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
