### PR TITLE
ci(ga): drop Node.js v12 from pipeline

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -90,5 +90,12 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 16.x
+    - name: Run commonjs build artifacts on Node.js 16.x
+      run: node -p "require('./commonjs')"
+
+    - name: Use Node 18.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18.x
     - name: Run commonjs build artifacts on Node.js 16.x
       run: node -p "require('./commonjs')"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -90,12 +90,5 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: 16.x
-    - name: Run commonjs build artifacts on Node.js 16.x
-      run: node -p "require('./commonjs')"
-
-    - name: Use Node 18.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 18.x
     - name: Run commonjs build artifacts on Node.js 16.x
       run: node -p "require('./commonjs')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 16
       - name: Install dependencies
         run: npm ci
       - name: Semantic Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
       - name: Install dependencies
         run: npm ci
       - name: Semantic Release


### PR DESCRIPTION
Jest no longer runs on Node.js 12. It needs to run tests on Node.js 14 now. We're still test build fragments in Node.js 12.4 though.