### PR TITLE
ci(release): update semantic-release-action to v3.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -12,3 +13,9 @@ updates:
     # cross-fetch and node-fetch must be synced manually
     - dependency-name: "cross-fetch"
     - dependency-name: "node-fetch"
+
+- package-ecosystem: "github-actions"
+  target-branch: "master"
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3.2.0
         with:
           dry_run: false
           extra_plugins: |


### PR DESCRIPTION
Dependabot was configured to update GitHub Actions automatically

Refs #2738

