### PR TITLE
feat(resolver): collect errors in ReferenceElement visitor hook

### DIFF
--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/example-object/index.js
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/example-object/index.js
@@ -135,20 +135,14 @@ describe('dereference', () => {
           describe('and with unresolvable URI', () => {
             const fixturePath = path.join(rootFixturePath, 'external-value-unresolvable');
 
-            test.only('should dereference', async () => {
-              try {
-                const rootFilePath = path.join(fixturePath, 'root.json');
-                const actual = await dereference(rootFilePath, {
-                  parse: { mediaType: mediaTypes.latest('json') },
-                });
-                const expected = globalThis.loadJsonFile(
-                  path.join(fixturePath, 'dereferenced.json')
-                );
+            test('should dereference', async () => {
+              const rootFilePath = path.join(fixturePath, 'root.json');
+              const actual = await dereference(rootFilePath, {
+                parse: { mediaType: mediaTypes.latest('json') },
+              });
+              const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-                expect(toValue(actual)).toEqual(expected);
-              } catch (e) {
-                console.dir(e);
-              }
+              expect(toValue(actual)).toEqual(expected);
             });
 
             test('should collect error', async () => {
@@ -165,7 +159,7 @@ describe('dereference', () => {
                 message: expect.stringMatching(/^Could not resolve reference: ENOENT/),
                 baseDoc: expect.stringMatching(/external-value-unresolvable\/root\.json$/),
                 externalValue: './ex.json',
-                fullPath: ['components', 'examples', 'example1'],
+                fullPath: ['components', 'examples', 'example1', 'externalValue'],
               });
             });
           });
@@ -212,7 +206,7 @@ describe('dereference', () => {
                 message: expect.stringMatching(/^Could not resolve reference: ExampleElement/),
                 baseDoc: expect.stringMatching(/external-value-value-both-defined\/root\.json$/),
                 externalValue: './ex.json',
-                fullPath: ['components', 'examples', 'example1'],
+                fullPath: ['components', 'examples', 'example1', 'externalValue'],
               });
             });
           });

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/direct-external-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/direct-external-circular/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "$ref": "./root.json#/components/parameters/externalRef",
+          "description": "another ref"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/direct-external-circular/ex.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/direct-external-circular/ex.json
@@ -1,5 +1,5 @@
 {
   "externalParameter": {
-    "$ref": "./root.json#/components/parameters/userId"
+    "$ref": "./root.json#/components/parameters/externalRef"
   }
 }

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/direct-internal-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/direct-internal-circular/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "userId": {
+          "$ref": "#/components/parameters/userId",
+          "description": "description 1"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/indirect-external-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/indirect-external-circular/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "$ref": "./root.json#/components/parameters/externalRef",
+          "description": "another ref"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/indirect-internal-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/indirect-internal-circular/dereferenced.json
@@ -1,0 +1,25 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "userId": {
+          "$ref": "#/components/parameters/userId",
+          "description": "description 1"
+        },
+        "indirection1": {
+          "$ref": "#/components/parameters/userId",
+          "description": "description 1"
+        },
+        "indirection2": {
+          "$ref": "#/components/parameters/userId",
+          "description": "description 1"
+        },
+        "indirection3": {
+          "$ref": "#/components/parameters/userId",
+          "description": "description 1"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/invalid-pointer/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/invalid-pointer/dereferenced.json
@@ -1,0 +1,19 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "userId": {
+          "$ref": "invalid-pointer",
+          "description": "override"
+        },
+        "userIdRef": {
+          "name": "userId",
+          "in": "query",
+          "description": "ID of the user",
+          "required": true
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/max-depth/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/max-depth/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "$ref": "./ex3.json#/externalParameter",
+          "description": "external ref"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/unresolvable-reference/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/__fixtures__/unresolvable-reference/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "parameters": {
+        "externalRef": {
+          "$ref": "./ex.json#/externalParameter",
+          "description": "external ref"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/index.js
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/reference-object/index.js
@@ -7,9 +7,6 @@ import {
   dereferenceApiDOM,
   resolve,
   parse,
-  DereferenceError,
-  MaximumDereferenceDepthError,
-  MaximumResolverDepthError,
   Reference,
   ReferenceSet,
 } from '@swagger-api/apidom-reference/configuration/empty';
@@ -244,85 +241,202 @@ describe('dereference', () => {
 
         describe('given Reference Objects with direct circular internal reference', () => {
           const fixturePath = path.join(rootFixturePath, 'direct-internal-circular');
+          const rootFilePath = path.join(fixturePath, 'root.json');
 
-          test('should throw error', async () => {
-            const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
+          test('should dereference', async () => {
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(
+                /^Could not resolve reference: Recursive JSON Pointer detected/
+              ),
+              baseDoc: expect.stringMatching(/direct-internal-circular\/root\.json$/),
+              $ref: '#/components/parameters/userId',
+              pointer: '/components/parameters/userId',
+              fullPath: ['components', 'parameters', 'userId', '$ref'],
+            });
           });
         });
 
         describe('given Reference Objects with indirect circular internal reference', () => {
           const fixturePath = path.join(rootFixturePath, 'indirect-internal-circular');
+          const rootFilePath = path.join(fixturePath, 'root.json');
 
-          test('should throw error', async () => {
-            const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
+          test('should dereference', async () => {
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(4);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(
+                /^Could not resolve reference: Recursive JSON Pointer detected/
+              ),
+              baseDoc: expect.stringMatching(/indirect-internal-circular\/root\.json$/),
+              $ref: '#/components/parameters/userId',
+              pointer: '/components/parameters/userId',
+              fullPath: ['components', 'parameters', 'userId', '$ref'],
+            });
           });
         });
 
         describe('given Reference Objects with direct circular external reference', () => {
           const fixturePath = path.join(rootFixturePath, 'direct-external-circular');
+          const rootFilePath = path.join(fixturePath, 'root.json');
 
-          test('should throw error', async () => {
-            const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
+          test('should dereference', async () => {
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(
+                /^Could not resolve reference: Recursive JSON Pointer detected/
+              ),
+              baseDoc: expect.stringMatching(/direct-external-circular\/ex\.json$/),
+              $ref: './root.json#/components/parameters/externalRef',
+              pointer: '/components/parameters/externalRef',
+              fullPath: ['components', 'parameters', 'externalRef', '$ref'],
+            });
           });
         });
 
         describe('given Reference Objects with indirect circular external reference', () => {
           const fixturePath = path.join(rootFixturePath, 'indirect-external-circular');
+          const rootFilePath = path.join(fixturePath, 'root.json');
 
-          test('should throw error', async () => {
-            const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
+          test('should dereference', async () => {
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(
+                /^Could not resolve reference: Recursive JSON Pointer detected/
+              ),
+              baseDoc: expect.stringMatching(/indirect-external-circular\/ex3\.json$/),
+              $ref: './root.json#/components/parameters/externalRef',
+              pointer: '/components/parameters/externalRef',
+              fullPath: ['components', 'parameters', 'externalRef', '$ref'],
+            });
           });
         });
 
         describe('given Reference Objects with unresolvable reference', () => {
           const fixturePath = path.join(rootFixturePath, 'unresolvable-reference');
+          const rootFilePath = path.join(fixturePath, 'root.json');
 
-          test('should throw error', async () => {
-            const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
+          test('should dereference', async () => {
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(/^Could not resolve reference: ENOENT/),
+              baseDoc: expect.stringMatching(/unresolvable-reference\/root\.json$/),
+              $ref: './ex.json#/externalParameter',
+              pointer: '/externalParameter',
+              fullPath: ['components', 'parameters', 'externalRef', '$ref'],
+            });
           });
         });
 
         describe('given Reference Objects with invalid JSON Pointer', () => {
           const fixturePath = path.join(rootFixturePath, 'invalid-pointer');
 
-          test('should throw error', async () => {
+          test('should dereference', async () => {
             const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-              });
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+            });
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
 
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const rootFilePath = path.join(fixturePath, 'root.json');
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(/^Could not resolve reference: ENOENT/),
+              baseDoc: expect.stringMatching(/invalid-pointer\/root\.json$/),
+              $ref: 'invalid-pointer',
+              pointer: '',
+              fullPath: ['components', 'parameters', 'userId', '$ref'],
+            });
           });
         });
 
@@ -357,48 +471,73 @@ describe('dereference', () => {
         describe('given Reference Objects and maxDepth of dereference', () => {
           const fixturePath = path.join(rootFixturePath, 'max-depth');
 
-          test('should throw error', async () => {
+          test('should dereference', async () => {
             const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                dereference: { maxDepth: 2 },
-              });
-
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
-            await expect(dereferenceThunk()).rejects.toMatchObject({
-              cause: {
-                cause: expect.any(MaximumDereferenceDepthError),
-              },
+            const actual = await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { maxDepth: 2 },
             });
-            await expect(dereferenceThunk()).rejects.toHaveProperty(
-              'cause.cause.message',
-              expect.stringMatching(/__fixtures__\/max-depth\/ex2\.json"$/)
-            );
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const rootFilePath = path.join(fixturePath, 'root.json');
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { maxDepth: 2, dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(
+                /^Could not resolve reference: Maximum dereference depth/
+              ),
+              baseDoc: expect.stringMatching(/max-depth\/ex2\.json$/),
+              $ref: './ex3.json#/externalParameter',
+              pointer: '/externalParameter',
+              fullPath: ['components', 'parameters', 'externalRef', '$ref'],
+            });
           });
         });
 
         describe('given Reference Objects and maxDepth of resolution', () => {
           const fixturePath = path.join(rootFixturePath, 'max-depth');
 
-          test('should throw error', async () => {
+          test('should dereference', async () => {
             const rootFilePath = path.join(fixturePath, 'root.json');
-            const dereferenceThunk = () =>
-              dereference(rootFilePath, {
-                parse: { mediaType: mediaTypes.latest('json') },
-                resolve: { maxDepth: 2 },
-              });
-
-            await expect(dereferenceThunk()).rejects.toThrow(DereferenceError);
-            await expect(dereferenceThunk()).rejects.toMatchObject({
-              cause: {
-                cause: expect.any(MaximumResolverDepthError),
-              },
+            const actual = await dereference(rootFilePath, {
+              resolve: { maxDepth: 2 },
+              parse: { mediaType: mediaTypes.latest('json') },
             });
-            await expect(dereferenceThunk()).rejects.toHaveProperty(
-              'cause.cause.message',
-              expect.stringMatching(/__fixtures__\/max-depth\/ex2\.json"$/)
-            );
+            const expected = globalThis.loadJsonFile(path.join(fixturePath, 'dereferenced.json'));
+
+            expect(toValue(actual)).toEqual(expected);
+          });
+
+          test('should collect error', async () => {
+            const rootFilePath = path.join(fixturePath, 'root.json');
+            const errors = [];
+
+            await dereference(rootFilePath, {
+              resolve: { maxDepth: 2 },
+              parse: { mediaType: mediaTypes.latest('json') },
+              dereference: { dereferenceOpts: { errors } },
+            });
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({
+              message: expect.stringMatching(
+                /^Could not resolve reference: Maximum resolution depth/
+              ),
+              baseDoc: expect.stringMatching(/max-depth\/ex2\.json$/),
+              $ref: './ex3.json#/externalParameter',
+              pointer: '/externalParameter',
+              fullPath: ['components', 'parameters', 'externalRef', '$ref'],
+            });
           });
         });
 


### PR DESCRIPTION
This change is specific to OpenAPI 3.1.0 resolution strategy. Errors are now collected, instead of
thrown and visitor traversal is not interrupted.

Refs #2802
