### PR TITLE
feat(resolver): collect errors in SchemaElement visitor hook

### DIFF
--- a/src/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/errors/index.js
+++ b/src/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/errors/index.js
@@ -1,0 +1,7 @@
+import createError from '../../../../../../../specmap/lib/create-error.js';
+
+// eslint-disable-next-line import/prefer-default-export
+export const SchemaRefError = createError('SchemaRefError', function cb(message, extra, oriError) {
+  this.originalError = oriError;
+  Object.assign(this, extra || {});
+});

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$anchor-not-found/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$anchor-not-found/dereferenced.json
@@ -1,0 +1,23 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "$ref": "#user-profile"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$id-unresolvable/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$id-unresolvable/dereferenced.json
@@ -1,0 +1,25 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "$id": "./schemas/",
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "$id": "./nested/",
+              "$ref": "./ex.json"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$ref-url-unresolvable/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$ref-url-unresolvable/dereferenced.json
@@ -1,0 +1,23 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "$ref": "./ex.json"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$ref-urn-unresolvable/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/$ref-urn-unresolvable/dereferenced.json
@@ -1,0 +1,23 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "properties": {
+            "login": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "profile": {
+              "$ref": "urn:uuid:3"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/direct-external-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/direct-external-circular/dereferenced.json
@@ -1,0 +1,10 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {}
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/direct-internal-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/direct-internal-circular/dereferenced.json
@@ -1,0 +1,12 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "$ref": "#/components/schemas/User"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/indirect-external-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/indirect-external-circular/dereferenced.json
@@ -1,0 +1,10 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {}
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/indirect-internal-circular/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/indirect-internal-circular/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {},
+        "Indirection1": {},
+        "Indirection2": {},
+        "Indirection3": {}
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/indirect-internal-circular/root.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/indirect-internal-circular/root.json
@@ -8,10 +8,10 @@
       "Indirection1": {
         "$ref": "#/components/schemas/Indirection2"
       },
-      "Indirection3": {
+      "Indirection2": {
         "$ref": "#/components/schemas/Indirection3"
       },
-      "Indirection4": {
+      "Indirection3": {
         "$ref": "#/components/schemas/User"
       }
     }

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/infinite-recursion/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/infinite-recursion/dereferenced.json
@@ -1,0 +1,15 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object"
+        },
+        "UserProfile": {
+          "type": "object"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/invalid-pointer/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/invalid-pointer/dereferenced.json
@@ -1,0 +1,13 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object",
+          "$ref": "#/components/schemas/invalid-pointer"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/max-depth/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/max-depth/dereferenced.json
@@ -1,0 +1,12 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "type": "object"
+        }
+      }
+    }
+  }
+]

--- a/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/unresolvable-reference/dereferenced.json
+++ b/test/helpers/apidom/reference/dereference/strategies/openapi-3-1-swagger-client/schema-object/__fixtures__/unresolvable-reference/dereferenced.json
@@ -1,0 +1,16 @@
+[
+  {
+    "openapi": "3.1.0",
+    "components": {
+      "schemas": {
+        "User": {
+          "properties": {
+            "profile": {
+              "$ref": "#/components/schemas/UserProfile"
+            }
+          }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
This change is specific to OpenAPI 3.1.0 resolution strategy. Errors are now collected, instead of
thrown and visitor traversal is not interrupted.

Refs #2806