### PR TITLE
fix(build): fix bundling of overridden ApiDOM deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5768,9 +5768,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.304",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.304.tgz",
-      "integrity": "sha512-6c8M+ojPgDIXN2NyfGn8oHASXYnayj+gSEnGeLMKb9zjsySeVB/j7KkNAAG9yDcv8gNlhvFg5REa1N/kQU6pgA==",
+      "version": "1.4.305",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.305.tgz",
+      "integrity": "sha512-WETy6tG0CT5gm1O+xCbyapWNsCcmIvrn4NHViIGYo2AT8FV2qUCXdaB+WqYxSv/vS5mFqhBYnfZAAkVArjBmUg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -11130,9 +11130,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.0.1.tgz",
+      "integrity": "sha512-C4CrOG1kAnaIxQPTAoiAmZCR2up1yjDdseGpr8UCUw5UqBUao5E1q2bOv0cAX0+y8MUxcyrvkTsoj5DvGRnvdQ==",
       "dev": true,
       "inBundle": true,
       "dependencies": {
@@ -14155,9 +14155,10 @@
       }
     },
     "node_modules/unraw": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unraw/-/unraw-2.0.1.tgz",
-      "integrity": "sha512-tdOvLfRzHolwYcHS6HIX860MkK9LQ4+oLuNwFYL7bpgTEO64PZrcQxkisgwJYCfF8sKiWLwwu1c83DvMkbefIQ==",
+      "name": "-",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/-/-/--0.0.1.tgz",
+      "integrity": "sha512-3HfneK3DGAm05fpyj20sT3apkNcvPpCuccOThOPdzz8sY7GgQGe0l93XH9bt+YzibcTIgUAIMoyVJI740RtgyQ==",
       "dev": true,
       "inBundle": true
     },
@@ -14839,9 +14840,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
-      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -17440,7 +17441,7 @@
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
         "stampit": "=4.3.2",
-        "unraw": "=2.0.1"
+        "unraw": "npm:-@0.0.1"
       }
     },
     "@swagger-api/apidom-core": {
@@ -17606,7 +17607,7 @@
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:-@0.0.1",
         "@types/ramda": "npm:-@0.0.1",
         "axios": "npm:-@0.0.1",
-        "minimatch": "=6.2.0",
+        "minimatch": "*",
         "process": "=0.11.10",
         "ramda": "=0.28.0",
         "ramda-adjunct": "=3.4.0",
@@ -19210,9 +19211,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.304",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.304.tgz",
-      "integrity": "sha512-6c8M+ojPgDIXN2NyfGn8oHASXYnayj+gSEnGeLMKb9zjsySeVB/j7KkNAAG9yDcv8gNlhvFg5REa1N/kQU6pgA==",
+      "version": "1.4.305",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.305.tgz",
+      "integrity": "sha512-WETy6tG0CT5gm1O+xCbyapWNsCcmIvrn4NHViIGYo2AT8FV2qUCXdaB+WqYxSv/vS5mFqhBYnfZAAkVArjBmUg==",
       "dev": true
     },
     "emittery": {
@@ -23186,9 +23187,9 @@
       }
     },
     "minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.0.1.tgz",
+      "integrity": "sha512-C4CrOG1kAnaIxQPTAoiAmZCR2up1yjDdseGpr8UCUw5UqBUao5E1q2bOv0cAX0+y8MUxcyrvkTsoj5DvGRnvdQ==",
       "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
@@ -25423,9 +25424,9 @@
       "dev": true
     },
     "unraw": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unraw/-/unraw-2.0.1.tgz",
-      "integrity": "sha512-tdOvLfRzHolwYcHS6HIX860MkK9LQ4+oLuNwFYL7bpgTEO64PZrcQxkisgwJYCfF8sKiWLwwu1c83DvMkbefIQ==",
+      "version": "npm:-@0.0.1",
+      "resolved": "https://registry.npmjs.org/-/-/--0.0.1.tgz",
+      "integrity": "sha512-3HfneK3DGAm05fpyj20sT3apkNcvPpCuccOThOPdzz8sY7GgQGe0l93XH9bt+YzibcTIgUAIMoyVJI740RtgyQ==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -25946,9 +25947,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
-      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "Buu Nguyen <buunguyen@gmail.com>",
     "Josh Ponelat <jponelat@gmail.com>",
     "Kyle Shockey <kyleshockey1@gmail.com>",
-    "Sahar Jafari <shr.jafari@gmail.com>"
+    "Sahar Jafari <shr.jafari@gmail.com>",
+    "Vladimír Gorej <vladimir.gorej@gmail.com>"
   ],
   "files": [
     "LICENSE",
@@ -138,15 +139,21 @@
   ],
   "overrides": {
     "@swagger-api/apidom-ast": {
-      "short-unique-id": "npm:-@0.0.1",
-      "@types/ramda": "npm:-@0.0.1"
+      "unraw": "npm:-@0.0.1",
+      "@types/ramda": {
+        ".": "npm:-@0.0.1"
+      }
     },
     "@swagger-api/apidom-core": {
       "short-unique-id": "npm:-@0.0.1",
-      "@types/ramda": "npm:-@0.0.1"
+      "@types/ramda": {
+        ".": "npm:-@0.0.1"
+      }
     },
     "@swagger-api/apidom-ns-json-schema-draft-4": {
-      "@types/ramda": "npm:-@0.0.1"
+      "@types/ramda": {
+        ".": "npm:-@0.0.1"
+      }
     },
     "@swagger-api/apidom-ns-openapi-3-0": {
       "@types/ramda": "npm:-@0.0.1"
@@ -155,20 +162,51 @@
       "@types/ramda": "npm:-@0.0.1"
     },
     "@swagger-api/apidom-reference": {
-      "@swagger-api/apidom-ns-asyncapi-2": "npm:-@0.0.1",
-      "@swagger-api/apidom-ns-api-design-systems": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-api-design-systems-json": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-json": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "npm:-@0.0.1",
-      "@swagger-api/apidom-parser-adapter-yaml-1-2": "npm:-@0.0.1",
-      "axios": "npm:-@0.0.1",
-      "@types/ramda": "npm:-@0.0.1"
+      "@swagger-api/apidom-ns-asyncapi-2": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-ns-api-design-systems": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-json": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+        ".": "npm:-@0.0.1"
+      },
+      "@swagger-api/apidom-parser-adapter-yaml-1-2": {
+        ".": "npm:-@0.0.1"
+      },
+      "axios": {
+        ".": "npm:-@0.0.1"
+      },
+      "@types/ramda": {
+        ".": "npm:-@0.0.1"
+      },
+      "minimatch": {
+        ".": "*"
+      }
     }
   }
 }


### PR DESCRIPTION
Without this fix `npm ci` script in newer npm versions 
has problem consolidating the dependency tree.