### PR TITLE
ci(release): re-enable automatic CICD pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,16 @@
 name: Release
 on:
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Node.js CI"
     branches:
-      - beta
+      - master
+    types:
+      - completed
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.releaserc
+++ b/.releaserc
@@ -1,8 +1,7 @@
 {
   "release": {
     "branches": [
-      {"name": "master"},
-      {"name": "beta", "channel": "beta", "prerelease": "beta"}
+      {"name": "master"}
     ],
     "tagFormat": "v${version}"
   },


### PR DESCRIPTION
The CICD pipeline was disabled during alpha/beta phases of 3.19.0 release. This change re-enables it.