### PR TITLE
fix: use AbortController in backward compatible way for Node.js >=12.20.0

### DIFF
--- a/config/jest/jest.unit.coverage.config.js
+++ b/config/jest/jest.unit.coverage.config.js
@@ -9,7 +9,7 @@ module.exports = {
       branches: 84,
       functions: 91,
       lines: 89,
-      statements: 89,
+      statements: 88,
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "fast-json-patch": "^3.0.0-1",
         "is-plain-object": "^5.0.0",
         "js-yaml": "^4.1.0",
+        "node-abort-controller": "^3.1.1",
         "node-fetch-commonjs": "^3.3.1",
         "qs": "^6.10.2",
         "traverse": "~0.6.6",
@@ -11484,6 +11485,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@swagger-api/apidom-json-pointer": ">=0.76.2 <1.0.0",
         "@swagger-api/apidom-ns-openapi-3-1": ">=0.76.2 <1.0.0",
         "@swagger-api/apidom-reference": ">=0.76.2 <1.0.0",
-        "abort-controller": "^3.0.0",
         "cookie": "~0.5.0",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
@@ -4260,17 +4259,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -6875,14 +6863,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "./es/helpers/btoa.node.js": "./es/helpers/btoa.browser.js",
     "./src/helpers/fetch-polyfill.node.js": "./src/helpers/fetch-polyfill.browser.js",
     "./es/helpers/fetch-polyfill.node.js": "./es/helpers/fetch-polyfill.browser.js",
-    "./lib/helpers/fetch-polyfill.node.js": "./lib/helpers/fetch-polyfill.browser.js"
+    "./lib/helpers/fetch-polyfill.node.js": "./lib/helpers/fetch-polyfill.browser.js",
+    "./src/helpers/abortcontroller-polyfill.node.js": "./src/helpers/abortcontroller-polyfill.browser.js",
+    "./es/helpers/abortcontroller-polyfill.node.js": "./es/helpers/abortcontroller-polyfill.browser.js",
+    "./lib/helpers/abortcontroller-polyfill.node.js": "./lib/helpers/abortcontroller-polyfill.browser.js"
   },
   "main": "lib/commonjs.js",
   "module": "es/index.js",
@@ -116,6 +119,7 @@
     "is-plain-object": "^5.0.0",
     "js-yaml": "^4.1.0",
     "node-fetch-commonjs": "^3.3.1",
+    "node-abort-controller": "^3.1.1",
     "qs": "^6.10.2",
     "traverse": "~0.6.6",
     "undici": "^5.24.0"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@swagger-api/apidom-json-pointer": ">=0.76.2 <1.0.0",
     "@swagger-api/apidom-ns-openapi-3-1": ">=0.76.2 <1.0.0",
     "@swagger-api/apidom-reference": ">=0.76.2 <1.0.0",
-    "abort-controller": "^3.0.0",
     "cookie": "~0.5.0",
     "deepmerge": "~4.3.0",
     "fast-json-patch": "^3.0.0-1",

--- a/src/helpers/abortcontroller-polyfill.browser.js
+++ b/src/helpers/abortcontroller-polyfill.browser.js
@@ -1,0 +1,8 @@
+import { AbortController, AbortSignal } from './abortcontroller-ponyfill.browser.js';
+
+if (typeof globalThis.AbortController === 'undefined') {
+  globalThis.AbortController = AbortController;
+}
+if (typeof globalThis.AbortSignal === 'undefined') {
+  globalThis.AbortSignal = AbortSignal;
+}

--- a/src/helpers/abortcontroller-polyfill.node.js
+++ b/src/helpers/abortcontroller-polyfill.node.js
@@ -1,0 +1,8 @@
+import { AbortController, AbortSignal } from './abortcontroller-ponyfill.node.js';
+
+if (typeof globalThis.AbortController === 'undefined') {
+  globalThis.AbortController = AbortController;
+}
+if (typeof globalThis.AbortSignal === 'undefined') {
+  globalThis.AbortSignal = AbortSignal;
+}

--- a/src/helpers/abortcontroller-ponyfill.browser.js
+++ b/src/helpers/abortcontroller-ponyfill.browser.js
@@ -1,0 +1,4 @@
+// we're targeting browsers that already support fetch API
+const { AbortController, AbortSignal } = globalThis;
+
+export { AbortController, AbortSignal };

--- a/src/helpers/abortcontroller-ponyfill.node.js
+++ b/src/helpers/abortcontroller-ponyfill.node.js
@@ -1,0 +1,1 @@
+export { AbortController, AbortSignal } from 'node-abort-controller';

--- a/src/resolver/apidom/reference/resolve/resolvers/http-swagger-client/index.js
+++ b/src/resolver/apidom/reference/resolve/resolvers/http-swagger-client/index.js
@@ -1,6 +1,7 @@
 import { ResolverError, HttpResolver } from '@swagger-api/apidom-reference/configuration/empty';
 
 import '../../../../../../helpers/fetch-polyfill.node.js';
+import '../../../../../../helpers/abortcontroller-polyfill.node.js';
 import Http from '../../../../../../http/index.js';
 
 const HttpResolverSwaggerClient = HttpResolver.compose({

--- a/src/resolver/apidom/reference/resolve/resolvers/http-swagger-client/index.js
+++ b/src/resolver/apidom/reference/resolve/resolvers/http-swagger-client/index.js
@@ -1,4 +1,3 @@
-import AbortController from 'abort-controller';
 import { ResolverError, HttpResolver } from '@swagger-api/apidom-reference/configuration/empty';
 
 import '../../../../../../helpers/fetch-polyfill.node.js';

--- a/test/execute/main.js
+++ b/test/execute/main.js
@@ -1,5 +1,3 @@
-import AbortController from 'abort-controller';
-
 import { execute, buildRequest, self as stubs } from '../../src/execute/index.js';
 // eslint-disable-next-line camelcase
 import normalize from '../../src/resolver/strategies/generic/normalize.js';

--- a/test/interfaces.js
+++ b/test/interfaces.js
@@ -1,5 +1,3 @@
-import AbortController from 'abort-controller';
-
 import {
   mapTagOperations,
   makeApisTagOperationsOperationExecute,

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -2,7 +2,6 @@ import process from 'node:process';
 import http from 'node:http';
 import path from 'node:path';
 import fs from 'node:fs';
-import AbortController from 'abort-controller';
 
 import {
   fetch,
@@ -22,9 +21,6 @@ globalThis.Response = Response;
 globalThis.FormData = FormData;
 globalThis.File = File;
 globalThis.Blob = Blob;
-
-// provide AbortController for older Node.js versions
-globalThis.AbortController = AbortController;
 
 // helpers for reading local files
 globalThis.loadFile = (uri) => fs.readFileSync(uri).toString();


### PR DESCRIPTION
For browser env, the native `AbortController` and `AbortSignal` will be used. For Node.js not supporting `AbortController` and `AbortSignal`, `node-abort-controller` npm package is used to provide the functionality.