### PR TITLE
Fix PathVariable pattern with *

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -10,18 +10,27 @@ export function path({ req, value, parameter }) {
     req.url = req.url
       .split(`{${name}}`)
       .join(encodeDisallowedCharacters(serialize(value, effectiveMediaType), { escape: true }));
+    req.url = req.url
+      .split(`{*${name}}`)
+      .join(encodeDisallowedCharacters(serialize(value, effectiveMediaType), { escape: false }));
     return;
   }
 
-  const styledValue = stylize({
+  req.url = req.url.split(`{${name}}`).join(stylize({
     key: parameter.name,
     value,
     style: style || 'simple',
     explode: explode || false,
     escape: true,
-  });
+  }));
 
-  req.url = req.url.split(`{${name}}`).join(styledValue);
+  req.url = req.url.split(`{*${name}}`).join(stylize({
+    key: parameter.name,
+    value,
+    style: style || 'simple',
+    explode: explode || false,
+    escape: false,
+  }));
 }
 
 export function query({ req, value, parameter }) {

--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -16,21 +16,25 @@ export function path({ req, value, parameter }) {
     return;
   }
 
-  req.url = req.url.split(`{${name}}`).join(stylize({
-    key: parameter.name,
-    value,
-    style: style || 'simple',
-    explode: explode || false,
-    escape: true,
-  }));
+  req.url = req.url.split(`{${name}}`).join(
+    stylize({
+      key: parameter.name,
+      value,
+      style: style || 'simple',
+      explode: explode || false,
+      escape: true,
+    })
+  );
 
-  req.url = req.url.split(`{*${name}}`).join(stylize({
-    key: parameter.name,
-    value,
-    style: style || 'simple',
-    explode: explode || false,
-    escape: false,
-  }));
+  req.url = req.url.split(`{*${name}}`).join(
+    stylize({
+      key: parameter.name,
+      value,
+      style: style || 'simple',
+      explode: explode || false,
+      escape: false,
+    })
+  );
 }
 
 export function query({ req, value, parameter }) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds a split, in OAS3 path builder, for Spring's PathVariable {*path} Pattern

### Description
<!--- Describe your changes in detail -->

Adds split on {*path} without escaping special characters to allow slash as in url endpoints

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

With Spring you can define a path pattern "/other/path/{*extra}" to match multiple segments at the end of a path.
So {*extra} might contains "other/path/segments" see https://spring.io/blog/2020/06/30/url-matching-with-pathpattern-in-spring-mvc for more info.


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested using this https://github.com/lucarota/file-server spring application as backend

### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
