### PR TITLE
fix: create default OpenAPI.servers fields if omitted

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -4,3 +4,4 @@ export { default as getOperationRaw } from './get-operation-raw.js';
 export { default as opId } from './op-id.js';
 export { default as idFromPathMethod } from './id-from-path-method/index.js';
 export { default as idFromPathMethodLegacy } from './id-from-path-method/legacy.js';
+export { default as isHttpUrl } from './is-http-url.js';

--- a/src/helpers/is-http-url.js
+++ b/src/helpers/is-http-url.js
@@ -1,4 +1,5 @@
 import { url } from '@swagger-api/apidom-reference/configuration/empty';
 
 const { isHttpUrl } = url;
+
 export default isHttpUrl;

--- a/src/helpers/is-http-url.js
+++ b/src/helpers/is-http-url.js
@@ -1,0 +1,4 @@
+import { url } from '@swagger-api/apidom-reference/configuration/empty';
+
+const { isHttpUrl } = url;
+export default isHttpUrl;

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ import openApi30ResolveStrategy from './resolver/strategies/openapi-3-0/index.js
 import openApi31ApiDOMResolveStrategy from './resolver/strategies/openapi-3-1-apidom/index.js';
 import { makeApisTagOperation } from './interfaces.js';
 import { execute, buildRequest, baseUrl } from './execute/index.js';
-import { opId } from './helpers/index.js';
+import { opId, isHttpUrl } from './helpers/index.js';
+import { isOpenAPI2, isOpenAPI3 } from './helpers/openapi-predicates.js';
 import HttpResolverSwaggerClient from './resolver/apidom/reference/resolve/resolvers/http-swagger-client/index.js';
 import JsonParser from './resolver/apidom/reference/parse/parsers/json/index.js';
 import YamlParser from './resolver/apidom/reference/parse/parsers/yaml-1-2/index.js';
@@ -131,8 +132,8 @@ Swagger.prototype = {
 Swagger.prototype.applyDefaults = function applyDefaults() {
   const { spec } = this;
   const specUrl = this.url;
-  // TODO: OAS3: support servers here
-  if (specUrl && specUrl.startsWith('http')) {
+
+  if (isOpenAPI2(spec) && isHttpUrl(specUrl)) {
     const parsed = new URL(specUrl);
     if (!spec.host) {
       spec.host = parsed.host;
@@ -142,6 +143,10 @@ Swagger.prototype.applyDefaults = function applyDefaults() {
     }
     if (!spec.basePath) {
       spec.basePath = '/';
+    }
+  } else if (isOpenAPI3(spec) && isHttpUrl(specUrl)) {
+    if (!spec.servers) {
+      spec.servers = [{ url: specUrl }];
     }
   }
 };


### PR DESCRIPTION
This change is specific to OpenAPI 3.x.y definitions.

Refs #3143

---

Supersedes https://github.com/swagger-api/swagger-js/pull/3218 