### PR TITLE
fix: create spec compliant default OpenAPI.servers fields if omitted

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -343,7 +343,7 @@ function oas3BaseUrl({ spec, pathName, method, server, contextUrl, serverVariabl
     [selectedServerObj] = servers;
   }
 
-  if (selectedServerUrl.indexOf('{') > -1) {
+  if (selectedServerUrl.includes('{')) {
     // do variable substitution
     const varNames = getVariableTemplateNames(selectedServerUrl);
     varNames.forEach((vari) => {

--- a/src/index.js
+++ b/src/index.js
@@ -144,9 +144,9 @@ Swagger.prototype.applyDefaults = function applyDefaults() {
     if (!spec.basePath) {
       spec.basePath = '/';
     }
-  } else if (isOpenAPI3(spec) && isHttpUrl(specUrl)) {
-    if (!spec.servers) {
-      spec.servers = [{ url: specUrl }];
+  } else if (isOpenAPI3(spec)) {
+    if (!spec.servers || (Array.isArray(spec.servers) && spec.servers.length === 0)) {
+      spec.servers = [{ url: '/' }];
     }
   }
 };


### PR DESCRIPTION
This change is specific to OpenAPI 3.x.y definitions.

Refs #3143

