### PR TITLE
fix(execute): handle Server Objects overrides for OpenAPI 2.0/3.0.x

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
 export const ACCEPT_HEADER_VALUE_FOR_DOCUMENTS = 'application/json, application/yaml';
 
 export const DEFAULT_BASE_URL = 'https://swagger.io';
+
+export const DEFAULT_OPENAPI_3_SERVER = Object.freeze({ url: '/' });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { DEFAULT_OPENAPI_3_SERVER } from './constants.js';
 import Http, { makeHttp, serializeRes, serializeHeaders } from './http/index.js';
 import { makeResolve } from './resolver/index.js';
 import { makeResolveSubtree } from './subtree-resolver/index.js';
@@ -135,6 +136,7 @@ Swagger.prototype.applyDefaults = function applyDefaults() {
 
   if (isOpenAPI2(spec) && isHttpUrl(specUrl)) {
     const parsed = new URL(specUrl);
+
     if (!spec.host) {
       spec.host = parsed.host;
     }
@@ -145,8 +147,10 @@ Swagger.prototype.applyDefaults = function applyDefaults() {
       spec.basePath = '/';
     }
   } else if (isOpenAPI3(spec)) {
-    if (!spec.servers || (Array.isArray(spec.servers) && spec.servers.length === 0)) {
-      spec.servers = [{ url: '/' }];
+    const isEmptyServerList = Array.isArray(spec.servers) && spec.servers.length === 0;
+
+    if (!spec.servers || isEmptyServerList) {
+      spec.servers = [DEFAULT_OPENAPI_3_SERVER];
     }
   }
 };


### PR DESCRIPTION
This change is specific to OpenAPI 2.0 and OpenAPI 3.0.x.

Refs #2967
