### PR TITLE
fix(execute): empty field added to multi-value parameters

### DIFF
--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -50,7 +50,7 @@ export function query({ req, value, parameter }) {
     value = '0';
   }
 
-  if (value) {
+  if (value && (!Array.isArray(value) || value.length > 0)) {
     const { style, explode, allowReserved } = parameter;
     req.query[parameter.name] = {
       value,
@@ -79,7 +79,7 @@ export function header({ req, parameter, value }) {
     return;
   }
 
-  if (typeof value !== 'undefined') {
+  if (typeof value !== 'undefined' && (!Array.isArray(value) || value.length > 0)) {
     req.headers[parameter.name] = stylize({
       key: parameter.name,
       value,
@@ -101,7 +101,7 @@ export function cookie({ req, parameter, value }) {
     return;
   }
 
-  if (type !== 'undefined') {
+  if (type !== 'undefined' && (!Array.isArray(value) || value.length > 0)) {
     const prefix =
       type === 'object' && !Array.isArray(value) && parameter.explode ? '' : `${parameter.name}=`;
 

--- a/src/execute/oas3/parameter-builders.js
+++ b/src/execute/oas3/parameter-builders.js
@@ -50,7 +50,7 @@ export function query({ req, value, parameter }) {
     value = '0';
   }
 
-  if (value && (!Array.isArray(value) || value.length > 0)) {
+  if (value) {
     const { style, explode, allowReserved } = parameter;
     req.query[parameter.name] = {
       value,
@@ -79,7 +79,7 @@ export function header({ req, parameter, value }) {
     return;
   }
 
-  if (typeof value !== 'undefined' && (!Array.isArray(value) || value.length > 0)) {
+  if (value !== undefined && !(Array.isArray(value) && value.length === 0)) {
     req.headers[parameter.name] = stylize({
       key: parameter.name,
       value,
@@ -101,7 +101,7 @@ export function cookie({ req, parameter, value }) {
     return;
   }
 
-  if (type !== 'undefined' && (!Array.isArray(value) || value.length > 0)) {
+  if (value !== undefined && !(Array.isArray(value) && value.length === 0)) {
     const prefix =
       type === 'object' && !Array.isArray(value) && parameter.explode ? '' : `${parameter.name}=`;
 

--- a/test/execute/openapi-3-1.js
+++ b/test/execute/openapi-3-1.js
@@ -122,60 +122,6 @@ describe('given OpenAPI 3.1.0 definition', () => {
           },
         },
       },
-      '/findWithQuery': {
-        get: {
-          operationId: 'findWithQuery',
-          parameters: [
-            {
-              name: 'status',
-              in: 'query',
-              schema: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  enum: ['admin', 'customer'],
-                },
-              },
-            },
-          ],
-        },
-      },
-      '/findWithHeader': {
-        get: {
-          operationId: 'findWithHeader',
-          parameters: [
-            {
-              name: 'status',
-              in: 'header',
-              schema: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  enum: ['admin', 'customer'],
-                },
-              },
-            },
-          ],
-        },
-      },
-      '/findWithCookie': {
-        get: {
-          operationId: 'findWithCookie',
-          parameters: [
-            {
-              name: 'status',
-              in: 'cookie',
-              schema: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                  enum: ['admin', 'customer'],
-                },
-              },
-            },
-          ],
-        },
-      },
     },
   };
   let server;
@@ -240,51 +186,6 @@ describe('given OpenAPI 3.1.0 definition', () => {
         accept: 'application/json',
         Authorization: 'Bearer 3492342948239482398',
       },
-      method: 'GET',
-    });
-  });
-
-  test('should build a request without empty multi-value parameters in query', () => {
-    const request = SwaggerClient.buildRequest({
-      spec,
-      operationId: 'findWithQuery',
-      parameters: { status: [] },
-    });
-
-    expect(request).toEqual({
-      url: 'http://localhost:8080/findWithQuery',
-      credentials: 'same-origin',
-      headers: {},
-      method: 'GET',
-    });
-  });
-
-  test('should build a request without empty multi-value parameters in header', () => {
-    const request = SwaggerClient.buildRequest({
-      spec,
-      operationId: 'findWithHeader',
-      parameters: { status: [] },
-    });
-
-    expect(request).toEqual({
-      url: 'http://localhost:8080/findWithHeader',
-      credentials: 'same-origin',
-      headers: {},
-      method: 'GET',
-    });
-  });
-
-  test('should build a request without empty multi-value parameters in cookie', () => {
-    const request = SwaggerClient.buildRequest({
-      spec,
-      operationId: 'findWithCookie',
-      parameters: { status: [] },
-    });
-
-    expect(request).toEqual({
-      url: 'http://localhost:8080/findWithCookie',
-      credentials: 'same-origin',
-      headers: {},
       method: 'GET',
     });
   });

--- a/test/execute/openapi-3-1.js
+++ b/test/execute/openapi-3-1.js
@@ -122,6 +122,60 @@ describe('given OpenAPI 3.1.0 definition', () => {
           },
         },
       },
+      '/findWithQuery': {
+        get: {
+          operationId: 'findWithQuery',
+          parameters: [
+            {
+              name: 'status',
+              in: 'query',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['admin', 'customer'],
+                },
+              },
+            },
+          ],
+        },
+      },
+      '/findWithHeader': {
+        get: {
+          operationId: 'findWithHeader',
+          parameters: [
+            {
+              name: 'status',
+              in: 'header',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['admin', 'customer'],
+                },
+              },
+            },
+          ],
+        },
+      },
+      '/findWithCookie': {
+        get: {
+          operationId: 'findWithCookie',
+          parameters: [
+            {
+              name: 'status',
+              in: 'cookie',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['admin', 'customer'],
+                },
+              },
+            },
+          ],
+        },
+      },
     },
   };
   let server;
@@ -185,6 +239,216 @@ describe('given OpenAPI 3.1.0 definition', () => {
       headers: {
         accept: 'application/json',
         Authorization: 'Bearer 3492342948239482398',
+      },
+      method: 'GET',
+    });
+  });
+
+  test('should build a request without empty multi-value parameters in query', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithQuery',
+      parameters: { status: [] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithQuery',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+
+  test('should build a request without empty multi-value parameters in header', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithHeader',
+      parameters: { status: [] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithHeader',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+
+  test('should build a request without empty multi-value parameters in cookie', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithCookie',
+      parameters: { status: [] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithCookie',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+});
+
+describe('given OpenAPI 3.1.0 definition with multi-value parameters', () => {
+  const spec = {
+    openapi: '3.1.0',
+    info: {
+      title: 'Testing API',
+      version: '1.0.0',
+    },
+    servers: [
+      {
+        url: 'http://localhost:8080',
+      },
+    ],
+    paths: {
+      '/findWithQuery': {
+        get: {
+          operationId: 'findWithQuery',
+          parameters: [
+            {
+              name: 'status',
+              in: 'query',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['admin', 'customer'],
+                },
+              },
+            },
+          ],
+        },
+      },
+      '/findWithHeader': {
+        get: {
+          operationId: 'findWithHeader',
+          parameters: [
+            {
+              name: 'status',
+              in: 'header',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['admin', 'customer'],
+                },
+              },
+            },
+          ],
+        },
+      },
+      '/findWithCookie': {
+        get: {
+          operationId: 'findWithCookie',
+          parameters: [
+            {
+              name: 'status',
+              in: 'cookie',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['admin', 'customer'],
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  test('should build a request without parameters in query', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithQuery',
+      parameters: { status: [] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithQuery',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+
+  test('should build a request with an empty string parameter in query', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithQuery',
+      parameters: { status: [''] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithQuery?status=',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+
+  test('should build a request without parameters in header', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithHeader',
+      parameters: { status: [] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithHeader',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+
+  test('should build a request with an empty string parameter in header', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithHeader',
+      parameters: { status: [''] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithHeader',
+      credentials: 'same-origin',
+      headers: {
+        status: '',
+      },
+      method: 'GET',
+    });
+  });
+
+  test('should build a request without parameters in cookie', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithCookie',
+      parameters: { status: [] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithCookie',
+      credentials: 'same-origin',
+      headers: {},
+      method: 'GET',
+    });
+  });
+
+  test('should build a request with an empty string parameter in cookie', () => {
+    const request = SwaggerClient.buildRequest({
+      spec,
+      operationId: 'findWithCookie',
+      parameters: { status: [''] },
+    });
+
+    expect(request).toEqual({
+      url: 'http://localhost:8080/findWithCookie',
+      credentials: 'same-origin',
+      headers: {
+        Cookie: 'status=',
       },
       method: 'GET',
     });


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/5176

Fixes the issue for when no value is selected, sending an empty string in an array after selecting the '--' option is a separate issue in Swagger UI.