### PR TITLE
fix(security): fix proxy-Authorization header security issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ Swagger Client Version | Release Date | OpenAPI Spec compatibility             |
 `swagger-client` requires Node.js `>=12.20.0` and uses different `fetch` implementation depending
 on Node.js version.
 
-- `>=12.20.0 <16.8` - [node-fetch@3](https://www.npmjs.com/package/node-fetch)
-- `>=16.8 <18` - [undici](https://www.npmjs.com/package/undici) 
+- `>=12.20.0 <18` - [node-fetch@3](https://www.npmjs.com/package/node-fetch) 
 - `>=18` - [native Node.js fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch)
 
 > NOTE: swagger-client minimum Node.js runtime version aligns with [Node.js Releases](https://nodejs.org/en/about/releases/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "rimraf": "=5.0.5",
         "source-map-explorer": "^2.5.3",
         "terser-webpack-plugin": "^5.0.3",
-        "undici": "^6.6.2",
+        "undici": "^5.28.3",
         "webpack": "=5.90.3",
         "webpack-bundle-size-analyzer": "=3.1.0",
         "webpack-cli": "=5.1.4",
@@ -14950,15 +14950,15 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
-      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,9 @@
         "is-plain-object": "^5.0.0",
         "js-yaml": "^4.1.0",
         "node-abort-controller": "^3.1.1",
-        "node-fetch-commonjs": "^3.3.1",
+        "node-fetch-commonjs": "^3.3.2",
         "qs": "^6.10.2",
-        "traverse": "~0.6.6",
-        "undici": "^5.24.0"
+        "traverse": "~0.6.6"
       },
       "devDependencies": {
         "@babel/cli": "^7.21.0",
@@ -57,6 +56,7 @@
         "rimraf": "=5.0.5",
         "source-map-explorer": "^2.5.3",
         "terser-webpack-plugin": "^5.0.3",
+        "undici": "^6.6.2",
         "webpack": "=5.90.3",
         "webpack-bundle-size-analyzer": "=3.1.0",
         "webpack-cli": "=5.1.4",
@@ -2570,9 +2570,10 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -14949,14 +14950,15 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.2.tgz",
-      "integrity": "sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.6.2.tgz",
+      "integrity": "sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==",
+      "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rimraf": "=5.0.5",
     "source-map-explorer": "^2.5.3",
     "terser-webpack-plugin": "^5.0.3",
+    "undici": "^6.6.2",
     "webpack": "=5.90.3",
     "webpack-bundle-size-analyzer": "=3.1.0",
     "webpack-cli": "=5.1.4",
@@ -119,11 +120,10 @@
     "fast-json-patch": "^3.0.0-1",
     "is-plain-object": "^5.0.0",
     "js-yaml": "^4.1.0",
-    "node-fetch-commonjs": "^3.3.1",
     "node-abort-controller": "^3.1.1",
+    "node-fetch-commonjs": "^3.3.2",
     "qs": "^6.10.2",
-    "traverse": "~0.6.6",
-    "undici": "^5.24.0"
+    "traverse": "~0.6.6"
   },
   "overrides": {
     "@swagger-api/apidom-reference": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "rimraf": "=5.0.5",
     "source-map-explorer": "^2.5.3",
     "terser-webpack-plugin": "^5.0.3",
-    "undici": "^6.6.2",
+    "undici": "^5.28.3",
     "webpack": "=5.90.3",
     "webpack-bundle-size-analyzer": "=3.1.0",
     "webpack-cli": "=5.1.4",

--- a/src/helpers/fetch-polyfill.node.js
+++ b/src/helpers/fetch-polyfill.node.js
@@ -1,13 +1,4 @@
 import {
-  fetch as fetchU,
-  Headers as HeaderU,
-  Request as RequestU,
-  Response as ResponseU,
-  FormData as FormDataU,
-  File as FileU,
-  Blob as BlobU,
-} from './fetch-ponyfill-undici.node.js';
-import {
   fetch as fetchNF,
   Headers as HeadersNF,
   Request as RequestNF,
@@ -18,23 +9,23 @@ import {
 } from './fetch-ponyfill-node-fetch.node.js';
 
 if (typeof globalThis.fetch === 'undefined') {
-  globalThis.fetch = fetchU || fetchNF;
+  globalThis.fetch = fetchNF;
 }
 if (typeof globalThis.Headers === 'undefined') {
-  globalThis.Headers = HeaderU || HeadersNF;
+  globalThis.Headers = HeadersNF;
 }
 if (typeof globalThis.Request === 'undefined') {
-  globalThis.Request = RequestU || RequestNF;
+  globalThis.Request = RequestNF;
 }
 if (typeof globalThis.Response === 'undefined') {
-  globalThis.Response = ResponseU || ResponseNF;
+  globalThis.Response = ResponseNF;
 }
 if (typeof globalThis.FormData === 'undefined') {
-  globalThis.FormData = FormDataU || FormDataNF;
+  globalThis.FormData = FormDataNF;
 }
 if (typeof globalThis.File === 'undefined') {
-  globalThis.File = FileU || FileNF;
+  globalThis.File = FileNF;
 }
 if (typeof globalThis.Blob === 'undefined') {
-  globalThis.Blob = BlobU || BlobNF;
+  globalThis.Blob = BlobNF;
 }

--- a/src/helpers/fetch-ponyfill-undici.node.js
+++ b/src/helpers/fetch-ponyfill-undici.node.js
@@ -1,6 +1,0 @@
-import { Blob } from 'buffer';
-import { fetch, Response, Headers, Request, FormData, File } from 'undici';
-
-const BlobU = typeof fetch === 'undefined' ? undefined : Blob;
-
-export { fetch, Response, Headers, Request, FormData, File, BlobU as Blob };

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -3,6 +3,7 @@ import process from 'node:process';
 import http from 'node:http';
 import path from 'node:path';
 import fs from 'node:fs';
+import { ReadableStream } from 'node:stream/web';
 import { fetch, Headers, Request, Response, FormData, File } from 'undici';
 
 // force using undici for testing
@@ -13,6 +14,7 @@ globalThis.Response = Response;
 globalThis.FormData = FormData;
 globalThis.File = File;
 globalThis.Blob = Blob;
+globalThis.ReadableStream = ReadableStream;
 
 // helpers for reading local files
 globalThis.loadFile = (uri) => fs.readFileSync(uri).toString();

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,17 +1,9 @@
+import { Blob } from 'node:buffer';
 import process from 'node:process';
 import http from 'node:http';
 import path from 'node:path';
 import fs from 'node:fs';
-
-import {
-  fetch,
-  Headers,
-  Request,
-  Response,
-  FormData,
-  File,
-  Blob,
-} from '../src/helpers/fetch-ponyfill-undici.node.js';
+import { fetch, Headers, Request, Response, FormData, File } from 'undici';
 
 // force using undici for testing
 globalThis.fetch = fetch;


### PR DESCRIPTION
Refs #3382
Refs https://github.com/nodejs/undici/issues/2521


Swagger-client Fetch API support in Node.js environment has moved from this:

```
>=12.20.0 <16.8 - [node-fetch@3](https://www.npmjs.com/package/node-fetch)
>=16.8 <18 - [undici](https://www.npmjs.com/package/undici)
>=18 - [native Node.js fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch)
```

to the following

```
>=12.20.0 <18 - [node-fetch@3](https://www.npmjs.com/package/node-fetch)
>=18 - [native Node.js fetch](https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#fetch)
```
