### PR TITLE
fix(execute): skip undefined parameters in body and path request builders for OpenAPI 2.0

### DIFF
--- a/src/execute/swagger2/parameter-builders.js
+++ b/src/execute/swagger2/parameter-builders.js
@@ -11,7 +11,9 @@ export default {
 
 // Add the body to the request
 function bodyBuilder({ req, value }) {
-  req.body = value;
+  if (value !== undefined) {
+    req.body = value;
+  }
 }
 
 // Add a form data object.
@@ -48,7 +50,9 @@ function headerBuilder({ req, parameter, value }) {
 
 // Replace path paramters, with values ( ie: the URL )
 function pathBuilder({ req, value, parameter }) {
-  req.url = req.url.split(`{${parameter.name}}`).join(encodeURIComponent(value));
+  if (value !== undefined) {
+    req.url = req.url.replace(new RegExp(`{${parameter.name}}`, 'g'), encodeURIComponent(value));
+  }
 }
 
 // Add a query to the `query` object, which will later be stringified into the URL's search

--- a/test/execute/main.js
+++ b/test/execute/main.js
@@ -1739,13 +1739,29 @@ describe('execute', () => {
           });
         });
 
-        test('should generate a request with an empty body parameter', () => {
+        test('should not generate a request with an empty body parameter', () => {
           const req = buildRequest({ spec, operationId: 'postMe', parameters: {} });
 
-          expect(req).toEqual({
+          expect(req).toStrictEqual({
             url: 'http://swagger.io/v1/one',
             method: 'POST',
-            body: undefined,
+            credentials: 'same-origin',
+            headers: {},
+          });
+        });
+
+        test('should not generate a request with an undefined body parameter', () => {
+          const req = buildRequest({
+            spec,
+            operationId: 'postMe',
+            parameters: {
+              bodyParam: undefined,
+            },
+          });
+
+          expect(req).toStrictEqual({
+            url: 'http://swagger.io/v1/one',
+            method: 'POST',
             credentials: 'same-origin',
             headers: {},
           });
@@ -1960,6 +1976,41 @@ describe('execute', () => {
 
         expect(req).toEqual({
           url: 'http://swagger.io/v1/123',
+          method: 'GET',
+          credentials: 'same-origin',
+          headers: {},
+        });
+      });
+
+      test('should not replace path parameters with undefined values', () => {
+        const spec = {
+          host: 'swagger.io',
+          basePath: '/v1',
+          paths: {
+            '/{id}/{status}': {
+              get: {
+                operationId: 'getMe',
+                parameters: [
+                  {
+                    in: 'path',
+                    name: 'id',
+                    type: 'number',
+                  },
+                  {
+                    in: 'path',
+                    name: 'status',
+                    type: 'string',
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const req = buildRequest({ spec, operationId: 'getMe', parameters: { id: undefined } });
+
+        expect(req).toEqual({
+          url: 'http://swagger.io/v1/{id}/{status}',
           method: 'GET',
           credentials: 'same-origin',
           headers: {},


### PR DESCRIPTION
Refs #3438