### PR TITLE
fix(execute): fix encoding of complex nested type values in OpenAPI 3.x request builders

### DIFF
--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -6,6 +6,11 @@ export function encodeDisallowedCharacters(str, { escape } = {}, parse) {
   if (typeof str === 'number') {
     str = str.toString();
   }
+
+  if (typeof str === 'object' && !Array.isArray(str)) {
+    str = JSON.stringify(str);
+  }
+
   if (typeof str !== 'string' || !str.length) {
     return str;
   }

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -7,10 +7,6 @@ export function encodeDisallowedCharacters(str, { escape } = {}, parse) {
     str = str.toString();
   }
 
-  if (str !== null && typeof str === 'object' && !Array.isArray(str)) {
-    str = JSON.stringify(str);
-  }
-
   if (typeof str !== 'string' || !str.length) {
     return str;
   }
@@ -60,23 +56,29 @@ export default function stylize(config) {
   return encodePrimitive(config);
 }
 
-function encodeArray({ key, value, style, explode, escape }) {
-  const valueEncoder = (str) =>
-    encodeDisallowedCharacters(str, {
-      escape,
-    });
+function valueEncoder(value, escape) {
+  if (value !== null && typeof value === 'object') {
+    value = JSON.stringify(value);
+  } else if (typeof val === 'number') {
+    value = value.toString();
+  }
+  return encodeDisallowedCharacters(value, {
+    escape,
+  });
+}
 
+function encodeArray({ key, value, style, explode, escape }) {
   if (style === 'simple') {
-    return value.map((val) => valueEncoder(val)).join(',');
+    return value.map((val) => valueEncoder(val, escape)).join(',');
   }
 
   if (style === 'label') {
-    return `.${value.map((val) => valueEncoder(val)).join('.')}`;
+    return `.${value.map((val) => valueEncoder(val, escape)).join('.')}`;
   }
 
   if (style === 'matrix') {
     return value
-      .map((val) => valueEncoder(val))
+      .map((val) => valueEncoder(val, escape))
       .reduce((prev, curr) => {
         if (!prev || explode) {
           return `${prev || ''};${key}=${curr}`;
@@ -87,33 +89,28 @@ function encodeArray({ key, value, style, explode, escape }) {
 
   if (style === 'form') {
     const after = explode ? `&${key}=` : ',';
-    return value.map((val) => valueEncoder(val)).join(after);
+    return value.map((val) => valueEncoder(val, escape)).join(after);
   }
 
   if (style === 'spaceDelimited') {
     const after = explode ? `${key}=` : '';
-    return value.map((val) => valueEncoder(val)).join(` ${after}`);
+    return value.map((val) => valueEncoder(val, escape)).join(` ${after}`);
   }
 
   if (style === 'pipeDelimited') {
     const after = explode ? `${key}=` : '';
-    return value.map((val) => valueEncoder(val)).join(`|${after}`);
+    return value.map((val) => valueEncoder(val, escape)).join(`|${after}`);
   }
 
   return undefined;
 }
 
 function encodeObject({ key, value, style, explode, escape }) {
-  const valueEncoder = (str) =>
-    encodeDisallowedCharacters(str, {
-      escape,
-    });
-
   const valueKeys = Object.keys(value);
 
   if (style === 'simple') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr]);
+      const val = valueEncoder(value[curr], escape);
       const middleChar = explode ? '=' : ',';
       const prefix = prev ? `${prev},` : '';
 
@@ -123,7 +120,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'label') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr]);
+      const val = valueEncoder(value[curr], escape);
       const middleChar = explode ? '=' : '.';
       const prefix = prev ? `${prev}.` : '.';
 
@@ -133,7 +130,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'matrix' && explode) {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr]);
+      const val = valueEncoder(value[curr], escape);
       const prefix = prev ? `${prev};` : ';';
 
       return `${prefix}${curr}=${val}`;
@@ -143,7 +140,7 @@ function encodeObject({ key, value, style, explode, escape }) {
   if (style === 'matrix') {
     // no explode
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr]);
+      const val = valueEncoder(value[curr], escape);
       const prefix = prev ? `${prev},` : `;${key}=`;
 
       return `${prefix}${curr},${val}`;
@@ -152,7 +149,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'form') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr]);
+      const val = valueEncoder(value[curr], escape);
       const prefix = prev ? `${prev}${explode ? '&' : ','}` : '';
       const separator = explode ? '=' : ',';
 
@@ -164,29 +161,24 @@ function encodeObject({ key, value, style, explode, escape }) {
 }
 
 function encodePrimitive({ key, value, style, escape }) {
-  const valueEncoder = (str) =>
-    encodeDisallowedCharacters(str, {
-      escape,
-    });
-
   if (style === 'simple') {
-    return valueEncoder(value);
+    return valueEncoder(value, escape);
   }
 
   if (style === 'label') {
-    return `.${valueEncoder(value)}`;
+    return `.${valueEncoder(value, escape)}`;
   }
 
   if (style === 'matrix') {
-    return `;${key}=${valueEncoder(value)}`;
+    return `;${key}=${valueEncoder(value, escape)}`;
   }
 
   if (style === 'form') {
-    return valueEncoder(value);
+    return valueEncoder(value, escape);
   }
 
   if (style === 'deepObject') {
-    return valueEncoder(value, {}, true);
+    return valueEncoder(value, escape);
   }
 
   return undefined;

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -7,7 +7,7 @@ export function encodeDisallowedCharacters(str, { escape } = {}, parse) {
     str = str.toString();
   }
 
-  if (typeof str === 'object' && !Array.isArray(str)) {
+  if (str !== null && typeof str === 'object' && !Array.isArray(str)) {
     str = JSON.stringify(str);
   }
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -56,11 +56,9 @@ export default function stylize(config) {
   return encodePrimitive(config);
 }
 
-function valueEncoder(value, escape) {
-  if (value !== null && typeof value === 'object') {
+export function valueEncoder(value, escape) {
+  if (Array.isArray(value) || (value !== null && typeof value === 'object')) {
     value = JSON.stringify(value);
-  } else if (typeof val === 'number') {
-    value = value.toString();
   }
   return encodeDisallowedCharacters(value, {
     escape,

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -2,7 +2,7 @@ import qs from 'qs';
 import jsYaml from 'js-yaml';
 
 import '../helpers/fetch-polyfill.node.js';
-import { encodeDisallowedCharacters } from '../execute/oas3/style-serializer.js';
+import { valueEncoder } from '../execute/oas3/style-serializer.js';
 
 // For testing
 export const self = {
@@ -320,17 +320,7 @@ function formatKeyValueBySerializationOption(key, value, skipEncoding, serializa
       ? 'unsafe'
       : 'reserved';
 
-  const encodeFn = (v) => {
-    if (v !== null && typeof v === 'object') {
-      v = JSON.stringify(v);
-    } else if (typeof val === 'number') {
-      v = v.toString();
-    }
-    return encodeDisallowedCharacters(v, {
-      escape,
-    });
-  };
-
+  const encodeFn = (v) => valueEncoder(v, escape);
   const encodeKeyFn = skipEncoding ? (k) => k : (k) => encodeFn(k);
 
   // Primitive

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -319,8 +319,19 @@ function formatKeyValueBySerializationOption(key, value, skipEncoding, serializa
     : serializationOption && serializationOption.allowReserved
       ? 'unsafe'
       : 'reserved';
-  const encodeFn = (v) => encodeDisallowedCharacters(v, { escape });
-  const encodeKeyFn = skipEncoding ? (k) => k : (k) => encodeDisallowedCharacters(k, { escape });
+
+  const encodeFn = (v) => {
+    if (v !== null && typeof v === 'object') {
+      v = JSON.stringify(v);
+    } else if (typeof val === 'number') {
+      v = v.toString();
+    }
+    return encodeDisallowedCharacters(v, {
+      escape,
+    });
+  };
+
+  const encodeKeyFn = skipEncoding ? (k) => k : (k) => encodeFn(k);
 
   // Primitive
   if (typeof value !== 'object') {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -524,7 +524,55 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         method: 'GET',
       });
     });
+  });
+  describe('with petstore v3', () => {
+    it('should build updatePetWithForm correctly', () => {
+      const req = buildRequest({
+        spec: petstoreSpec,
+        requestContentType: 'application/x-www-form-urlencoded',
+        operationId: 'updatePetWithForm',
+        parameters: {
+          petId: 1234,
+        },
+        requestBody: {
+          thePetId: 1234,
+          name: 'OAS3 pet',
+        },
+      });
 
+      expect(req).toEqual({
+        method: 'POST',
+        url: 'http://petstore.swagger.io/v2/pet/1234',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: 'thePetId=1234&name=OAS3%20pet',
+      });
+    });
+
+    it('should build addPet correctly', () => {
+      const req = buildRequest({
+        spec: petstoreSpec,
+        operationId: 'addPet',
+        requestBody: {
+          one: 1,
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: 'http://petstore.swagger.io/v2/pet',
+        credentials: 'same-origin',
+        headers: {},
+        body: {
+          one: 1,
+        },
+      });
+    });
+  });
+
+  describe('`schema` parameters', () => {
     it('should encode JSON values provided as objects', () => {
       const req = buildRequest({
         spec: {
@@ -612,52 +660,6 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         headers: {
           FooHeader: 'a={"b":{"c":{"d":"e"}}}',
           Cookie: 'myCookie=foo,{"bar":{"baz":"qux"}}',
-        },
-      });
-    });
-  });
-  describe('with petstore v3', () => {
-    it('should build updatePetWithForm correctly', () => {
-      const req = buildRequest({
-        spec: petstoreSpec,
-        requestContentType: 'application/x-www-form-urlencoded',
-        operationId: 'updatePetWithForm',
-        parameters: {
-          petId: 1234,
-        },
-        requestBody: {
-          thePetId: 1234,
-          name: 'OAS3 pet',
-        },
-      });
-
-      expect(req).toEqual({
-        method: 'POST',
-        url: 'http://petstore.swagger.io/v2/pet/1234',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: 'thePetId=1234&name=OAS3%20pet',
-      });
-    });
-
-    it('should build addPet correctly', () => {
-      const req = buildRequest({
-        spec: petstoreSpec,
-        operationId: 'addPet',
-        requestBody: {
-          one: 1,
-        },
-      });
-
-      expect(req).toEqual({
-        method: 'POST',
-        url: 'http://petstore.swagger.io/v2/pet',
-        credentials: 'same-origin',
-        headers: {},
-        body: {
-          one: 1,
         },
       });
     });

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -524,6 +524,97 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         method: 'GET',
       });
     });
+
+    it('should encode JSON values provided as objects', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/{pathPartial}': {
+              post: {
+                operationId: 'myOp',
+                parameters: [
+                  {
+                    name: 'query',
+                    in: 'query',
+                    schema: {
+                      type: 'object',
+                    },
+                  },
+                  {
+                    name: 'FooHeader',
+                    in: 'header',
+                    schema: {
+                      type: 'object',
+                    },
+                    explode: true,
+                  },
+                  {
+                    name: 'pathPartial',
+                    in: 'path',
+                    schema: {
+                      type: 'object',
+                    },
+                    explode: true,
+                  },
+                  {
+                    name: 'myCookie',
+                    in: 'cookie',
+                    schema: {
+                      type: 'object',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        parameters: {
+          query: {
+            a: {
+              b: {
+                c: 'd',
+              },
+            },
+          },
+          FooHeader: {
+            a: {
+              b: {
+                c: {
+                  d: 'e',
+                },
+              },
+            },
+          },
+          pathPartial: {
+            foo: {
+              bar: { baz: 'qux' },
+            },
+            a: {
+              b: {
+                c: 'd',
+              },
+            },
+          },
+          myCookie: {
+            foo: {
+              bar: { baz: 'qux' },
+            },
+          },
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/foo=${escape('{"bar":{"baz":"qux"}}')},a=${escape('{"b":{"c":"d"}}')}?a=${escape('{"b":{"c":"d"}}')}`,
+        credentials: 'same-origin',
+        headers: {
+          FooHeader: 'a={"b":{"c":{"d":"e"}}}',
+          Cookie: 'myCookie=foo,{"bar":{"baz":"qux"}}',
+        },
+      });
+    });
   });
   describe('with petstore v3', () => {
     it('should build updatePetWithForm correctly', () => {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -663,6 +663,133 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         },
       });
     });
+
+    it('should encode arrays of arrays and objects', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/': {
+              post: {
+                operationId: 'myOp',
+                parameters: [
+                  {
+                    name: 'arrayOfObjects',
+                    in: 'query',
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                      },
+                    },
+                    explode: false,
+                  },
+                  {
+                    name: 'arrayOfArrays',
+                    in: 'query',
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                        },
+                      },
+                    },
+                    explode: false,
+                  },
+                  {
+                    name: 'headerArrayOfObjects',
+                    in: 'header',
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                      },
+                    },
+                  },
+                  {
+                    name: 'headerArrayOfArrays',
+                    in: 'header',
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        parameters: {
+          arrayOfObjects: [
+            {
+              a: {
+                b: 'c',
+              },
+            },
+            {
+              d: {
+                e: 'f',
+              },
+            },
+          ],
+          arrayOfArrays: [
+            [
+              {
+                a: {
+                  b: 'c',
+                },
+              },
+            ],
+          ],
+          headerArrayOfObjects: [
+            {
+              a: {
+                b: 'c',
+              },
+            },
+            {
+              d: {
+                e: 'f',
+              },
+            },
+          ],
+          headerArrayOfArrays: [
+            [
+              {
+                a: {
+                  b: 'c',
+                },
+              },
+            ],
+            [
+              {
+                d: {
+                  e: 'f',
+                },
+              },
+            ],
+          ],
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/?arrayOfObjects=${escape('{"a":{"b":"c"}}')},${escape('{"d":{"e":"f"}}')}&arrayOfArrays=${escape('[{"a":{"b":"c"}}]')}`,
+        credentials: 'same-origin',
+        headers: {
+          headerArrayOfObjects: '{"a":{"b":"c"}},{"d":{"e":"f"}}',
+          headerArrayOfArrays: '[{"a":{"b":"c"}}],[{"d":{"e":"f"}}]',
+        },
+      });
+    });
   });
 
   describe('`content` parameters', () => {


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/9755

From the test example, when encoding these parameters:
```
query: {
  a: {
    b: {
      c: 'd',
    },
  },
},
pathPartial: {
  foo: {
    bar: { baz: 'qux' },
  },
  a: {
    b: {
      c: 'd',
    },
  },
}
```
we will now get the following URL:
```
/foo=%7B%22bar%22%3A%7B%22baz%22%3A%22qux%22%7D%7D,a=%7B%22b%22%3A%7B%22c%22%3A%22d%22%7D%7D?a=%7B%22b%22%3A%7B%22c%22%3A%22d%22%7D%7D
```

which will decode to: 
```
/foo={"bar":{"baz":"qux"}},a={"b":{"c":"d"}}?a={"b":{"c":"d"}}
```

The cURL result for the 2.0 specification is:
```
curl -X 'GET' \
'https://petstore.swagger.io/v2/pet/findByStatus/%7B%22test%22%3A%20%7B%22test2%22%3A%20%22test3%22%20%7D%20%7D?queryParam=%7B%22test%22%3A%20%7B%22test2%22%3A%20%22test3%22%20%7D%20%7D' \
  -H 'accept: application/xml' \
  -H 'headerParam: {"test": {"test2": "test3" } }'
```
and the URL decodes to: 
```
https://petstore.swagger.io/v2/pet/findByStatus/{"test": {"test2": "test3" } }?queryParam={"test": {"test2": "test3" } }
```
so it seems to me like it doesn't need any changes.




