### PR TITLE
fix(execute): parse stringified objects nested in arrays

### DIFF
--- a/src/execute/oas3/content-serializer.js
+++ b/src/execute/oas3/content-serializer.js
@@ -23,5 +23,5 @@ export default function serialize(value, mediaType) {
     return JSON.stringify(value);
   }
 
-  return value.toString();
+  return String(value);
 }

--- a/src/execute/oas3/content-serializer.js
+++ b/src/execute/oas3/content-serializer.js
@@ -9,6 +9,17 @@ export default function serialize(value, mediaType) {
       // Assume the user has a JSON string
       return value;
     }
+
+    if (Array.isArray(value)) {
+      value = value.map((v) => {
+        try {
+          return JSON.parse(v);
+        } catch (e) {
+          return v;
+        }
+      });
+    }
+
     return JSON.stringify(value);
   }
 

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -871,6 +871,96 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       });
     });
 
+    it('should serialize JSON values provided as arrays of stringified objects', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/{pathPartial}': {
+              post: {
+                operationId: 'myOp',
+                parameters: [
+                  {
+                    name: 'query',
+                    in: 'query',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                          },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    name: 'FooHeader',
+                    in: 'header',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                          },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    name: 'pathPartial',
+                    in: 'path',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                          },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    name: 'myCookie',
+                    in: 'cookie',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        parameters: {
+          query: ['{"a":1}', '{"b":"2"}'],
+          FooHeader: ['{"foo":"bar"}'],
+          pathPartial: ['{"baz":"qux"}'],
+          myCookie: ['{"flavor":"chocolate chip"}'],
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/${escape('[{"baz":"qux"}]')}?query=${escape('[{"a":1},{"b":"2"}]')}`,
+        credentials: 'same-origin',
+        headers: {
+          FooHeader: '[{"foo":"bar"}]',
+          Cookie: 'myCookie=[{"flavor":"chocolate chip"}]',
+        },
+      });
+    });
+
     it('should not serialize undefined parameters', () => {
       const spec = {
         openapi: '3.0.1',


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/9521

The URL for this example:

<img width="576" alt="Screenshot 2024-04-10 at 14 36 22" src="https://github.com/swagger-api/swagger-js/assets/44094416/3510fd14-0f4a-4078-be03-e27b99de4b60">

should now be encoded as:
```
http://localhost:3200/endpoint?param=%5B%7B%22a%22%3A%7B%22c%22%3A%22string%22%7D%2C%22b%22%3A0%7D%5D
```

which should decode to:
```
http://localhost:3200/endpoint?param=[{"a":{"c":"string"},"b":0}]
```


