### PR TITLE
fix(execute): parse stringified objects

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -323,6 +323,14 @@ function formatKeyValueBySerializationOption(key, value, skipEncoding, serializa
   const encodeFn = (v) => valueEncoder(v, escape);
   const encodeKeyFn = skipEncoding ? (k) => k : (k) => encodeFn(k);
 
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      // can't parse the value so treat it as as a simple string
+    }
+  }
+
   // Primitive
   if (typeof value !== 'object') {
     return [[encodeKeyFn(key), encodeFn(value)]];
@@ -442,7 +450,13 @@ export function mergeInQueryOrForm(req = {}) {
       req.formdata = formdata;
       req.body = formdata;
     } else {
-      req.body = encodeFormOrQuery(form);
+      let data = {};
+      if (typeof form === 'string') {
+        data = { form };
+      } else {
+        data = form;
+      }
+      req.body = encodeFormOrQuery(data);
     }
 
     delete req.form;

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -450,13 +450,7 @@ export function mergeInQueryOrForm(req = {}) {
       req.formdata = formdata;
       req.body = formdata;
     } else {
-      let data = {};
-      if (typeof form === 'string') {
-        data = { form };
-      } else {
-        data = form;
-      }
-      req.body = encodeFormOrQuery(data);
+      req.body = encodeFormOrQuery(form);
     }
 
     delete req.form;

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -871,6 +871,71 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       });
     });
 
+    it('should serialize JSON values provided as objects in `deepObject` style', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/': {
+              post: {
+                operationId: 'myOp',
+                requestBody: {
+                  content: {
+                    'application/x-www-form-urlencoded': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          a: {
+                            type: 'object',
+                            properties: {
+                              b: {
+                                type: 'string',
+                              },
+                              c: {
+                                type: 'array',
+                              },
+                              d: {
+                                type: 'object',
+                              },
+                            },
+                          },
+                        },
+                      },
+                      encoding: {
+                        a: {
+                          style: 'deepObject',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        requestBody: {
+          a: {
+            b: 'c',
+            c: ['d', 'e'],
+            d: {
+              e: 'f',
+            },
+          },
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/`,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        credentials: 'same-origin',
+        body: 'a%5Bb%5D=c&a%5Bc%5D=%5B%22d%22%2C%22e%22%5D&a%5Bd%5D=%7B%22e%22%3A%22f%22%7D',
+      });
+    });
+
     it('should serialize JSON values provided as arrays of stringified objects', () => {
       const req = buildRequest({
         spec: {


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/7734

This example from the test:
```js
requestBody: {
  a: {
    b: 'c',
    c: ['d', 'e'],
    d: {
      e: 'f',
    },
  },
},
```
will return: 
```
a%5Bb%5D=c&a%5Bc%5D=%5B%22d%22%2C%22e%22%5D&a%5Bd%5D=%7B%22e%22%3A%22f%22%7D
```
which should decode to:
```
a[b]=c&a[c]=["d","e"]&a[d]={"e":"f"}
```

As established for previous issues, we're not encoding nested objects/arrays, as the behaviour for that is undefined.