### PR TITLE
fix(execute): fix encoding for stringified request body

### DIFF
--- a/src/http/index.js
+++ b/src/http/index.js
@@ -405,6 +405,19 @@ export function encodeFormOrQuery(data) {
    * @param {string} parameterName - Parameter name
    * @return {object} encoded parameter names and values
    */
+  if (typeof data === 'string') {
+    try {
+      data = JSON.parse(data);
+      Object.entries(data).forEach(([key, value]) => {
+        if (typeof value === 'object' && !Array.isArray(value)) {
+          data[key] = JSON.stringify(value);
+        }
+      });
+    } catch {
+      return valueEncoder(data, 'reserved');
+    }
+  }
+
   const encodedQuery = Object.keys(data).reduce((result, parameterName) => {
     // eslint-disable-next-line no-restricted-syntax
     for (const [key, value] of formatKeyValue(parameterName, data[parameterName])) {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -961,6 +961,45 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       });
     });
 
+    it('should serialize JSON values provided for schemas without properties', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/': {
+              post: {
+                operationId: 'myOp',
+                requestBody: {
+                  content: {
+                    'application/x-www-form-urlencoded': {
+                      schema: {
+                        type: 'object',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        requestBody: JSON.stringify({
+          primitiveParam: 'string',
+          objectParam: { a: { b: 'c' }, d: [1, 2, 3] },
+        }),
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/`,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        credentials: 'same-origin',
+        body: 'primitiveParam=string&objectParam=%7B%22a%22%3A%7B%22b%22%3A%22c%22%7D%2C%22d%22%3A%5B1%2C2%2C3%5D%7D',
+      });
+    });
+
     it('should not serialize undefined parameters', () => {
       const spec = {
         openapi: '3.0.1',


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/7810

With these changes we should now parse the string and then iterate through it only if it's actually an object.

The issue is that we are sending a stringified object and then iterating through it as if it were just an object. It happened even if I updated the examples in the specification provided in the issue, which seemed wronged to me,  to:
```yaml
examples:
  authorization_code grant type:
    description: authorization_code grant type
    value:
      grant_type: authorization_code
      code: xxxxxxxxxx
      client_id: xxxxxxxxxx
  client_credentials grant type:
    description: client_credentials grant type
    value: 
      grant_type: client_credentials
      client_id: xxxxxxxxxx
      client_secret: xxxxxxxxxx
  refresh_token grant type:
    description: refresh_token grant type
    value: 
      grant_type: refresh_token
      refresh_token: xxxxxxxxxx
```
so that it shows as an object in Swagger UI:

<img width="404" alt="Screenshot 2024-04-22 at 14 38 52" src="https://github.com/swagger-api/swagger-js/assets/44094416/c6f2e1d3-9374-47f1-90bd-e863953e746b">

