### PR TITLE
refactor(http): refactor http client

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -3,7 +3,8 @@ import { isPlainObject } from 'is-plain-object';
 import { url } from '@swagger-api/apidom-reference/configuration/empty';
 
 import { DEFAULT_BASE_URL, DEFAULT_OPENAPI_3_SERVER } from '../constants.js';
-import stockHttp, { mergeInQueryOrForm } from '../http/index.js';
+import stockHttp from '../http/index.js';
+import { serializeRequest } from '../http/serializers/request/index.js';
 import createError from '../specmap/lib/create-error.js';
 import SWAGGER2_PARAMETER_BUILDERS from './swagger2/parameter-builders.js';
 import * as OAS3_PARAMETER_BUILDERS from './oas3/parameter-builders.js';
@@ -305,9 +306,7 @@ export function buildRequest(options) {
 
   // Will add the query object into the URL, if it exists
   // ... will also create a FormData instance, if multipart/form-data (eg: a file)
-  mergeInQueryOrForm(req);
-
-  return req;
+  return serializeRequest(req);
 }
 
 const stripNonAlpha = (str) => (str ? str.replace(/\W/g, '') : null);

--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -64,11 +64,32 @@ export default function buildRequest(options, req) {
 
             req.form = {};
             Object.keys(requestBody).forEach((k) => {
+              let value;
+              try {
+                value = JSON.parse(requestBody[k]);
+              } catch {
+                value = requestBody[k];
+              }
               req.form[k] = {
-                value: requestBody[k],
+                value,
                 encoding: encoding[k] || {},
               };
             });
+          } else if (typeof requestBody === 'string') {
+            const encoding = requestBodyDef.content[requestContentType]?.encoding ?? {};
+
+            try {
+              req.form = {};
+              const form = JSON.parse(requestBody);
+              Object.entries(form).forEach(([key, value]) => {
+                req.form[key] = {
+                  value,
+                  encoding: encoding[key] || {},
+                };
+              });
+            } catch {
+              req.form = requestBody;
+            }
           } else {
             req.form = requestBody;
           }

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -1,14 +1,10 @@
-import qs from 'qs';
-import jsYaml from 'js-yaml';
-
 import '../helpers/fetch-polyfill.node.js';
-import { valueEncoder } from '../execute/oas3/style-serializer.js';
-
-// For testing
-export const self = {
+import { mergeInQueryOrForm, encodeFormOrQuery, isFile } from './serializers/request/index.js';
+import {
   serializeRes,
-  mergeInQueryOrForm,
-};
+  serializeHeaders,
+  shouldDownloadAsText,
+} from './serializers/response/index.js';
 
 // Handles fetch-like syntax and the case where there is only one object passed-in
 // (which will have the URL as a property). Also serializes the response.
@@ -23,7 +19,7 @@ export default async function http(url, request = {}) {
   // Serializes query, for convenience
   // Should be the last thing we do, as its hard to mutate the URL with
   // the search string, but much easier to manipulate the req.query object
-  self.mergeInQueryOrForm(request);
+  mergeInQueryOrForm(request);
 
   // Newlines in header values cause weird error messages from `window.fetch`,
   // so let's message them out.
@@ -59,7 +55,7 @@ export default async function http(url, request = {}) {
   let res;
   try {
     res = await (request.userFetch || fetch)(request.url, request);
-    res = await self.serializeRes(res, url, request);
+    res = await serializeRes(res, url, request);
     if (request.responseInterceptor) {
       res = (await request.responseInterceptor(res)) || res;
     }
@@ -85,418 +81,26 @@ export default async function http(url, request = {}) {
   return res;
 }
 
-// exported for testing
-export const shouldDownloadAsText = (contentType = '') =>
-  /(json|xml|yaml|text)\b/.test(contentType);
-
-function parseBody(body, contentType) {
-  if (
-    contentType &&
-    (contentType.indexOf('application/json') === 0 || contentType.indexOf('+json') > 0)
-  ) {
-    return JSON.parse(body);
-  }
-  return jsYaml.load(body);
-}
-
-// Serialize the response, returns a promise with headers and the body part of the hash
-export function serializeRes(oriRes, url, { loadSpec = false } = {}) {
-  const res = {
-    ok: oriRes.ok,
-    url: oriRes.url || url,
-    status: oriRes.status,
-    statusText: oriRes.statusText,
-    headers: serializeHeaders(oriRes.headers),
-  };
-  const contentType = res.headers['content-type'];
-  const useText = loadSpec || shouldDownloadAsText(contentType);
-  const getBody = useText ? oriRes.text : oriRes.blob || oriRes.buffer;
-  return getBody.call(oriRes).then((body) => {
-    res.text = body;
-    res.data = body;
-    if (useText) {
-      try {
-        const obj = parseBody(body, contentType);
-        res.body = obj;
-        res.obj = obj;
-      } catch (e) {
-        res.parseError = e;
-      }
-    }
-    return res;
-  });
-}
-
-function serializeHeaderValue(value) {
-  const isMulti = value.includes(', ');
-
-  return isMulti ? value.split(', ') : value;
-}
-
-// Serialize headers into a hash, where mutliple-headers result in an array.
-//
-// eg: Cookie: one
-//     Cookie: two
-//  =  { Cookie: [ "one", "two" ]
-export function serializeHeaders(headers = {}) {
-  if (typeof headers.entries !== 'function') return {};
-
-  return Array.from(headers.entries()).reduce((acc, [header, value]) => {
-    acc[header] = serializeHeaderValue(value);
-    return acc;
-  }, {});
-}
-
-export function isFile(obj, navigatorObj) {
-  if (!navigatorObj && typeof navigator !== 'undefined') {
-    // eslint-disable-next-line no-undef
-    navigatorObj = navigator;
-  }
-  if (navigatorObj && navigatorObj.product === 'ReactNative') {
-    if (obj && typeof obj === 'object' && typeof obj.uri === 'string') {
-      return true;
-    }
-    return false;
-  }
-
-  if (typeof File !== 'undefined' && obj instanceof File) {
-    return true;
-  }
-  if (typeof Blob !== 'undefined' && obj instanceof Blob) {
-    return true;
-  }
-  if (ArrayBuffer.isView(obj)) {
-    return true;
-  }
-
-  return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function';
-}
-
-function isArrayOfFile(obj, navigatorObj) {
-  return Array.isArray(obj) && obj.some((v) => isFile(v, navigatorObj));
-}
-
-const STYLE_SEPARATORS = {
-  form: ',',
-  spaceDelimited: '%20',
-  pipeDelimited: '|',
-};
-
-const SEPARATORS = {
-  csv: ',',
-  ssv: '%20',
-  tsv: '%09',
-  pipes: '|',
-};
-
-/**
- * Specialized sub-class of File class, that only
- * accepts string data and retain this data in `data`
- * public property throughout the lifecycle of its instances.
- *
- * This sub-class is exclusively used only when Encoding Object
- * is defined within the Media Type Object (OpenAPI 3.x.y).
- */
-class FileWithData extends File {
-  constructor(data, name = '', options = {}) {
-    super([data], name, options);
-    this.data = data;
-  }
-
-  valueOf() {
-    return this.data;
-  }
-
-  toString() {
-    return this.valueOf();
-  }
-}
-
-// Formats a key-value and returns an array of key-value pairs.
-//
-// Return value example 1: [['color', 'blue']]
-// Return value example 2: [['color', 'blue,black,brown']]
-// Return value example 3: [['color', ['blue', 'black', 'brown']]]
-// Return value example 4: [['color', 'R,100,G,200,B,150']]
-// Return value example 5: [['R', '100'], ['G', '200'], ['B', '150']]
-// Return value example 6: [['color[R]', '100'], ['color[G]', '200'], ['color[B]', '150']]
-function formatKeyValue(key, input, skipEncoding = false) {
-  const { collectionFormat, allowEmptyValue, serializationOption, encoding } = input;
-  // `input` can be string
-  const value = typeof input === 'object' && !Array.isArray(input) ? input.value : input;
-  const encodeFn = skipEncoding ? (k) => k.toString() : (k) => encodeURIComponent(k);
-  const encodedKey = encodeFn(key);
-
-  if (typeof value === 'undefined' && allowEmptyValue) {
-    return [[encodedKey, '']];
-  }
-
-  // file
-  if (isFile(value) || isArrayOfFile(value)) {
-    return [[encodedKey, value]];
-  }
-
-  // for OAS 3 Parameter Object for serialization
-  if (serializationOption) {
-    return formatKeyValueBySerializationOption(key, value, skipEncoding, serializationOption);
-  }
-
-  // for OAS 3 Encoding Object
-  if (encoding) {
-    if (
-      [typeof encoding.style, typeof encoding.explode, typeof encoding.allowReserved].some(
-        (type) => type !== 'undefined'
-      )
-    ) {
-      const { style, explode, allowReserved } = encoding;
-      return formatKeyValueBySerializationOption(key, value, skipEncoding, {
-        style,
-        explode,
-        allowReserved,
-      });
-    }
-
-    if (typeof encoding.contentType === 'string') {
-      if (encoding.contentType.startsWith('application/json')) {
-        // if value is a string, assume value is already a JSON string
-        const json = typeof value === 'string' ? value : JSON.stringify(value);
-        const encodedJson = encodeFn(json);
-        const file = new FileWithData(encodedJson, 'blob', { type: encoding.contentType });
-
-        return [[encodedKey, file]];
-      }
-
-      const encodedData = encodeFn(String(value));
-      const blob = new FileWithData(encodedData, 'blob', { type: encoding.contentType });
-
-      return [[encodedKey, blob]];
-    }
-
-    // Primitive
-    if (typeof value !== 'object') {
-      return [[encodedKey, encodeFn(value)]];
-    }
-
-    // Array of primitives
-    if (Array.isArray(value) && value.every((v) => typeof v !== 'object')) {
-      return [[encodedKey, value.map(encodeFn).join(',')]];
-    }
-
-    // Array or object
-    return [[encodedKey, encodeFn(JSON.stringify(value))]];
-  }
-
-  // for OAS 2 Parameter Object
-  // Primitive
-  if (typeof value !== 'object') {
-    return [[encodedKey, encodeFn(value)]];
-  }
-
-  // Array
-  if (Array.isArray(value)) {
-    if (collectionFormat === 'multi') {
-      // In case of multipart/formdata, it is used as array.
-      // Otherwise, the caller will convert it to a query by qs.stringify.
-      return [[encodedKey, value.map(encodeFn)]];
-    }
-
-    return [[encodedKey, value.map(encodeFn).join(SEPARATORS[collectionFormat || 'csv'])]];
-  }
-
-  // Object
-  return [[encodedKey, '']];
-}
-
-function formatKeyValueBySerializationOption(key, value, skipEncoding, serializationOption) {
-  const style = serializationOption.style || 'form';
-  const explode =
-    typeof serializationOption.explode === 'undefined'
-      ? style === 'form'
-      : serializationOption.explode;
-  // eslint-disable-next-line no-nested-ternary
-  const escape = skipEncoding
-    ? false
-    : serializationOption && serializationOption.allowReserved
-      ? 'unsafe'
-      : 'reserved';
-
-  const encodeFn = (v) => valueEncoder(v, escape);
-  const encodeKeyFn = skipEncoding ? (k) => k : (k) => encodeFn(k);
-
-  if (typeof value === 'string') {
-    try {
-      value = JSON.parse(value);
-    } catch {
-      // can't parse the value so treat it as as a simple string
-    }
-  }
-
-  // Primitive
-  if (typeof value !== 'object') {
-    return [[encodeKeyFn(key), encodeFn(value)]];
-  }
-
-  // Array
-  if (Array.isArray(value)) {
-    if (explode) {
-      // In case of multipart/formdata, it is used as array.
-      // Otherwise, the caller will convert it to a query by qs.stringify.
-      return [[encodeKeyFn(key), value.map(encodeFn)]];
-    }
-    return [[encodeKeyFn(key), value.map(encodeFn).join(STYLE_SEPARATORS[style])]];
-  }
-
-  // Object
-  if (style === 'deepObject') {
-    return Object.keys(value).map((valueKey) => [
-      encodeKeyFn(`${key}[${valueKey}]`),
-      encodeFn(value[valueKey]),
-    ]);
-  }
-
-  if (explode) {
-    return Object.keys(value).map((valueKey) => [encodeKeyFn(valueKey), encodeFn(value[valueKey])]);
-  }
-
-  return [
-    [
-      encodeKeyFn(key),
-      Object.keys(value)
-        .map((valueKey) => [`${encodeKeyFn(valueKey)},${encodeFn(value[valueKey])}`])
-        .join(','),
-    ],
-  ];
-}
-
-function buildFormData(reqForm) {
-  /**
-   * Build a new FormData instance, support array as field value
-   * OAS2.0 - when collectionFormat is multi
-   * OAS3.0 - when explode of Encoding Object is true
-   *
-   * This function explicitly handles Buffers (for backward compatibility)
-   * if provided as a values to FormData. FormData can only handle USVString
-   * or Blob.
-   *
-   * @param {Object} reqForm - ori req.form
-   * @return {FormData} - new FormData instance
-   */
-  return Object.entries(reqForm).reduce((formData, [name, input]) => {
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [key, value] of formatKeyValue(name, input, true)) {
-      if (Array.isArray(value)) {
-        // eslint-disable-next-line no-restricted-syntax
-        for (const v of value) {
-          if (ArrayBuffer.isView(v)) {
-            const blob = new Blob([v]);
-            formData.append(key, blob);
-          } else {
-            formData.append(key, v);
-          }
-        }
-      } else if (ArrayBuffer.isView(value)) {
-        const blob = new Blob([value]);
-        formData.append(key, blob);
-      } else {
-        formData.append(key, value);
-      }
-    }
-    return formData;
-  }, new FormData());
-}
-
-// Encodes an object using appropriate serializer.
-export function encodeFormOrQuery(data) {
-  /**
-   * Encode parameter names and values
-   * @param {Object} result - parameter names and values
-   * @param {string} parameterName - Parameter name
-   * @return {object} encoded parameter names and values
-   */
-  if (typeof data === 'string') {
-    try {
-      data = JSON.parse(data);
-      Object.entries(data).forEach(([key, value]) => {
-        if (typeof value === 'object' && !Array.isArray(value)) {
-          data[key] = JSON.stringify(value);
-        }
-      });
-    } catch {
-      return valueEncoder(data, 'reserved');
-    }
-  }
-
-  const encodedQuery = Object.keys(data).reduce((result, parameterName) => {
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [key, value] of formatKeyValue(parameterName, data[parameterName])) {
-      if (value instanceof FileWithData) {
-        result[key] = value.valueOf();
-      } else {
-        result[key] = value;
-      }
-    }
-    return result;
-  }, {});
-
-  return qs.stringify(encodedQuery, { encode: false, indices: false }) || '';
-}
-
-// If the request has a `query` object, merge it into the request.url, and delete the object
-// If file and/or multipart, also create FormData instance
-export function mergeInQueryOrForm(req = {}) {
-  const { url = '', query, form } = req;
-  const joinSearch = (...strs) => {
-    const search = strs.filter((a) => a).join('&'); // Only truthy value
-    return search ? `?${search}` : ''; // Only add '?' if there is a str
-  };
-
-  if (form) {
-    const hasFile = Object.keys(form).some((key) => {
-      const { value } = form[key];
-      return isFile(value) || isArrayOfFile(value);
-    });
-
-    const contentType = req.headers['content-type'] || req.headers['Content-Type'];
-
-    if (hasFile || /multipart\/form-data/i.test(contentType)) {
-      const formdata = buildFormData(req.form);
-      req.formdata = formdata;
-      req.body = formdata;
-    } else {
-      req.body = encodeFormOrQuery(form);
-    }
-
-    delete req.form;
-  }
-
-  if (query) {
-    const [baseUrl, oriSearch] = url.split('?');
-    let newStr = '';
-
-    if (oriSearch) {
-      const oriQuery = qs.parse(oriSearch);
-      const keysToRemove = Object.keys(query);
-      keysToRemove.forEach((key) => delete oriQuery[key]);
-      newStr = qs.stringify(oriQuery, { encode: true });
-    }
-
-    const finalStr = joinSearch(newStr, encodeFormOrQuery(query));
-    req.url = baseUrl + finalStr;
-    delete req.query;
-  }
-  return req;
-}
-
 // Wrap a http function ( there are otherways to do this, consider this deprecated )
-export function makeHttp(httpFn, preFetch, postFetch) {
+function makeHttp(httpFn, preFetch, postFetch) {
   postFetch = postFetch || ((a) => a);
   preFetch = preFetch || ((a) => a);
   return (req) => {
     if (typeof req === 'string') {
       req = { url: req };
     }
-    self.mergeInQueryOrForm(req);
+    mergeInQueryOrForm(req);
     req = preFetch(req);
     return postFetch(httpFn(req));
   };
 }
+
+export {
+  makeHttp,
+  mergeInQueryOrForm,
+  encodeFormOrQuery,
+  isFile,
+  serializeRes,
+  serializeHeaders,
+  shouldDownloadAsText,
+};

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -1,8 +1,8 @@
 import '../helpers/fetch-polyfill.node.js';
 import { serializeRequest } from './serializers/request/index.js';
-import { serializeResponse, serializeHeaders } from './serializers/response/index.js';
+import { serializeResponse } from './serializers/response/index.js';
 
-export { serializeResponse as serializeRes, serializeHeaders };
+export { serializeResponse as serializeRes };
 
 // Handles fetch-like syntax and the case where there is only one object passed-in
 // (which will have the URL as a property). Also serializes the response.

--- a/src/http/serializers/request/file.js
+++ b/src/http/serializers/request/file.js
@@ -1,0 +1,53 @@
+function isFile(obj, navigatorObj) {
+  if (!navigatorObj && typeof navigator !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    navigatorObj = navigator;
+  }
+  if (navigatorObj && navigatorObj.product === 'ReactNative') {
+    if (obj && typeof obj === 'object' && typeof obj.uri === 'string') {
+      return true;
+    }
+    return false;
+  }
+
+  if (typeof File !== 'undefined' && obj instanceof File) {
+    return true;
+  }
+  if (typeof Blob !== 'undefined' && obj instanceof Blob) {
+    return true;
+  }
+  if (ArrayBuffer.isView(obj)) {
+    return true;
+  }
+
+  return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function';
+}
+
+function isArrayOfFile(obj, navigatorObj) {
+  return Array.isArray(obj) && obj.some((v) => isFile(v, navigatorObj));
+}
+
+/**
+ * Specialized sub-class of File class, that only
+ * accepts string data and retain this data in `data`
+ * public property throughout the lifecycle of its instances.
+ *
+ * This sub-class is exclusively used only when Encoding Object
+ * is defined within the Media Type Object (OpenAPI 3.x.y).
+ */
+class FileWithData extends File {
+  constructor(data, name = '', options = {}) {
+    super([data], name, options);
+    this.data = data;
+  }
+
+  valueOf() {
+    return this.data;
+  }
+
+  toString() {
+    return this.valueOf();
+  }
+}
+
+export { isFile, isArrayOfFile, FileWithData };

--- a/src/http/serializers/request/file.js
+++ b/src/http/serializers/request/file.js
@@ -1,4 +1,4 @@
-function isFile(obj, navigatorObj) {
+export function isFile(obj, navigatorObj) {
   if (!navigatorObj && typeof navigator !== 'undefined') {
     // eslint-disable-next-line no-undef
     navigatorObj = navigator;
@@ -23,7 +23,7 @@ function isFile(obj, navigatorObj) {
   return obj !== null && typeof obj === 'object' && typeof obj.pipe === 'function';
 }
 
-function isArrayOfFile(obj, navigatorObj) {
+export function isArrayOfFile(obj, navigatorObj) {
   return Array.isArray(obj) && obj.some((v) => isFile(v, navigatorObj));
 }
 
@@ -35,7 +35,7 @@ function isArrayOfFile(obj, navigatorObj) {
  * This sub-class is exclusively used only when Encoding Object
  * is defined within the Media Type Object (OpenAPI 3.x.y).
  */
-class FileWithData extends File {
+export class FileWithData extends File {
   constructor(data, name = '', options = {}) {
     super([data], name, options);
     this.data = data;
@@ -49,5 +49,3 @@ class FileWithData extends File {
     return this.valueOf();
   }
 }
-
-export { isFile, isArrayOfFile, FileWithData };

--- a/src/http/serializers/request/format.js
+++ b/src/http/serializers/request/format.js
@@ -1,0 +1,163 @@
+import { isFile, isArrayOfFile, FileWithData } from './file.js';
+import { valueEncoder } from '../../../execute/oas3/style-serializer.js';
+
+const STYLE_SEPARATORS = {
+  form: ',',
+  spaceDelimited: '%20',
+  pipeDelimited: '|',
+};
+
+const SEPARATORS = {
+  csv: ',',
+  ssv: '%20',
+  tsv: '%09',
+  pipes: '|',
+};
+
+// Formats a key-value and returns an array of key-value pairs.
+//
+// Return value example 1: [['color', 'blue']]
+// Return value example 2: [['color', 'blue,black,brown']]
+// Return value example 3: [['color', ['blue', 'black', 'brown']]]
+// Return value example 4: [['color', 'R,100,G,200,B,150']]
+// Return value example 5: [['R', '100'], ['G', '200'], ['B', '150']]
+// Return value example 6: [['color[R]', '100'], ['color[G]', '200'], ['color[B]', '150']]
+export default function formatKeyValue(key, input, skipEncoding = false) {
+  const { collectionFormat, allowEmptyValue, serializationOption, encoding } = input;
+  // `input` can be string
+  const value = typeof input === 'object' && !Array.isArray(input) ? input.value : input;
+  const encodeFn = skipEncoding ? (k) => k.toString() : (k) => encodeURIComponent(k);
+  const encodedKey = encodeFn(key);
+
+  if (typeof value === 'undefined' && allowEmptyValue) {
+    return [[encodedKey, '']];
+  }
+
+  // file
+  if (isFile(value) || isArrayOfFile(value)) {
+    return [[encodedKey, value]];
+  }
+
+  // for OAS 3 Parameter Object for serialization
+  if (serializationOption) {
+    return formatKeyValueBySerializationOption(key, value, skipEncoding, serializationOption);
+  }
+
+  // for OAS 3 Encoding Object
+  if (encoding) {
+    if (
+      [typeof encoding.style, typeof encoding.explode, typeof encoding.allowReserved].some(
+        (type) => type !== 'undefined'
+      )
+    ) {
+      const { style, explode, allowReserved } = encoding;
+      return formatKeyValueBySerializationOption(key, value, skipEncoding, {
+        style,
+        explode,
+        allowReserved,
+      });
+    }
+
+    if (typeof encoding.contentType === 'string') {
+      if (encoding.contentType.startsWith('application/json')) {
+        // if value is a string, assume value is already a JSON string
+        const json = typeof value === 'string' ? value : JSON.stringify(value);
+        const encodedJson = encodeFn(json);
+        const file = new FileWithData(encodedJson, 'blob', { type: encoding.contentType });
+
+        return [[encodedKey, file]];
+      }
+
+      const encodedData = encodeFn(String(value));
+      const blob = new FileWithData(encodedData, 'blob', { type: encoding.contentType });
+
+      return [[encodedKey, blob]];
+    }
+
+    // Primitive
+    if (typeof value !== 'object') {
+      return [[encodedKey, encodeFn(value)]];
+    }
+
+    // Array of primitives
+    if (Array.isArray(value) && value.every((v) => typeof v !== 'object')) {
+      return [[encodedKey, value.map(encodeFn).join(',')]];
+    }
+
+    // Array or object
+    return [[encodedKey, encodeFn(JSON.stringify(value))]];
+  }
+
+  // for OAS 2 Parameter Object
+  // Primitive
+  if (typeof value !== 'object') {
+    return [[encodedKey, encodeFn(value)]];
+  }
+
+  // Array
+  if (Array.isArray(value)) {
+    if (collectionFormat === 'multi') {
+      // In case of multipart/formdata, it is used as array.
+      // Otherwise, the caller will convert it to a query by qs.stringify.
+      return [[encodedKey, value.map(encodeFn)]];
+    }
+
+    return [[encodedKey, value.map(encodeFn).join(SEPARATORS[collectionFormat || 'csv'])]];
+  }
+
+  // Object
+  return [[encodedKey, '']];
+}
+
+function formatKeyValueBySerializationOption(key, value, skipEncoding, serializationOption) {
+  const style = serializationOption.style || 'form';
+  const explode =
+    typeof serializationOption.explode === 'undefined'
+      ? style === 'form'
+      : serializationOption.explode;
+  // eslint-disable-next-line no-nested-ternary
+  const escape = skipEncoding
+    ? false
+    : serializationOption && serializationOption.allowReserved
+      ? 'unsafe'
+      : 'reserved';
+
+  const encodeFn = (v) => valueEncoder(v, escape);
+  const encodeKeyFn = skipEncoding ? (k) => k : (k) => encodeFn(k);
+
+  // Primitive
+  if (typeof value !== 'object') {
+    return [[encodeKeyFn(key), encodeFn(value)]];
+  }
+
+  // Array
+  if (Array.isArray(value)) {
+    if (explode) {
+      // In case of multipart/formdata, it is used as array.
+      // Otherwise, the caller will convert it to a query by qs.stringify.
+      return [[encodeKeyFn(key), value.map(encodeFn)]];
+    }
+    return [[encodeKeyFn(key), value.map(encodeFn).join(STYLE_SEPARATORS[style])]];
+  }
+
+  // Object
+  if (style === 'deepObject') {
+    return Object.keys(value).map((valueKey) => [
+      encodeKeyFn(`${key}[${valueKey}]`),
+      encodeFn(value[valueKey]),
+    ]);
+  }
+
+  if (explode) {
+    return Object.keys(value).map((valueKey) => [encodeKeyFn(valueKey), encodeFn(value[valueKey])]);
+  }
+
+  return [
+    [
+      encodeKeyFn(key),
+      Object.keys(value)
+        .map((valueKey) => [`${encodeKeyFn(valueKey)},${encodeFn(value[valueKey])}`])
+        .join(','),
+    ],
+  ];
+}

--- a/src/http/serializers/request/index.js
+++ b/src/http/serializers/request/index.js
@@ -1,0 +1,112 @@
+import qs from 'qs';
+
+import formatKeyValue from './format.js';
+import { isFile, isArrayOfFile, FileWithData } from './file.js';
+
+function buildFormData(reqForm) {
+  /**
+   * Build a new FormData instance, support array as field value
+   * OAS2.0 - when collectionFormat is multi
+   * OAS3.0 - when explode of Encoding Object is true
+   *
+   * This function explicitly handles Buffers (for backward compatibility)
+   * if provided as a values to FormData. FormData can only handle USVString
+   * or Blob.
+   *
+   * @param {Object} reqForm - ori req.form
+   * @return {FormData} - new FormData instance
+   */
+  return Object.entries(reqForm).reduce((formData, [name, input]) => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [key, value] of formatKeyValue(name, input, true)) {
+      if (Array.isArray(value)) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const v of value) {
+          if (ArrayBuffer.isView(v)) {
+            const blob = new Blob([v]);
+            formData.append(key, blob);
+          } else {
+            formData.append(key, v);
+          }
+        }
+      } else if (ArrayBuffer.isView(value)) {
+        const blob = new Blob([value]);
+        formData.append(key, blob);
+      } else {
+        formData.append(key, value);
+      }
+    }
+    return formData;
+  }, new FormData());
+}
+
+// Encodes an object using appropriate serializer.
+function encodeFormOrQuery(data) {
+  /**
+   * Encode parameter names and values
+   * @param {Object} result - parameter names and values
+   * @param {string} parameterName - Parameter name
+   * @return {object} encoded parameter names and values
+   */
+  const encodedQuery = Object.keys(data).reduce((result, parameterName) => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [key, value] of formatKeyValue(parameterName, data[parameterName])) {
+      if (value instanceof FileWithData) {
+        result[key] = value.valueOf();
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }, {});
+
+  return qs.stringify(encodedQuery, { encode: false, indices: false }) || '';
+}
+
+// If the request has a `query` object, merge it into the request.url, and delete the object
+// If file and/or multipart, also create FormData instance
+function mergeInQueryOrForm(req = {}) {
+  const { url = '', query, form } = req;
+  const joinSearch = (...strs) => {
+    const search = strs.filter((a) => a).join('&'); // Only truthy value
+    return search ? `?${search}` : ''; // Only add '?' if there is a str
+  };
+
+  if (form) {
+    const hasFile = Object.keys(form).some((key) => {
+      const { value } = form[key];
+      return isFile(value) || isArrayOfFile(value);
+    });
+
+    const contentType = req.headers['content-type'] || req.headers['Content-Type'];
+
+    if (hasFile || /multipart\/form-data/i.test(contentType)) {
+      const formdata = buildFormData(req.form);
+      req.formdata = formdata;
+      req.body = formdata;
+    } else {
+      req.body = encodeFormOrQuery(form);
+    }
+
+    delete req.form;
+  }
+
+  if (query) {
+    const [baseUrl, oriSearch] = url.split('?');
+    let newStr = '';
+
+    if (oriSearch) {
+      const oriQuery = qs.parse(oriSearch);
+      const keysToRemove = Object.keys(query);
+      keysToRemove.forEach((key) => delete oriQuery[key]);
+      newStr = qs.stringify(oriQuery, { encode: true });
+    }
+
+    const finalStr = joinSearch(newStr, encodeFormOrQuery(query));
+    req.url = baseUrl + finalStr;
+    delete req.query;
+  }
+  return req;
+}
+
+export { mergeInQueryOrForm, encodeFormOrQuery, isFile };

--- a/src/http/serializers/request/index.js
+++ b/src/http/serializers/request/index.js
@@ -41,7 +41,7 @@ function buildFormData(reqForm) {
 }
 
 // Encodes an object using appropriate serializer.
-function encodeFormOrQuery(data) {
+export function encodeFormOrQuery(data) {
   /**
    * Encode parameter names and values
    * @param {Object} result - parameter names and values
@@ -65,7 +65,7 @@ function encodeFormOrQuery(data) {
 
 // If the request has a `query` object, merge it into the request.url, and delete the object
 // If file and/or multipart, also create FormData instance
-function mergeInQueryOrForm(req = {}) {
+export function serializeRequest(req = {}) {
   const { url = '', query, form } = req;
   const joinSearch = (...strs) => {
     const search = strs.filter((a) => a).join('&'); // Only truthy value
@@ -108,5 +108,3 @@ function mergeInQueryOrForm(req = {}) {
   }
   return req;
 }
-
-export { mergeInQueryOrForm, encodeFormOrQuery, isFile };

--- a/src/http/serializers/response/index.js
+++ b/src/http/serializers/response/index.js
@@ -34,7 +34,7 @@ export function serializeHeaders(headers = {}) {
 }
 
 // Serialize the response, returns a promise with headers and the body part of the hash
-export function serializeRes(oriRes, url, { loadSpec = false } = {}) {
+export function serializeResponse(oriRes, url, { loadSpec = false } = {}) {
   const res = {
     ok: oriRes.ok,
     url: oriRes.url || url,

--- a/src/http/serializers/response/index.js
+++ b/src/http/serializers/response/index.js
@@ -1,0 +1,62 @@
+import jsYaml from 'js-yaml';
+
+export const shouldDownloadAsText = (contentType = '') =>
+  /(json|xml|yaml|text)\b/.test(contentType);
+
+function parseBody(body, contentType) {
+  if (
+    contentType &&
+    (contentType.indexOf('application/json') === 0 || contentType.indexOf('+json') > 0)
+  ) {
+    return JSON.parse(body);
+  }
+  return jsYaml.load(body);
+}
+
+function serializeHeaderValue(value) {
+  const isMulti = value.includes(', ');
+
+  return isMulti ? value.split(', ') : value;
+}
+
+// Serialize headers into a hash, where mutliple-headers result in an array.
+//
+// eg: Cookie: one
+//     Cookie: two
+//  =  { Cookie: [ "one", "two" ]
+export function serializeHeaders(headers = {}) {
+  if (typeof headers.entries !== 'function') return {};
+
+  return Array.from(headers.entries()).reduce((acc, [header, value]) => {
+    acc[header] = serializeHeaderValue(value);
+    return acc;
+  }, {});
+}
+
+// Serialize the response, returns a promise with headers and the body part of the hash
+export function serializeRes(oriRes, url, { loadSpec = false } = {}) {
+  const res = {
+    ok: oriRes.ok,
+    url: oriRes.url || url,
+    status: oriRes.status,
+    statusText: oriRes.statusText,
+    headers: serializeHeaders(oriRes.headers),
+  };
+  const contentType = res.headers['content-type'];
+  const useText = loadSpec || shouldDownloadAsText(contentType);
+  const getBody = useText ? oriRes.text : oriRes.blob || oriRes.buffer;
+  return getBody.call(oriRes).then((body) => {
+    res.text = body;
+    res.data = body;
+    if (useText) {
+      try {
+        const obj = parseBody(body, contentType);
+        res.body = obj;
+        res.obj = obj;
+      } catch (e) {
+        res.parseError = e;
+      }
+    }
+    return res;
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import { DEFAULT_OPENAPI_3_SERVER } from './constants.js';
-import Http, { makeHttp, serializeRes, serializeHeaders } from './http/index.js';
+import Http, { makeHttp, serializeRes } from './http/index.js';
+import { serializeHeaders } from './http/serializers/response/index.js';
 import { makeResolve } from './resolver/index.js';
 import { makeResolveSubtree } from './subtree-resolver/index.js';
 import genericResolveStrategy from './resolver/strategies/generic/index.js';

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -1,13 +1,13 @@
 import * as undici from 'undici';
 
-import http, {
+import http from '../../src/http/index.js';
+import { serializeRequest, encodeFormOrQuery } from '../../src/http/serializers/request/index.js';
+import { isFile } from '../../src/http/serializers/request/file.js';
+import {
+  serializeResponse,
   serializeHeaders,
-  mergeInQueryOrForm,
-  encodeFormOrQuery,
-  serializeRes,
   shouldDownloadAsText,
-  isFile,
-} from '../../src/http/index.js';
+} from '../../src/http/serializers/response/index.js';
 
 describe('http', () => {
   let mockAgent;
@@ -226,7 +226,7 @@ describe('http', () => {
     });
   });
 
-  describe('mergeInQueryOrForm', () => {
+  describe('serializeRequest', () => {
     test('should add query into URL ( with exising url )', () => {
       const req = {
         url: 'https://swagger.io?one=1&two=1',
@@ -239,7 +239,7 @@ describe('http', () => {
           },
         },
       };
-      expect(mergeInQueryOrForm(req)).toEqual({
+      expect(serializeRequest(req)).toEqual({
         url: 'https://swagger.io?one=1&two=2&three=3',
       });
     });
@@ -255,7 +255,7 @@ describe('http', () => {
           },
         },
       };
-      mergeInQueryOrForm(req);
+      serializeRequest(req);
       const fdArrayItem = req.formdata.getAll('testJson');
       expect(fdArrayItem.length).toEqual(1);
       expect(fdArrayItem[0]).toEqual('{"name": "John"}');
@@ -358,7 +358,7 @@ describe('http', () => {
     });
   });
 
-  describe('serializeRes', () => {
+  describe('serializeResponse', () => {
     test('should serialize fetch-like response and call serializeHeaders', () => {
       const response = new Response('data', {
         // eslint-disable-line no-undef
@@ -369,7 +369,7 @@ describe('http', () => {
         },
       });
 
-      return serializeRes(response, 'https://swagger.io').then((serializedResponse) => {
+      return serializeResponse(response, 'https://swagger.io').then((serializedResponse) => {
         expect(serializedResponse.headers).toEqual({
           authorization: ['Basic hoop-la', 'Advanced hoop-la'],
           'content-type': 'text/plain',
@@ -389,7 +389,7 @@ describe('http', () => {
         .then((_res) => {
           // eslint-disable-line no-undef
           originalRes = _res;
-          return serializeRes(_res, 'https://swagger.io');
+          return serializeResponse(_res, 'https://swagger.io');
         })
         .then((resSerialize) => {
           expect(resSerialize.data).toBe(resSerialize.text);
@@ -411,7 +411,7 @@ describe('http', () => {
       return fetch('http://swagger.io')
         .then((_res) =>
           // eslint-disable-line no-undef
-          serializeRes(_res, 'https://swagger.io')
+          serializeResponse(_res, 'https://swagger.io')
         )
         .then((resSerialize) => {
           expect(resSerialize.data).toBe(resSerialize.text);


### PR DESCRIPTION
Refs #3481

1. Moved request and response serializing/encoding into separate files 
2. Moved the logic introduced by https://github.com/swagger-api/swagger-js/pull/3476 and https://github.com/swagger-api/swagger-js/pull/3474 to request builder
