### PR TITLE
Allowing user to  set "AUTH_TOKEN" in env to download privately hosted schema as well

### DIFF
--- a/src/resolver/utils/index.js
+++ b/src/resolver/utils/index.js
@@ -3,8 +3,13 @@ import { ACCEPT_HEADER_VALUE_FOR_DOCUMENTS } from '../../constants.js';
 // eslint-disable-next-line import/prefer-default-export
 export function makeFetchJSON(http, opts = {}) {
   const { requestInterceptor, responseInterceptor } = opts;
+
   // Set credentials with 'http.withCredentials' value
   const credentials = http.withCredentials ? 'include' : 'same-origin';
+
+  // Get Authorization token from environment variables if set
+  const authToken = process.env.AUTH_TOKEN ? `Bearer ${process.env.AUTH_TOKEN}` : undefined;
+
   return (docPath) =>
     http({
       url: docPath,
@@ -13,6 +18,8 @@ export function makeFetchJSON(http, opts = {}) {
       responseInterceptor,
       headers: {
         Accept: ACCEPT_HEADER_VALUE_FOR_DOCUMENTS,
+        // Conditionally add the Authorization header if the token exists
+        ...(authToken && { Authorization: authToken }),
       },
       credentials,
     }).then((res) => res.body);


### PR DESCRIPTION
In certain use cases where OpenAPI specifications reference schemas hosted on private URLs, it's important to support authentication to allow access to these resources. I identified this section of code that resolves schema references. To enable seamless access to private URLs, I propose extending the functionality to include an Authorization header if a user sets an authentication token via an environment variable. This way, when the schema reference is hosted on a private server, users can authenticate by setting the auth token in their environment, allowing the private URL to be accessed.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Allowing user to "**AUTH_TOKEN**" in env to download privately hosted schema as well.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently Editor can resolve only ref which is publicly available , but if we add this then it can allow to resolved authenticated url as well.
<!--- If it fixes an open issue, please link to the issue here. -->
Not sure!
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
