### PR TITLE
fix(security): fix unsafe cookie serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
         "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.9 <1.0.0-beta.0",
         "@swagger-api/apidom-reference": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-        "cookie": "~0.7.0",
+        "cookie": "~0.7.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
     "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.9 <1.0.0-beta.0",
     "@swagger-api/apidom-reference": ">=1.0.0-alpha.9 <1.0.0-beta.0",
-    "cookie": "~0.7.0",
+    "cookie": "~0.7.2",
     "deepmerge": "~4.3.0",
     "fast-json-patch": "^3.0.0-1",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Fix was provided by updating cookie to v0.7.2.

Refs CVE-2024-47764
Refs GHSA-pxg6-pf52-xh8x

