### PR TITLE
feat(analytics): use Scarf.js to provide anonymized installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Swagger Client Version | Release Date | OpenAPI Spec compatibility             |
 
 ## Anonymized analytics
 
-Swagger Client uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#what-information-does-scarf-js-provide-me-as-a-package-author). 
-These analytics help support the maintainers of this library. However, if you'd like to [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics),
-you can do so by setting `scarfSettings.enabled = false` in your project's package.json.
-Alternatively, you can set the environment variable `SCARF_ANALYTICS=false` before you install.
+Swagger Client uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). 
+These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics),
+you can set the `scafeSettings.enabled` field to `false` in your project's `package.json` file, e.g.,  `{ ... "scarfSettings.enabled":  false }`.
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,19 @@ Swagger Client Version | Release Date | OpenAPI Spec compatibility             |
 
 ## Anonymized analytics
 
-Swagger Client uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). 
-These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics),
-you can set the `scafeSettings.enabled` field to `false` in your project's `package.json` file, e.g.,  `{ ... "scarfSettings.enabled":  false }`.
+Swagger Client uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scafeSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
 Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Swagger Client Version | Release Date | OpenAPI Spec compatibility             |
 3.10.x | 2020-01-17   | 2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3        | [tag v3.10.0](https://github.com/swagger-api/swagger-js/tree/v3.10.0)
 2.1.32 | 2017-01-12   | 1.0, 1.1, 1.2                          | [tag v2.1.32](https://github.com/swagger-api/swagger-js/tree/v2.1.32). This [release](https://github.com/swagger-api/swagger-js/releases/tag/v2.1.32) is only available on GitHub.
 
+## Anonymized analytics
+
+Swagger Client uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#what-information-does-scarf-js-provide-me-as-a-package-author). 
+These analytics help support the maintainers of this library. However, if you'd like to [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics),
+you can do so by setting `scarfSettings.enabled = false` in your project's package.json.
+Alternatively, you can set the environment variable `SCARF_ANALYTICS=false` before you install.
+
 ## Documentation
 
 #### Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
+        "@scarf/scarf": "^1.3.0",
         "@swagger-api/apidom-core": ">=1.0.0-alpha.9 <1.0.0-beta.0",
         "@swagger-api/apidom-error": ">=1.0.0-alpha.9 <1.0.0-beta.0",
         "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
@@ -3376,6 +3377,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.3.0.tgz",
+      "integrity": "sha512-lHKK8M5CTcpFj2hZDB3wIjb0KAbEOgDmiJGDv1WBRfQgRm/a8/XMEkG/N1iM01xgbUDsPQwi42D+dFo1XPAKew==",
+      "hasInstallScript": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@babel/runtime-corejs3": "^7.22.15",
+    "@scarf/scarf": "=1.3.0",
     "@swagger-api/apidom-core": ">=1.0.0-alpha.9 <1.0.0-beta.0",
     "@swagger-api/apidom-error": ">=1.0.0-alpha.9 <1.0.0-beta.0",
     "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
@@ -82,13 +83,13 @@
     "deepmerge": "~4.3.0",
     "fast-json-patch": "^3.0.0-1",
     "js-yaml": "^4.1.0",
+    "neotraverse": "=0.6.18",
     "node-abort-controller": "^3.1.1",
     "node-fetch-commonjs": "^3.3.2",
     "openapi-path-templating": "^1.5.1",
     "openapi-server-url-templating": "^1.0.0",
     "ramda": "^0.30.1",
-    "ramda-adjunct": "^5.0.0",
-    "neotraverse": "=0.6.18"
+    "ramda-adjunct": "^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.21.0",


### PR DESCRIPTION
## Anonymized analytics

Swagger Client uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scafeSettings.enabled` field to `false` in your project's `package.json`:

```
// package.json
{
  // ...
  "scarfSettings": {
    "enabled": false
  }
  // ...
}
```

Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.