### PR TITLE
fix(execute): fix encoding of object properties with null value

### DIFF
--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -41,7 +41,7 @@ export default function stylize(config) {
 }
 
 export function valueEncoder(value, escape = false) {
-  if (Array.isArray(value) || typeof value === 'object') {
+  if (Array.isArray(value) || (value !== null && typeof value === 'object')) {
     value = JSON.stringify(value);
   } else if (typeof value === 'number' || typeof value === 'boolean') {
     value = String(value);
@@ -96,7 +96,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'simple') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape);
+      const val = valueEncoder(value[curr], escape) ?? '';
       const middleChar = explode ? '=' : ',';
       const prefix = prev ? `${prev},` : '';
 
@@ -106,7 +106,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'label') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape);
+      const val = valueEncoder(value[curr], escape) ?? '';
       const middleChar = explode ? '=' : '.';
       const prefix = prev ? `${prev}.` : '.';
 
@@ -116,7 +116,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'matrix' && explode) {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape);
+      const val = valueEncoder(value[curr], escape) ?? '';
       const prefix = prev ? `${prev};` : ';';
 
       return `${prefix}${curr}=${val}`;
@@ -126,7 +126,7 @@ function encodeObject({ key, value, style, explode, escape }) {
   if (style === 'matrix') {
     // no explode
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape);
+      const val = valueEncoder(value[curr], escape) ?? '';
       const prefix = prev ? `${prev},` : `;${key}=`;
 
       return `${prefix}${curr},${val}`;
@@ -135,7 +135,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'form') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape);
+      const val = valueEncoder(value[curr], escape) ?? '';
       const prefix = prev ? `${prev}${explode ? '&' : ','}` : '';
       const separator = explode ? '=' : ',';
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -50,7 +50,7 @@ export function valueEncoder(value, escape = false) {
   if (escape && typeof value === 'string' && value.length > 0) {
     return encodeCharacters(value, escape);
   }
-  return value;
+  return value ?? '';
 }
 
 function encodeArray({ key, value, style, explode, escape }) {
@@ -96,7 +96,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'simple') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape) ?? '';
+      const val = valueEncoder(value[curr], escape);
       const middleChar = explode ? '=' : ',';
       const prefix = prev ? `${prev},` : '';
 
@@ -106,7 +106,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'label') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape) ?? '';
+      const val = valueEncoder(value[curr], escape);
       const middleChar = explode ? '=' : '.';
       const prefix = prev ? `${prev}.` : '.';
 
@@ -116,7 +116,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'matrix' && explode) {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape) ?? '';
+      const val = valueEncoder(value[curr], escape);
       const prefix = prev ? `${prev};` : ';';
 
       return `${prefix}${curr}=${val}`;
@@ -126,7 +126,7 @@ function encodeObject({ key, value, style, explode, escape }) {
   if (style === 'matrix') {
     // no explode
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape) ?? '';
+      const val = valueEncoder(value[curr], escape);
       const prefix = prev ? `${prev},` : `;${key}=`;
 
       return `${prefix}${curr},${val}`;
@@ -135,7 +135,7 @@ function encodeObject({ key, value, style, explode, escape }) {
 
   if (style === 'form') {
     return valueKeys.reduce((prev, curr) => {
-      const val = valueEncoder(value[curr], escape) ?? '';
+      const val = valueEncoder(value[curr], escape);
       const prefix = prev ? `${prev}${explode ? '&' : ','}` : '';
       const separator = explode ? '=' : ',';
 

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -41,7 +41,7 @@ export default function stylize(config) {
 }
 
 export function valueEncoder(value, escape = false) {
-  if (Array.isArray(value) || (value !== null && typeof value === 'object')) {
+  if (Array.isArray(value) || typeof value === 'object') {
     value = JSON.stringify(value);
   } else if (typeof value === 'number' || typeof value === 'boolean') {
     value = String(value);

--- a/src/execute/oas3/style-serializer.js
+++ b/src/execute/oas3/style-serializer.js
@@ -47,7 +47,7 @@ export function valueEncoder(value, escape = false) {
     value = String(value);
   }
 
-  if (escape && value.length > 0) {
+  if (escape && typeof value === 'string' && value.length > 0) {
     return encodeCharacters(value, escape);
   }
   return value;

--- a/src/http/serializers/request/index.js
+++ b/src/http/serializers/request/index.js
@@ -40,9 +40,7 @@ function buildFormData(reqForm) {
 
 export const stringifyQuery = (queryObject, { encode = true } = {}) => {
   const buildNestedParams = (params, key, value) => {
-    if (value == null) {
-      params.append(key, '');
-    } else if (Array.isArray(value)) {
+    if (Array.isArray(value)) {
       value.reduce((acc, v) => buildNestedParams(params, key, v), params);
     } else if (value instanceof Date) {
       params.append(key, value.toISOString());

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -664,6 +664,78 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       });
     });
 
+    it('should encode objects with a property with `null` value', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/{pathPartial}': {
+              post: {
+                operationId: 'myOp',
+                parameters: [
+                  {
+                    name: 'query',
+                    in: 'query',
+                    schema: {
+                      type: 'object',
+                    },
+                  },
+                  {
+                    name: 'FooHeader',
+                    in: 'header',
+                    schema: {
+                      type: 'object',
+                    },
+                    explode: true,
+                  },
+                  {
+                    name: 'pathPartial',
+                    in: 'path',
+                    schema: {
+                      type: 'object',
+                    },
+                    explode: true,
+                  },
+                  {
+                    name: 'myCookie',
+                    in: 'cookie',
+                    schema: {
+                      type: 'object',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        parameters: {
+          pathPartial: {
+            a: null,
+          },
+          query: {
+            b: null,
+          },
+          FooHeader: {
+            c: null,
+          },
+          myCookie: {
+            d: null,
+          },
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/a=null?b=null`,
+        credentials: 'same-origin',
+        headers: {
+          FooHeader: 'c=null',
+          Cookie: 'myCookie=d,null',
+        },
+      });
+    });
+
     it('should encode arrays of arrays and objects', () => {
       const req = buildRequest({
         spec: {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -736,6 +736,70 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
       });
     });
 
+    it('should encode arrays with `undefined` items', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/{pathPartial}': {
+              post: {
+                operationId: 'myOp',
+                parameters: [
+                  {
+                    name: 'query',
+                    in: 'query',
+                    schema: {
+                      type: 'array',
+                    },
+                  },
+                  {
+                    name: 'FooHeader',
+                    in: 'header',
+                    schema: {
+                      type: 'array',
+                    },
+                    explode: true,
+                  },
+                  {
+                    name: 'pathPartial',
+                    in: 'path',
+                    schema: {
+                      type: 'array',
+                    },
+                    explode: true,
+                  },
+                  {
+                    name: 'myCookie',
+                    in: 'cookie',
+                    schema: {
+                      type: 'array',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        parameters: {
+          pathPartial: [undefined],
+          query: [undefined],
+          FooHeader: [undefined],
+          myCookie: [undefined],
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/?query=`,
+        credentials: 'same-origin',
+        headers: {
+          FooHeader: '',
+          Cookie: 'myCookie=',
+        },
+      });
+    });
+
     it('should encode arrays of arrays and objects', () => {
       const req = buildRequest({
         spec: {

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -727,11 +727,11 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
 
       expect(req).toEqual({
         method: 'POST',
-        url: `/a=null?b=null`,
+        url: `/a=?b=`,
         credentials: 'same-origin',
         headers: {
-          FooHeader: 'c=null',
-          Cookie: 'myCookie=d,null',
+          FooHeader: 'c=',
+          Cookie: 'myCookie=d,',
         },
       });
     });
@@ -758,7 +758,6 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
                     schema: {
                       type: 'array',
                     },
-                    explode: true,
                   },
                   {
                     name: 'pathPartial',
@@ -766,7 +765,6 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
                     schema: {
                       type: 'array',
                     },
-                    explode: true,
                   },
                   {
                     name: 'myCookie',
@@ -796,6 +794,69 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         headers: {
           FooHeader: '',
           Cookie: 'myCookie=',
+        },
+      });
+    });
+
+    it('should encode arrays with multiple `undefined` items', () => {
+      const req = buildRequest({
+        spec: {
+          openapi: '3.0.0',
+          paths: {
+            '/{pathPartial}': {
+              post: {
+                operationId: 'myOp',
+                parameters: [
+                  {
+                    name: 'query',
+                    in: 'query',
+                    schema: {
+                      type: 'array',
+                    },
+                    explode: false,
+                  },
+                  {
+                    name: 'FooHeader',
+                    in: 'header',
+                    schema: {
+                      type: 'array',
+                    },
+                  },
+                  {
+                    name: 'pathPartial',
+                    in: 'path',
+                    schema: {
+                      type: 'array',
+                    },
+                  },
+                  {
+                    name: 'myCookie',
+                    in: 'cookie',
+                    schema: {
+                      type: 'array',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        operationId: 'myOp',
+        parameters: {
+          pathPartial: [undefined, undefined, undefined],
+          query: [undefined, undefined, undefined],
+          FooHeader: [undefined, undefined, undefined],
+          myCookie: [undefined, undefined, undefined],
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'POST',
+        url: `/,,?query=,,`,
+        credentials: 'same-origin',
+        headers: {
+          FooHeader: ',,',
+          Cookie: 'myCookie=,,',
         },
       });
     });


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/10226

Fixes the issue with `null` and `undefined` values causing errors due to trying to check their length. 