### PR TITLE
chore(deps): replace cookie with @swaggerexpect/cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@swagger-api/apidom-json-pointer": ">=1.0.0-beta.6 <1.0.0-rc.0",
         "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-beta.6 <1.0.0-rc.0",
         "@swagger-api/apidom-reference": ">=1.0.0-beta.6 <1.0.0-rc.0",
-        "cookie": "~0.7.2",
+        "@swaggerexpert/cookie": "^1.4.1",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
         "js-yaml": "^4.1.0",
@@ -3762,6 +3762,18 @@
         "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-beta.3 <1.0.0-rc.0"
       }
     },
+    "node_modules/@swaggerexpert/cookie": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-1.4.1.tgz",
+      "integrity": "sha512-ZRbRC2017wMs+uZeIOC55ghwgbTxeolo+s6I0njzqina7MTrOhz8WMfTj0KGk3hfBUO/yhTQD/aQZ0lQHEIKxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -5460,15 +5472,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.39.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@swagger-api/apidom-json-pointer": ">=1.0.0-beta.6 <1.0.0-rc.0",
     "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-beta.6 <1.0.0-rc.0",
     "@swagger-api/apidom-reference": ">=1.0.0-beta.6 <1.0.0-rc.0",
-    "cookie": "~0.7.2",
+    "@swaggerexpert/cookie": "^1.4.1",
     "deepmerge": "~4.3.0",
     "fast-json-patch": "^3.0.0-1",
     "js-yaml": "^4.1.0",

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -1,10 +1,15 @@
-import cookie from 'cookie';
 import { identity } from 'ramda';
 import { isPlainObject } from 'ramda-adjunct';
 import {
   test as testServerURLTemplate,
   substitute as substituteServerURLTemplate,
 } from 'openapi-server-url-templating';
+import {
+  serializeCookie,
+  cookieValueLenientEncoder,
+  cookieNameLenientValidator,
+  cookieValueLenientValidator,
+} from '@swaggerexpert/cookie';
 import { ApiDOMStructuredError } from '@swagger-api/apidom-error';
 import { url } from '@swagger-api/apidom-reference/configuration/empty';
 
@@ -297,7 +302,15 @@ export function buildRequest(options) {
     const cookieString = Object.keys(req.cookies).reduce((prev, cookieName) => {
       const cookieValue = req.cookies[cookieName];
       const prefix = prev ? '&' : '';
-      const stringified = cookie.serialize(cookieName, cookieValue);
+      const stringified = serializeCookie([[cookieName, cookieValue]], {
+        encoders: {
+          value: cookieValueLenientEncoder,
+        },
+        validators: {
+          name: cookieNameLenientValidator,
+          value: cookieValueLenientValidator,
+        },
+      });
       return prev + prefix + stringified;
     }, '');
     req.headers.Cookie = cookieString;


### PR DESCRIPTION
This should be a fully backward compatible
replacement with benefit of new library
being compatible with Node.js 12.20.x.

Closes #3714

