### PR TITLE
fix(execute): serialize req.cookies into valid cookie-string

### DIFF
--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -1,5 +1,5 @@
 import { identity } from 'ramda';
-import { isPlainObject } from 'ramda-adjunct';
+import { isPlainObject, isNonEmptyString } from 'ramda-adjunct';
 import {
   test as testServerURLTemplate,
   substitute as substituteServerURLTemplate,
@@ -309,7 +309,11 @@ export function buildRequest(options) {
       },
     });
 
-    req.headers.Cookie = cookieString;
+    if (isNonEmptyString(req.headers.Cookie)) {
+      req.headers.Cookie += `; ${cookieString}`;
+    } else {
+      req.headers.Cookie = cookieString;
+    }
   }
 
   if (req.cookies) {

--- a/src/execute/index.js
+++ b/src/execute/index.js
@@ -299,20 +299,16 @@ export function buildRequest(options) {
   // If the cookie convenience object exists in our request,
   // serialize its content and then delete the cookie object.
   if (req.cookies && Object.keys(req.cookies).length) {
-    const cookieString = Object.keys(req.cookies).reduce((prev, cookieName) => {
-      const cookieValue = req.cookies[cookieName];
-      const prefix = prev ? '&' : '';
-      const stringified = serializeCookie([[cookieName, cookieValue]], {
-        encoders: {
-          value: cookieValueLenientEncoder,
-        },
-        validators: {
-          name: cookieNameLenientValidator,
-          value: cookieValueLenientValidator,
-        },
-      });
-      return prev + prefix + stringified;
-    }, '');
+    const cookieString = serializeCookie(req.cookies, {
+      encoders: {
+        value: cookieValueLenientEncoder,
+      },
+      validators: {
+        name: cookieNameLenientValidator,
+        value: cookieValueLenientValidator,
+      },
+    });
+
     req.headers.Cookie = cookieString;
   }
 

--- a/src/helpers/cookie-value-encoder.js
+++ b/src/helpers/cookie-value-encoder.js
@@ -1,0 +1,11 @@
+import { cookieValueStrictEncoder } from '@swaggerexpert/cookie';
+
+const eqSignPE = '%3D';
+const ampersandPE = '%26';
+
+const cookieValueEncoder = (cookieValue) =>
+  cookieValueStrictEncoder(cookieValue).replace(/[=&]/gu, (match) =>
+    match === '=' ? eqSignPE : ampersandPE
+  );
+
+export default cookieValueEncoder;

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -474,6 +474,11 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
               name: 'MyApiKeyCookie',
               in: 'cookie',
             },
+            myApiKey1: {
+              type: 'apiKey',
+              name: 'MyApiKeyCookie1',
+              in: 'cookie',
+            },
           },
         },
         paths: {
@@ -483,6 +488,7 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
               security: [
                 {
                   myApiKey: [],
+                  myApiKey1: [],
                 },
               ],
             },
@@ -499,6 +505,9 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
             myApiKey: {
               value: 'MyToken',
             },
+            myApiKey1: {
+              value: 'MyToken1',
+            },
           },
         },
       });
@@ -508,7 +517,7 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
         url: '/',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'MyApiKeyCookie=MyToken',
+          Cookie: 'MyApiKeyCookie=MyToken; MyApiKeyCookie1=MyToken1',
         },
       });
     });

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -615,9 +615,6 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
             myApiKey: {
               value: 'MyToken',
             },
-            myApiKey1: {
-              value: 'MyToken1',
-            },
           },
         },
       });
@@ -627,7 +624,7 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
         url: '/',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'id=1&id=2&id=3; MyApiKeyCookie=MyToken',
+          Cookie: 'id=id%3D1%26id%3D2%26id%3D3; MyApiKeyCookie=MyToken',
         },
       });
     });

--- a/test/oas3/execute/authorization.js
+++ b/test/oas3/execute/authorization.js
@@ -474,6 +474,54 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
               name: 'MyApiKeyCookie',
               in: 'cookie',
             },
+          },
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation',
+              security: [
+                {
+                  myApiKey: [],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        securities: {
+          authorized: {
+            myApiKey: {
+              value: 'MyToken',
+            },
+          },
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {
+          Cookie: 'MyApiKeyCookie=MyToken',
+        },
+      });
+    });
+    test('should add multiple apiKey credentials as a cookie', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myApiKey: {
+              type: 'apiKey',
+              name: 'MyApiKeyCookie',
+              in: 'cookie',
+            },
             myApiKey1: {
               type: 'apiKey',
               name: 'MyApiKeyCookie1',
@@ -518,6 +566,68 @@ describe('Authorization - OpenAPI Specification 3.0', () => {
         credentials: 'same-origin',
         headers: {
           Cookie: 'MyApiKeyCookie=MyToken; MyApiKeyCookie1=MyToken1',
+        },
+      });
+    });
+    test('should append apiKey credentials to a cookie', () => {
+      const spec = {
+        openapi: '3.0.0',
+        components: {
+          securitySchemes: {
+            myApiKey: {
+              type: 'apiKey',
+              name: 'MyApiKeyCookie',
+              in: 'cookie',
+            },
+          },
+        },
+        paths: {
+          '/': {
+            get: {
+              operationId: 'myOperation',
+              parameters: [
+                {
+                  name: 'id',
+                  in: 'cookie',
+                  style: 'form',
+                  explode: true,
+                },
+              ],
+              security: [
+                {
+                  myApiKey: [],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      // when
+      const req = buildRequest({
+        spec,
+        operationId: 'myOperation',
+        parameters: {
+          id: [1, 2, 3],
+        },
+        securities: {
+          authorized: {
+            myApiKey: {
+              value: 'MyToken',
+            },
+            myApiKey1: {
+              value: 'MyToken1',
+            },
+          },
+        },
+      });
+
+      expect(req).toEqual({
+        method: 'GET',
+        url: '/',
+        credentials: 'same-origin',
+        headers: {
+          Cookie: 'id=1&id=2&id=3; MyApiKeyCookie=MyToken',
         },
       });
     });

--- a/test/oas3/execute/main.js
+++ b/test/oas3/execute/main.js
@@ -659,7 +659,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         credentials: 'same-origin',
         headers: {
           FooHeader: 'a={"b":{"c":{"d":"e"}}}',
-          Cookie: 'myCookie=foo,{"bar":{"baz":"qux"}}',
+          Cookie: 'myCookie=foo%2C{%22bar%22:{%22baz%22:%22qux%22}}',
         },
       });
     });
@@ -731,7 +731,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         credentials: 'same-origin',
         headers: {
           FooHeader: 'c=',
-          Cookie: 'myCookie=d,',
+          Cookie: 'myCookie=d%2C',
         },
       });
     });
@@ -856,7 +856,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         credentials: 'same-origin',
         headers: {
           FooHeader: ',,',
-          Cookie: 'myCookie=,,',
+          Cookie: 'myCookie=%2C%2C',
         },
       });
     });
@@ -1063,7 +1063,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         credentials: 'same-origin',
         headers: {
           FooHeader: '{"foo":"bar"}',
-          Cookie: 'myCookie={"flavor":"chocolate chip"}',
+          Cookie: 'myCookie={%22flavor%22:%22chocolate%20chip%22}',
         },
       });
     });
@@ -1218,7 +1218,7 @@ describe('buildRequest - OpenAPI Specification 3.0', () => {
         credentials: 'same-origin',
         headers: {
           FooHeader: '[{"foo":"bar"}]',
-          Cookie: 'myCookie=[{"flavor":"chocolate chip"}]',
+          Cookie: 'myCookie=[{%22flavor%22:%22chocolate%20chip%22}]',
         },
       });
     });

--- a/test/oas3/execute/style-explode/cookie.js
+++ b/test/oas3/execute/style-explode/cookie.js
@@ -137,6 +137,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
                 {
                   name: 'id',
                   in: 'cookie',
+                  explode: false,
                 },
               ],
             },
@@ -158,7 +159,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
         url: '/users',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'id=3,4,5',
+          Cookie: 'id=3%2C4%2C5',
         },
       });
     });
@@ -198,7 +199,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
         url: '/users',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'id=3,4,5',
+          Cookie: 'id=3%2C4%2C5',
         },
       });
     });
@@ -238,7 +239,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
         url: '/users',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'id=3&id=4&id=5',
+          Cookie: 'id=id%3D3%26id%3D4%26id%3D5',
         },
       });
     });
@@ -282,7 +283,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
         url: '/users',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'id=role,admin,firstName,Alex',
+          Cookie: 'id=role%2Cadmin%2CfirstName%2CAlex',
         },
       });
     });
@@ -322,7 +323,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
         url: '/users',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'id=role,admin,firstName,Alex',
+          Cookie: 'id=role%2Cadmin%2CfirstName%2CAlex',
         },
       });
     });
@@ -362,7 +363,7 @@ describe('OAS 3.0 - buildRequest w/ `style` & `explode` - cookie parameters', ()
         url: '/users',
         credentials: 'same-origin',
         headers: {
-          Cookie: 'role=admin&firstName=Alex',
+          Cookie: 'id=role%3Dadmin%26firstName%3DAlex',
         },
       });
     });


### PR DESCRIPTION
This is part of aligning with OpenAPI 3.0.4 clarifications.

Specifically this PR is aligning implementations around cookies with https://spec.openapis.org/oas/v3.0.4.html#appendix-d-serializing-headers-and-cookies.

`swagger-client` will now product valid cookies, which can be processed by [RFC 6265](https://tools.ietf.org/html/rfc6265) parser, `cookie-value` is percent decoded and can be further processed by [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570) implementation.