### PR TITLE
fix(resolver): avoid accessing properties of undefined or null parameters

### DIFF
--- a/src/resolver/strategies/generic/normalize.js
+++ b/src/resolver/strategies/generic/normalize.js
@@ -85,10 +85,12 @@ export default function normalize(parsedSpec) {
                 for (const param of inherits[inheritName]) {
                   const exists = operation[inheritName].some(
                     (opParam) =>
-                      (opParam.name && opParam.name === param.name) ||
-                      (opParam.$ref && opParam.$ref === param.$ref) ||
-                      (opParam.$$ref && opParam.$$ref === param.$$ref) ||
-                      opParam === param
+                      opParam &&
+                      param &&
+                      ((opParam.name && opParam.name === param.name) ||
+                        (opParam.$ref && opParam.$ref === param.$ref) ||
+                        (opParam.$$ref && opParam.$$ref === param.$$ref) ||
+                        opParam === param)
                   );
 
                   if (!exists) {


### PR DESCRIPTION
This PR fixes acessing properties of empty parameters during normalization, e.g.:

```yaml
openapi: 3.0.4
paths:
  /test:
    parameters:
      - 
    get:
      parameters:
        - 
```
