### PR TITLE
fix(resolver): re-evaluate element to be transcluded

### DIFF
--- a/src/resolver/strategies/openapi-3-1-apidom/resolve.js
+++ b/src/resolver/strategies/openapi-3-1-apidom/resolve.js
@@ -154,7 +154,9 @@ const resolveOpenAPI31Strategy = async (options) => {
           : circularReplacer,
       },
     });
-    const transcluded = transclude(fragmentElement, dereferenced, openApiElement);
+    // Re-evaluate element to be transcluded as fragmentElement might be mutated
+    const search = jsonPointerEvaluate(openApiElement, jsonPointer);
+    const transcluded = transclude(search, dereferenced, openApiElement);
     const normalized = skipNormalization ? transcluded : strategy.normalize(transcluded);
 
     return { spec: toValue(normalized), errors };

--- a/src/resolver/strategies/openapi-3-2-apidom/resolve.js
+++ b/src/resolver/strategies/openapi-3-2-apidom/resolve.js
@@ -154,7 +154,9 @@ const resolveOpenAPI32Strategy = async (options) => {
           : circularReplacer,
       },
     });
-    const transcluded = transclude(fragmentElement, dereferenced, openApiElement);
+    // Re-evaluate element to be transcluded as fragmentElement might be mutated
+    const search = jsonPointerEvaluate(openApiElement, jsonPointer);
+    const transcluded = transclude(search, dereferenced, openApiElement);
     const normalized = skipNormalization ? transcluded : strategy.normalize(transcluded);
 
     return { spec: toValue(normalized), errors };


### PR DESCRIPTION
Fixes an issue where resolving a subtree would cause it to be `null`.

This issue could be seen in Swagger Editor when trying to edit an operation that was expanded in Swagger UI - sometimes the operation would disappear. The resolver was called 3 times with the expanded operation and the last one would sometimes return `null`. This was caused by the transcluder being unable to find the element that should be replaced inside of the original spec, most likely due to mutations that happened to the dereferenced element. To prevent this, an additional evaluation of JSON pointer was added to find the original element and try to transclude it instead of the mutated one. 